### PR TITLE
Add more options and allow specifying tools at the agent and thread level

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -228,13 +228,15 @@ export const searchMessages = action({
       userId,
       threadId,
       messages: [{ role: "user", content: text }],
-      searchOtherThreads: true,
-      recentMessages: 0,
-      searchOptions: {
-        textSearch: true,
-        vectorSearch: true,
-        messageRange: { before: 0, after: 0 },
-        limit: 10,
+      contextOptions: {
+        searchOtherThreads: true,
+        recentMessages: 0,
+        searchOptions: {
+          textSearch: true,
+          vectorSearch: true,
+          messageRange: { before: 0, after: 0 },
+          limit: 10,
+        },
       },
     });
   },

--- a/example/convex/ideaAgents.ts
+++ b/example/convex/ideaAgents.ts
@@ -15,24 +15,19 @@ import { zid } from "convex-helpers/server/zod";
 /**
  * TOOLS
  */
+type Idea = {
+  title: string;
+  summary: string;
+  tags: string[];
+  ideaId: Id<"ideas">;
+  createdAt: string;
+  lastUpdated: string;
+};
+
 export const ideaSearch = createTool({
   description: "Search for ideas by space-delimited keywords",
-  args: z.object({
-    query: z.string(),
-  }),
-  handler: async (
-    ctx,
-    { query },
-  ): Promise<
-    Array<{
-      title: string;
-      summary: string;
-      tags: string[];
-      ideaId: Id<"ideas">;
-      createdAt: string;
-      lastUpdated: string;
-    }>
-  > => {
+  args: z.object({ query: z.string() }),
+  handler: async (ctx, { query }): Promise<Array<Idea>> => {
     console.log("searching for ideas", query);
     const ideas = await ctx.runQuery(api.ideas.searchIdeas, { query });
     console.log("found ideas", ideas);

--- a/example/src/pages/Home.tsx
+++ b/example/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export function Home() {
     threadId ? { threadId } : "skip",
     { initialNumItems: 10 },
   );
-  const getWeather = useAction(api.example.createThread);
+  const getWeather = useAction(api.example.createThreadAndGenerateText);
   const getOutfit = useAction(api.example.continueThread);
   const [followUpContent, setFollowUpContent] = useState("");
   // const token = useAuthToken();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.14",
+  "version": "0.0.15-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.14",
+      "version": "0.0.15-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/agent",
-  "version": "0.0.15-alpha.0",
+  "version": "0.0.15-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/agent",
-      "version": "0.0.15-alpha.0",
+      "version": "0.0.15-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.14",
+  "version": "0.0.15-alpha.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
   },
-  "version": "0.0.15-alpha.0",
+  "version": "0.0.15-alpha.2",
   "license": "Apache-2.0",
   "keywords": [
     "convex",


### PR DESCRIPTION
- you can now specify tools at the agent level, at createThread/continueThread, as well as generateText/streamText, where each level overrides the parent, and is type-safe with things like `toolChoice`
- options for storage and context are now top-level args, e.g. for generateText `{ prompt, contextOptions: { recentMessages: 10 } }` instead of `{ prompt, recentMessages: 10 }`
- BREAKING: renames getEmbeddings to generateEmbeddings

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
