### PR TITLE
Expose usageHandler for usage tracking

### DIFF
--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -180,11 +180,11 @@ export declare const components: {
                 };
             model?: string;
             provider?: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             reasoning?: string;
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -342,7 +342,7 @@ export declare const components: {
             reasoning?: string;
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -499,7 +499,7 @@ export declare const components: {
             reasoning?: string;
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -684,11 +684,11 @@ export declare const components: {
                   };
               model?: string;
               provider?: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               reasoning?: string;
               sources?: Array<{
                 id: string;
-                providerMetadata?: Record<string, any>;
+                providerMetadata?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
                 url: string;
@@ -722,7 +722,7 @@ export declare const components: {
                 | "unknown";
               isContinued: boolean;
               logprobs?: any;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, any>;
               reasoning?: string;
               reasoningDetails?: Array<any>;
@@ -866,7 +866,7 @@ export declare const components: {
               };
               sources?: Array<{
                 id: string;
-                providerMetadata?: Record<string, any>;
+                providerMetadata?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
                 url: string;
@@ -932,7 +932,7 @@ export declare const components: {
               | "unknown";
             isContinued: boolean;
             logprobs?: any;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             providerOptions?: Record<string, any>;
             reasoning?: string;
             reasoningDetails?: Array<any>;
@@ -1076,7 +1076,7 @@ export declare const components: {
             };
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -1359,7 +1359,7 @@ export declare const components: {
             reasoning?: string;
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -1573,7 +1573,7 @@ export declare const components: {
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -1731,7 +1731,7 @@ export declare const components: {
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.14-alpha.0",
+  "version": "0.0.14-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.14-alpha.0",
+      "version": "0.0.14-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.14-alpha.1",
+  "version": "0.0.14-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.14-alpha.1",
+      "version": "0.0.14-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.13",
+  "version": "0.0.14-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.13",
+      "version": "0.0.14-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.14-alpha.2",
+  "version": "0.0.14-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.14-alpha.2",
+      "version": "0.0.14-alpha.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.14-alpha.1",
+  "version": "0.0.14-alpha.2",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.14-alpha.0",
+  "version": "0.0.14-alpha.1",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.14-alpha.2",
+  "version": "0.0.14-alpha.3",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.13",
+  "version": "0.0.14-alpha.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -150,15 +150,16 @@ type CoreMessageMaybeWithId = CoreMessage & { id?: string | undefined };
 export type UsageHandler = (
   ctx: RunActionCtx,
   args: {
-    userId?: string;
-    threadId?: string;
+    userId: string | undefined;
+    threadId: string | undefined;
+    agentName: string | undefined;
     usage: Usage;
     // Often has more information, like cached token usage in the case of openai.
-    providerMetadata?: ProviderMetadata;
+    providerMetadata: ProviderMetadata | undefined;
     model: string;
     provider: string;
   }
-) => Promise<void>;
+) => void | Promise<void>;
 
 export class Agent<AgentTools extends ToolSet> {
   constructor(
@@ -694,6 +695,7 @@ export class Agent<AgentTools extends ToolSet> {
             await this.options.usageHandler(ctx, {
               userId,
               threadId,
+              agentName: this.options.name,
               model: model.modelId,
               provider: model.provider,
               usage: step.usage,
@@ -791,6 +793,7 @@ export class Agent<AgentTools extends ToolSet> {
           await this.options.usageHandler(ctx, {
             userId,
             threadId,
+            agentName: this.options.name,
             model: model.modelId,
             provider: model.provider,
             usage: step.usage,
@@ -914,6 +917,7 @@ export class Agent<AgentTools extends ToolSet> {
         await this.options.usageHandler(ctx, {
           userId,
           threadId,
+          agentName: this.options.name,
           model: model.modelId,
           provider: model.provider,
           usage: result.usage,
@@ -994,6 +998,7 @@ export class Agent<AgentTools extends ToolSet> {
           await this.options.usageHandler(ctx, {
             userId,
             threadId,
+            agentName: this.options.name,
             model: model.modelId,
             provider: model.provider,
             usage: result.usage,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -534,11 +534,6 @@ export class Agent<AgentTools extends ToolSet> {
    * @param ctx The ctx argument to a mutation or action.
    * @param args What to save
    */
-  /**
-   * Explicitly save a "step" created by the AI SDK.
-   * @param ctx The ctx argument to a mutation or action.
-   * @param args What to save
-   */
   async saveStep<TOOLS extends ToolSet>(
     ctx: RunMutationCtx,
     args: {
@@ -586,14 +581,6 @@ export class Agent<AgentTools extends ToolSet> {
     });
   }
 
-  /**
-   * Commit or rollback a message that was pending.
-   * This is done automatically when saving messages by default.
-   * If creating pending messages, you can call this when the full "transaction" is done.
-   * @param ctx The ctx argument to your mutation or action.
-   * @param args What message to save. Generally the parent message sent into
-   *   the generateText call.
-   */
   /**
    * Commit or rollback a message that was pending.
    * This is done automatically when saving messages by default.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -53,7 +53,7 @@ import {
   type ProviderMetadata,
   type ProviderOptions,
   type SearchOptions,
-  Usage,
+  type Usage,
   vSafeObjectArgs,
   vTextArgs,
 } from "../validators.js";
@@ -65,6 +65,16 @@ import type {
   UseApi,
 } from "./types.js";
 import schema from "../component/schema.js";
+
+export {
+  vUsage,
+  vProviderMetadata,
+  vUserMessage,
+  vAssistantMessage,
+  vToolMessage,
+  vSystemMessage,
+  vMessage,
+} from "../validators.js";
 
 export type ThreadDoc = OpaqueIds<
   { _id: string; _creationTime: number } & Infer<

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -155,11 +155,11 @@ export type Mounts = {
               };
           model?: string;
           provider?: string;
-          providerMetadata?: Record<string, any>;
+          providerMetadata?: Record<string, Record<string, any>>;
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -313,7 +313,7 @@ export type Mounts = {
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -466,7 +466,7 @@ export type Mounts = {
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -623,11 +623,11 @@ export type Mounts = {
                 };
             model?: string;
             provider?: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             reasoning?: string;
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -661,7 +661,7 @@ export type Mounts = {
               | "unknown";
             isContinued: boolean;
             logprobs?: any;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             providerOptions?: Record<string, any>;
             reasoning?: string;
             reasoningDetails?: Array<any>;
@@ -805,7 +805,7 @@ export type Mounts = {
             };
             sources?: Array<{
               id: string;
-              providerMetadata?: Record<string, any>;
+              providerMetadata?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
               url: string;
@@ -871,7 +871,7 @@ export type Mounts = {
             | "unknown";
           isContinued: boolean;
           logprobs?: any;
-          providerMetadata?: Record<string, any>;
+          providerMetadata?: Record<string, Record<string, any>>;
           providerOptions?: Record<string, any>;
           reasoning?: string;
           reasoningDetails?: Array<any>;
@@ -1015,7 +1015,7 @@ export type Mounts = {
           };
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -1294,7 +1294,7 @@ export type Mounts = {
           reasoning?: string;
           sources?: Array<{
             id: string;
-            providerMetadata?: Record<string, any>;
+            providerMetadata?: Record<string, Record<string, any>>;
             sourceType: "url";
             title?: string;
             url: string;
@@ -1504,7 +1504,7 @@ export type Mounts = {
         reasoning?: string;
         sources?: Array<{
           id: string;
-          providerMetadata?: Record<string, any>;
+          providerMetadata?: Record<string, Record<string, any>>;
           sourceType: "url";
           title?: string;
           url: string;
@@ -1662,7 +1662,7 @@ export type Mounts = {
         reasoning?: string;
         sources?: Array<{
           id: string;
-          providerMetadata?: Record<string, any>;
+          providerMetadata?: Record<string, Record<string, any>>;
           sourceType: "url";
           title?: string;
           url: string;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -5,8 +5,12 @@ import { vVectorDimension } from "./component/vector/tables";
 
 const providerOptions = v.optional(v.record(v.string(), v.any()));
 export type ProviderOptions = Infer<typeof providerOptions>;
+const providerMetadata = v.optional(
+  v.record(v.string(), v.record(v.string(), v.any()))
+);
+export { providerMetadata as vProviderMetadata };
+export type ProviderMetadata = Infer<typeof providerMetadata>;
 const experimental_providerMetadata = providerOptions;
-export type ProviderMetadata = Infer<typeof experimental_providerMetadata>;
 
 export const vThreadStatus = v.union(
   v.literal("active"),
@@ -161,7 +165,7 @@ export const vSource = v.object({
   id: v.string(),
   url: v.string(),
   title: v.optional(v.string()),
-  providerMetadata: providerOptions,
+  providerMetadata,
 });
 
 export const vRequest = v.object({
@@ -238,7 +242,7 @@ export const vMessageWithMetadata = v.object({
   finishReason: v.optional(vFinishReason),
   model: v.optional(v.string()),
   provider: v.optional(v.string()),
-  providerMetadata: v.optional(v.record(v.string(), v.any())),
+  providerMetadata,
   sources: v.optional(v.array(vSource)),
   reasoning: v.optional(v.string()),
   usage: v.optional(vUsage),
@@ -261,7 +265,7 @@ export const vStep = v.object({
   finishReason: vFinishReason,
   isContinued: v.boolean(),
   logprobs: v.optional(v.any()),
-  providerMetadata: providerOptions,
+  providerMetadata,
   providerOptions,
   reasoning: v.optional(v.string()),
   reasoningDetails: v.optional(v.array(v.any())),
@@ -295,7 +299,7 @@ export const vObjectResult = v.object({
   object: v.any(),
   error: v.optional(v.string()),
   warnings: v.optional(v.array(vLanguageModelV1CallWarning)),
-  providerMetadata: providerOptions,
+  providerMetadata,
   experimental_providerMetadata,
 });
 export type ObjectResult = Infer<typeof vObjectResult>;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -210,6 +210,7 @@ export const vUsage = v.object({
   completionTokens: v.number(),
   totalTokens: v.number(),
 });
+export type Usage = Infer<typeof vUsage>;
 
 export const vLanguageModelV1CallWarning = v.union(
   v.object({


### PR DESCRIPTION
Enables usage tracking (not via a dedicated component yet, but via whatever mechanism you want)

Fixes #1 

Still worth doing:

- [ ] Update README with syntax & basic usage
- [ ] Provide example using aggregate
- [ ] Outline how you could do an hourly cron to get usage data from the messages table instead of the callback

Open Q: Is a Usage component worth it? Is there a general API that's a lot better than bespoke aggregates / tables?