### PR TITLE
Surface more fields in messages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,12 @@ const messages = await ctx.runQuery(
 ```
 
 ```ts
-const messages = await agent.saveMessages(ctx, { threadId, userId, messages });
+const messages = await agent.saveMessages(ctx, { threadId, userId, messages: [
+  { role: "user", content: "Hello, world!" },
+]});
 ```
+Note: you can also pass in message metadata if you want to save usage, etc.
+See the docstrings in [the implementation](./src/client/index.ts#L473).
 
 ```ts
 const messages = await agent.saveSteps(ctx, { threadId, userId, step });

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -294,6 +294,11 @@ export declare const components: {
             text?: string;
             threadId: string;
             tool: boolean;
+            usage?: {
+              completionTokens: number;
+              promptTokens: number;
+              totalTokens: number;
+            };
             userId?: string;
           }>;
           pending?: {
@@ -420,6 +425,11 @@ export declare const components: {
             text?: string;
             threadId: string;
             tool: boolean;
+            usage?: {
+              completionTokens: number;
+              promptTokens: number;
+              totalTokens: number;
+            };
             userId?: string;
           };
         }
@@ -1205,6 +1215,11 @@ export declare const components: {
             text?: string;
             threadId: string;
             tool: boolean;
+            usage?: {
+              completionTokens: number;
+              promptTokens: number;
+              totalTokens: number;
+            };
             userId?: string;
           }>;
           pageStatus?: "SplitRecommended" | "SplitRequired" | null;
@@ -1388,6 +1403,11 @@ export declare const components: {
           text?: string;
           threadId: string;
           tool: boolean;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
           userId?: string;
         }>
       >;
@@ -1519,6 +1539,11 @@ export declare const components: {
           text?: string;
           threadId: string;
           tool: boolean;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
           userId?: string;
         }>
       >;

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -164,6 +164,7 @@ export declare const components: {
           model?: string;
           parentMessageId?: string;
           pending?: boolean;
+          provider?: string;
           stepId?: string;
           threadId: string;
           userId?: string;
@@ -286,6 +287,7 @@ export declare const components: {
             model?: string;
             order: number;
             parentMessageId?: string;
+            provider?: string;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -411,6 +413,7 @@ export declare const components: {
             model?: string;
             order: number;
             parentMessageId?: string;
+            provider?: string;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -1195,6 +1198,7 @@ export declare const components: {
             model?: string;
             order: number;
             parentMessageId?: string;
+            provider?: string;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -1377,6 +1381,7 @@ export declare const components: {
           model?: string;
           order: number;
           parentMessageId?: string;
+          provider?: string;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1507,6 +1512,7 @@ export declare const components: {
           model?: string;
           order: number;
           parentMessageId?: string;
+          provider?: string;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -54,14 +54,32 @@ export declare const components: {
         "internal",
         {
           agentName?: string;
-          embeddings?: {
-            dimension: 128 | 256 | 512 | 768 | 1024 | 1536 | 2048 | 3072 | 4096;
-            model: string;
-            vectors: Array<Array<number> | null>;
-          };
           failPendingSteps?: boolean;
           messages: Array<{
+            embedding?: {
+              dimension:
+                | 128
+                | 256
+                | 512
+                | 768
+                | 1024
+                | 1536
+                | 2048
+                | 3072
+                | 4096;
+              model: string;
+              vector: Array<number>;
+            };
+            error?: string;
             fileId?: string;
+            finishReason?:
+              | "stop"
+              | "length"
+              | "content-filter"
+              | "tool-calls"
+              | "error"
+              | "other"
+              | "unknown";
             id?: string;
             message:
               | {
@@ -160,11 +178,35 @@ export declare const components: {
                   providerOptions?: Record<string, any>;
                   role: "system";
                 };
+            model?: string;
+            provider?: string;
+            providerMetadata?: Record<string, any>;
+            reasoning?: string;
+            sources?: Array<{
+              id: string;
+              providerMetadata?: Record<string, any>;
+              sourceType: "url";
+              title?: string;
+              url: string;
+            }>;
+            text?: string;
+            usage?: {
+              completionTokens: number;
+              promptTokens: number;
+              totalTokens: number;
+            };
+            warnings?: Array<
+              | {
+                  details?: string;
+                  setting: string;
+                  type: "unsupported-setting";
+                }
+              | { details?: string; tool: any; type: "unsupported-tool" }
+              | { message: string; type: "other" }
+            >;
           }>;
-          model?: string;
           parentMessageId?: string;
           pending?: boolean;
-          provider?: string;
           stepId?: string;
           threadId: string;
           userId?: string;
@@ -186,6 +228,14 @@ export declare const components: {
               | string;
             error?: string;
             fileId?: string;
+            finishReason?:
+              | "stop"
+              | "length"
+              | "content-filter"
+              | "tool-calls"
+              | "error"
+              | "other"
+              | "unknown";
             id?: string;
             message?:
               | {
@@ -288,6 +338,15 @@ export declare const components: {
             order: number;
             parentMessageId?: string;
             provider?: string;
+            providerMetadata?: Record<string, any>;
+            reasoning?: string;
+            sources?: Array<{
+              id: string;
+              providerMetadata?: Record<string, any>;
+              sourceType: "url";
+              title?: string;
+              url: string;
+            }>;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -300,6 +359,15 @@ export declare const components: {
               totalTokens: number;
             };
             userId?: string;
+            warnings?: Array<
+              | {
+                  details?: string;
+                  setting: string;
+                  type: "unsupported-setting";
+                }
+              | { details?: string; tool: any; type: "unsupported-tool" }
+              | { message: string; type: "other" }
+            >;
           }>;
           pending?: {
             _creationTime: number;
@@ -317,6 +385,14 @@ export declare const components: {
               | string;
             error?: string;
             fileId?: string;
+            finishReason?:
+              | "stop"
+              | "length"
+              | "content-filter"
+              | "tool-calls"
+              | "error"
+              | "other"
+              | "unknown";
             id?: string;
             message?:
               | {
@@ -419,6 +495,15 @@ export declare const components: {
             order: number;
             parentMessageId?: string;
             provider?: string;
+            providerMetadata?: Record<string, any>;
+            reasoning?: string;
+            sources?: Array<{
+              id: string;
+              providerMetadata?: Record<string, any>;
+              sourceType: "url";
+              title?: string;
+              url: string;
+            }>;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -431,6 +516,15 @@ export declare const components: {
               totalTokens: number;
             };
             userId?: string;
+            warnings?: Array<
+              | {
+                  details?: string;
+                  setting: string;
+                  type: "unsupported-setting";
+                }
+              | { details?: string; tool: any; type: "unsupported-tool" }
+              | { message: string; type: "other" }
+            >;
           };
         }
       >;
@@ -438,16 +532,34 @@ export declare const components: {
         "mutation",
         "internal",
         {
-          embeddings?: {
-            dimension: 128 | 256 | 512 | 768 | 1024 | 1536 | 2048 | 3072 | 4096;
-            model: string;
-            vectors: Array<Array<number> | null>;
-          };
           failPendingSteps?: boolean;
           messageId: string;
           step: {
             messages: Array<{
+              embedding?: {
+                dimension:
+                  | 128
+                  | 256
+                  | 512
+                  | 768
+                  | 1024
+                  | 1536
+                  | 2048
+                  | 3072
+                  | 4096;
+                model: string;
+                vector: Array<number>;
+              };
+              error?: string;
               fileId?: string;
+              finishReason?:
+                | "stop"
+                | "length"
+                | "content-filter"
+                | "tool-calls"
+                | "error"
+                | "other"
+                | "unknown";
               id?: string;
               message:
                 | {
@@ -570,6 +682,32 @@ export declare const components: {
                     providerOptions?: Record<string, any>;
                     role: "system";
                   };
+              model?: string;
+              provider?: string;
+              providerMetadata?: Record<string, any>;
+              reasoning?: string;
+              sources?: Array<{
+                id: string;
+                providerMetadata?: Record<string, any>;
+                sourceType: "url";
+                title?: string;
+                url: string;
+              }>;
+              text?: string;
+              usage?: {
+                completionTokens: number;
+                promptTokens: number;
+                totalTokens: number;
+              };
+              warnings?: Array<
+                | {
+                    details?: string;
+                    setting: string;
+                    type: "unsupported-setting";
+                  }
+                | { details?: string; tool: any; type: "unsupported-tool" }
+                | { message: string; type: "other" }
+              >;
             }>;
             step: {
               experimental_providerMetadata?: Record<string, any>;
@@ -1107,6 +1245,14 @@ export declare const components: {
               | string;
             error?: string;
             fileId?: string;
+            finishReason?:
+              | "stop"
+              | "length"
+              | "content-filter"
+              | "tool-calls"
+              | "error"
+              | "other"
+              | "unknown";
             id?: string;
             message?:
               | {
@@ -1209,6 +1355,15 @@ export declare const components: {
             order: number;
             parentMessageId?: string;
             provider?: string;
+            providerMetadata?: Record<string, any>;
+            reasoning?: string;
+            sources?: Array<{
+              id: string;
+              providerMetadata?: Record<string, any>;
+              sourceType: "url";
+              title?: string;
+              url: string;
+            }>;
             status: "pending" | "success" | "failed";
             stepId?: string;
             stepOrder: number;
@@ -1221,6 +1376,15 @@ export declare const components: {
               totalTokens: number;
             };
             userId?: string;
+            warnings?: Array<
+              | {
+                  details?: string;
+                  setting: string;
+                  type: "unsupported-setting";
+                }
+              | { details?: string; tool: any; type: "unsupported-tool" }
+              | { message: string; type: "other" }
+            >;
           }>;
           pageStatus?: "SplitRecommended" | "SplitRequired" | null;
           splitCursor?: string | null;
@@ -1295,6 +1459,14 @@ export declare const components: {
             | string;
           error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message?:
             | {
@@ -1397,6 +1569,15 @@ export declare const components: {
           order: number;
           parentMessageId?: string;
           provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1409,6 +1590,11 @@ export declare const components: {
             totalTokens: number;
           };
           userId?: string;
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         }>
       >;
       textSearch: FunctionReference<
@@ -1431,6 +1617,14 @@ export declare const components: {
             | string;
           error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message?:
             | {
@@ -1533,6 +1727,15 @@ export declare const components: {
           order: number;
           parentMessageId?: string;
           provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1545,6 +1748,11 @@ export declare const components: {
             totalTokens: number;
           };
           userId?: string;
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         }>
       >;
       updateThread: FunctionReference<

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -469,12 +469,6 @@ export class Agent<AgentTools extends ToolSet> {
    * @param args The messages and context to save
    * @returns
    */
-  /**
-   * Explicitly save messages associated with the thread (& user if provided)
-   * @param ctx The ctx parameter to a mutation or action.
-   * @param args The messages and context to save
-   * @returns
-   */
   async saveMessages(
     ctx: RunMutationCtx,
     args: {
@@ -493,17 +487,11 @@ export class Agent<AgentTools extends ToolSet> {
       /**
        * The message that this is responding to.
        */
-      /**
-       * The message that this is responding to.
-       */
       parentMessageId?: string;
       /**
        * Whether to mark all pending messages in the thread as failed.
        * This is used to recover from a failure via a retry that wipes the slate clean.
-       */
-      /**
-       * Whether to mark all pending messages in the thread as failed.
-       * This is used to recover from a failure via a retry that wipes the slate clean.
+       * Defaults to true.
        */
       failPendingSteps?: boolean;
     }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -45,6 +45,7 @@ import {
   DEFAULT_MESSAGE_RANGE,
   DEFAULT_RECENT_MESSAGES,
   extractText,
+  isTool,
 } from "../shared.js";
 import {
   type CallSettings,
@@ -432,7 +433,7 @@ export class Agent<AgentTools extends ToolSet> {
         }
       | undefined;
     if (this.options.textEmbedding) {
-      const messageTexts = messages.map((m) => extractText(m));
+      const messageTexts = messages.map((m) => !isTool(m) && extractText(m));
       // Find the indexes of the messages that have text.
       const textIndexes = messageTexts
         .map((t, i) => (t ? i : undefined))

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -148,6 +148,7 @@ export type Mounts = {
         model?: string;
         parentMessageId?: string;
         pending?: boolean;
+        provider?: string;
         stepId?: string;
         threadId: string;
         userId?: string;
@@ -270,6 +271,7 @@ export type Mounts = {
           model?: string;
           order: number;
           parentMessageId?: string;
+          provider?: string;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -395,6 +397,7 @@ export type Mounts = {
           model?: string;
           order: number;
           parentMessageId?: string;
+          provider?: string;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1151,6 +1154,7 @@ export type Mounts = {
           model?: string;
           order: number;
           parentMessageId?: string;
+          provider?: string;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1333,6 +1337,7 @@ export type Mounts = {
         model?: string;
         order: number;
         parentMessageId?: string;
+        provider?: string;
         status: "pending" | "success" | "failed";
         stepId?: string;
         stepOrder: number;
@@ -1463,6 +1468,7 @@ export type Mounts = {
         model?: string;
         order: number;
         parentMessageId?: string;
+        provider?: string;
         status: "pending" | "success" | "failed";
         stepId?: string;
         stepOrder: number;

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -278,6 +278,11 @@ export type Mounts = {
           text?: string;
           threadId: string;
           tool: boolean;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
           userId?: string;
         }>;
         pending?: {
@@ -404,6 +409,11 @@ export type Mounts = {
           text?: string;
           threadId: string;
           tool: boolean;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
           userId?: string;
         };
       }
@@ -1161,6 +1171,11 @@ export type Mounts = {
           text?: string;
           threadId: string;
           tool: boolean;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
           userId?: string;
         }>;
         pageStatus?: "SplitRecommended" | "SplitRequired" | null;
@@ -1344,6 +1359,11 @@ export type Mounts = {
         text?: string;
         threadId: string;
         tool: boolean;
+        usage?: {
+          completionTokens: number;
+          promptTokens: number;
+          totalTokens: number;
+        };
         userId?: string;
       }>
     >;
@@ -1475,6 +1495,11 @@ export type Mounts = {
         text?: string;
         threadId: string;
         tool: boolean;
+        usage?: {
+          completionTokens: number;
+          promptTokens: number;
+          totalTokens: number;
+        };
         userId?: string;
       }>
     >;

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -38,14 +38,23 @@ export type Mounts = {
       "public",
       {
         agentName?: string;
-        embeddings?: {
-          dimension: 128 | 256 | 512 | 768 | 1024 | 1536 | 2048 | 3072 | 4096;
-          model: string;
-          vectors: Array<Array<number> | null>;
-        };
         failPendingSteps?: boolean;
         messages: Array<{
+          embedding?: {
+            dimension: 128 | 256 | 512 | 768 | 1024 | 1536 | 2048 | 3072 | 4096;
+            model: string;
+            vector: Array<number>;
+          };
+          error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message:
             | {
@@ -144,11 +153,31 @@ export type Mounts = {
                 providerOptions?: Record<string, any>;
                 role: "system";
               };
+          model?: string;
+          provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
+          text?: string;
+          usage?: {
+            completionTokens: number;
+            promptTokens: number;
+            totalTokens: number;
+          };
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         }>;
-        model?: string;
         parentMessageId?: string;
         pending?: boolean;
-        provider?: string;
         stepId?: string;
         threadId: string;
         userId?: string;
@@ -170,6 +199,14 @@ export type Mounts = {
             | string;
           error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message?:
             | {
@@ -272,6 +309,15 @@ export type Mounts = {
           order: number;
           parentMessageId?: string;
           provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -284,6 +330,11 @@ export type Mounts = {
             totalTokens: number;
           };
           userId?: string;
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         }>;
         pending?: {
           _creationTime: number;
@@ -301,6 +352,14 @@ export type Mounts = {
             | string;
           error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message?:
             | {
@@ -403,6 +462,15 @@ export type Mounts = {
           order: number;
           parentMessageId?: string;
           provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -415,6 +483,11 @@ export type Mounts = {
             totalTokens: number;
           };
           userId?: string;
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         };
       }
     >;
@@ -422,16 +495,34 @@ export type Mounts = {
       "mutation",
       "public",
       {
-        embeddings?: {
-          dimension: 128 | 256 | 512 | 768 | 1024 | 1536 | 2048 | 3072 | 4096;
-          model: string;
-          vectors: Array<Array<number> | null>;
-        };
         failPendingSteps?: boolean;
         messageId: string;
         step: {
           messages: Array<{
+            embedding?: {
+              dimension:
+                | 128
+                | 256
+                | 512
+                | 768
+                | 1024
+                | 1536
+                | 2048
+                | 3072
+                | 4096;
+              model: string;
+              vector: Array<number>;
+            };
+            error?: string;
             fileId?: string;
+            finishReason?:
+              | "stop"
+              | "length"
+              | "content-filter"
+              | "tool-calls"
+              | "error"
+              | "other"
+              | "unknown";
             id?: string;
             message:
               | {
@@ -530,6 +621,32 @@ export type Mounts = {
                   providerOptions?: Record<string, any>;
                   role: "system";
                 };
+            model?: string;
+            provider?: string;
+            providerMetadata?: Record<string, any>;
+            reasoning?: string;
+            sources?: Array<{
+              id: string;
+              providerMetadata?: Record<string, any>;
+              sourceType: "url";
+              title?: string;
+              url: string;
+            }>;
+            text?: string;
+            usage?: {
+              completionTokens: number;
+              promptTokens: number;
+              totalTokens: number;
+            };
+            warnings?: Array<
+              | {
+                  details?: string;
+                  setting: string;
+                  type: "unsupported-setting";
+                }
+              | { details?: string; tool: any; type: "unsupported-tool" }
+              | { message: string; type: "other" }
+            >;
           }>;
           step: {
             experimental_providerMetadata?: Record<string, any>;
@@ -1063,6 +1180,14 @@ export type Mounts = {
             | string;
           error?: string;
           fileId?: string;
+          finishReason?:
+            | "stop"
+            | "length"
+            | "content-filter"
+            | "tool-calls"
+            | "error"
+            | "other"
+            | "unknown";
           id?: string;
           message?:
             | {
@@ -1165,6 +1290,15 @@ export type Mounts = {
           order: number;
           parentMessageId?: string;
           provider?: string;
+          providerMetadata?: Record<string, any>;
+          reasoning?: string;
+          sources?: Array<{
+            id: string;
+            providerMetadata?: Record<string, any>;
+            sourceType: "url";
+            title?: string;
+            url: string;
+          }>;
           status: "pending" | "success" | "failed";
           stepId?: string;
           stepOrder: number;
@@ -1177,6 +1311,11 @@ export type Mounts = {
             totalTokens: number;
           };
           userId?: string;
+          warnings?: Array<
+            | { details?: string; setting: string; type: "unsupported-setting" }
+            | { details?: string; tool: any; type: "unsupported-tool" }
+            | { message: string; type: "other" }
+          >;
         }>;
         pageStatus?: "SplitRecommended" | "SplitRequired" | null;
         splitCursor?: string | null;
@@ -1251,6 +1390,14 @@ export type Mounts = {
           | string;
         error?: string;
         fileId?: string;
+        finishReason?:
+          | "stop"
+          | "length"
+          | "content-filter"
+          | "tool-calls"
+          | "error"
+          | "other"
+          | "unknown";
         id?: string;
         message?:
           | {
@@ -1353,6 +1500,15 @@ export type Mounts = {
         order: number;
         parentMessageId?: string;
         provider?: string;
+        providerMetadata?: Record<string, any>;
+        reasoning?: string;
+        sources?: Array<{
+          id: string;
+          providerMetadata?: Record<string, any>;
+          sourceType: "url";
+          title?: string;
+          url: string;
+        }>;
         status: "pending" | "success" | "failed";
         stepId?: string;
         stepOrder: number;
@@ -1365,6 +1521,11 @@ export type Mounts = {
           totalTokens: number;
         };
         userId?: string;
+        warnings?: Array<
+          | { details?: string; setting: string; type: "unsupported-setting" }
+          | { details?: string; tool: any; type: "unsupported-tool" }
+          | { message: string; type: "other" }
+        >;
       }>
     >;
     textSearch: FunctionReference<
@@ -1387,6 +1548,14 @@ export type Mounts = {
           | string;
         error?: string;
         fileId?: string;
+        finishReason?:
+          | "stop"
+          | "length"
+          | "content-filter"
+          | "tool-calls"
+          | "error"
+          | "other"
+          | "unknown";
         id?: string;
         message?:
           | {
@@ -1489,6 +1658,15 @@ export type Mounts = {
         order: number;
         parentMessageId?: string;
         provider?: string;
+        providerMetadata?: Record<string, any>;
+        reasoning?: string;
+        sources?: Array<{
+          id: string;
+          providerMetadata?: Record<string, any>;
+          sourceType: "url";
+          title?: string;
+          url: string;
+        }>;
         status: "pending" | "success" | "failed";
         stepId?: string;
         stepOrder: number;
@@ -1501,6 +1679,11 @@ export type Mounts = {
           totalTokens: number;
         };
         userId?: string;
+        warnings?: Array<
+          | { details?: string; setting: string; type: "unsupported-setting" }
+          | { details?: string; tool: any; type: "unsupported-tool" }
+          | { message: string; type: "other" }
+        >;
       }>
     >;
     updateThread: FunctionReference<

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -537,6 +537,7 @@ async function addStepHandler(
     stepId,
     messages,
     model: parentMessage.model,
+    provider: parentMessage.provider,
     agentName: parentMessage.agentName,
     pending: step.finishReason === "stop" ? false : true,
     failPendingSteps: false,

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -340,8 +340,10 @@ const addMessagesArgs = {
   threadId: v.id("threads"),
   stepId: v.optional(v.id("steps")),
   parentMessageId: v.optional(v.id("messages")),
+  // TODO: add more things like usage, sources, reasoning, etc.
   messages: v.array(vMessageWithFileAndId),
   model: v.optional(v.string()),
+  provider: v.optional(v.string()),
   agentName: v.optional(v.string()),
   pending: v.optional(v.boolean()),
   failPendingSteps: v.optional(v.boolean()),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -35,6 +35,7 @@ export const schema = defineSchema({
     message: v.optional(vMessage),
     error: v.optional(v.string()),
     model: v.optional(v.string()),
+    provider: v.optional(v.string()),
     text: v.optional(v.string()),
     embeddingId: v.optional(vVectorId),
     // TODO: add sub-messages back in? or be able to skip them?

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -6,6 +6,9 @@ import {
   vMessageStatus,
   vStep,
   vUsage,
+  vSource,
+  vLanguageModelV1CallWarning,
+  vFinishReason,
 } from "../validators.js";
 import { typedV } from "convex-helpers/validators";
 import vectorTables, { vVectorId } from "./vector/tables.js";
@@ -46,6 +49,11 @@ export const schema = defineSchema({
     order: v.number(),
     stepOrder: v.number(),
     usage: v.optional(vUsage),
+    finishReason: v.optional(vFinishReason),
+    providerMetadata: v.optional(v.record(v.string(), v.any())),
+    sources: v.optional(v.array(vSource)),
+    reasoning: v.optional(v.string()),
+    warnings: v.optional(v.array(vLanguageModelV1CallWarning)),
     fileId: v.optional(v.id("files")),
     status: vMessageStatus,
   })

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -5,6 +5,7 @@ import {
   vMessage,
   vMessageStatus,
   vStep,
+  vUsage,
 } from "../validators.js";
 import { typedV } from "convex-helpers/validators";
 import vectorTables, { vVectorId } from "./vector/tables.js";
@@ -44,6 +45,7 @@ export const schema = defineSchema({
     // Unset if it's not in a thread.
     order: v.number(),
     stepOrder: v.number(),
+    usage: v.optional(vUsage),
     fileId: v.optional(v.id("files")),
     status: vMessageStatus,
   })

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -222,6 +222,13 @@ export const vLanguageModelV1CallWarning = v.union(
     message: v.string(),
   })
 );
+
+export const vUsage = v.object({
+  promptTokens: v.number(),
+  completionTokens: v.number(),
+  totalTokens: v.number(),
+});
+
 export const vStep = v.object({
   experimental_providerMetadata,
   files: v.optional(v.array(v.any())),


### PR DESCRIPTION
Let's start moving towards a world where the steps tables doesn't need to exist, and we can get all the UIMessage fields from the messages table ( #27 ), to power things like `useChat` ( #20 ).

This adds a bunch of fields to messages, as well as changing the interface to some save methods / component api to add steps. As a result, this is a breaking change for those relying on the current manual saving behavior.

Also makes usage more accessible through the message query API ( #1 )