### PR TITLE
dynamic agent definitions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,3 +22,4 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npx pkg-pr-new publish
+      - run: cd playground && npx pkg-pr-new publish

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
           cache-dependency-path: |
             example/package.json
             package.json
-          node-version: "19.x"
+          node-version: "20.x"
           cache: "npm"
       - run: node setup.cjs
       - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,5 +21,4 @@ jobs:
       - run: npm test
       - run: npm run typecheck
       - run: npm run lint
-      - run: npx pkg-pr-new publish
-      - run: cd playground && npx pkg-pr-new publish
+      - run: npx pkg-pr-new publish ./ ./playground

--- a/playground/src/definePlaygroundAPI.ts
+++ b/playground/src/definePlaygroundAPI.ts
@@ -6,6 +6,7 @@ import {
   GenericDataModel,
   GenericQueryCtx,
   ApiFromModules,
+  GenericActionCtx,
 } from "convex/server";
 import {
   vMessageDoc,
@@ -25,33 +26,32 @@ export type PlaygroundAPI = ApiFromModules<{
   playground: ReturnType<typeof definePlaygroundAPI>;
 }>["playground"];
 
+export type AgentsFn<DataModel extends GenericDataModel> = (
+  ctx: GenericActionCtx<DataModel> | GenericQueryCtx<DataModel>,
+  args: { userId: string | undefined; threadId: string | undefined }
+) => Promise<Agent<ToolSet>[]>;
+
 // Playground API definition
-export function definePlaygroundAPI(
+export function definePlaygroundAPI<DataModel extends GenericDataModel>(
   component: AgentComponent,
   {
-    agents,
+    agents: agentsOrFn,
     userNameLookup,
   }: {
-    agents: Agent<ToolSet>[];
-    userNameLookup?: <DataModel extends GenericDataModel>(
+    agents: Agent<ToolSet>[] | AgentsFn<DataModel>;
+    userNameLookup?: (
       ctx: GenericQueryCtx<DataModel>,
       userId: string
     ) => string | Promise<string>;
   }
 ) {
-  // Map agent name to instance
-  const agentMap: Record<string, Agent<ToolSet>> = Object.fromEntries(
-    agents.map((agent, i) => [
-      agent.options.name ?? `Agent ${i} (missing 'name')`,
-      agent,
-    ])
-  );
-
-  for (const agent of agents) {
-    if (!agent.options.name) {
-      throw new Error(
-        `Agent has no name (instructions: ${agent.options.instructions})`
-      );
+  function validateAgents(agents: Agent<ToolSet>[]) {
+    for (const agent of agents) {
+      if (!agent.options.name) {
+        console.warn(
+          `Agent has no name (instructions: ${agent.options.instructions})`
+        );
+      }
     }
   }
 
@@ -74,14 +74,34 @@ export function definePlaygroundAPI(
     returns: v.boolean(),
   });
 
+  async function getAgents(
+    ctx: GenericActionCtx<DataModel> | GenericQueryCtx<DataModel>,
+    args: { userId: string | undefined; threadId: string | undefined }
+  ) {
+    const agents = Array.isArray(agentsOrFn)
+      ? agentsOrFn
+      : await agentsOrFn(ctx, args);
+    validateAgents(agents);
+    return agents.map((agent, i) => ({
+      name: agent.options.name ?? `Agent ${i} (missing 'name')`,
+      agent,
+    }));
+  }
+
   // List all agents
   const listAgents = queryGeneric({
     args: {
       apiKey: v.string(),
+      userId: v.optional(v.string()),
+      threadId: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+      const agents = await getAgents(ctx, {
+        userId: args.userId,
+        threadId: args.threadId,
+      });
       await validateApiKey(ctx, args.apiKey);
-      const agents = Object.entries(agentMap).map(([name, agent]) => ({
+      return agents.map(({ name, agent }) => ({
         name,
         instructions: agent.options.instructions,
         contextOptions: agent.options.contextOptions,
@@ -90,7 +110,6 @@ export function definePlaygroundAPI(
         maxRetries: agent.options.maxRetries,
         tools: agent.options.tools ? Object.keys(agent.options.tools) : [],
       }));
-      return agents;
     },
   });
 
@@ -194,21 +213,25 @@ export function definePlaygroundAPI(
   const createThread = mutationGeneric({
     args: {
       apiKey: v.string(),
-      agentName: v.string(),
       userId: v.string(),
       title: v.optional(v.string()),
       summary: v.optional(v.string()),
+      /** @deprecated Unused. */
+      agentName: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+      // if (args.agentName) {
+      //   console.warn(
+      //     "Upgrade to the latest version of @convex-dev/agent-playground"
+      //   );
+      // }
       await validateApiKey(ctx, args.apiKey);
-      const agent = agentMap[args.agentName];
-      if (!agent) throw new Error(`Unknown agent: ${args.agentName}`);
-      const { threadId } = await agent.createThread(ctx, {
+      const { _id } = await ctx.runMutation(component.threads.createThread, {
         userId: args.userId,
         title: args.title,
         summary: args.summary,
       });
-      return { threadId };
+      return { threadId: _id };
     },
     returns: v.object({ threadId: v.string() }),
   });
@@ -228,7 +251,7 @@ export function definePlaygroundAPI(
       messages: v.optional(v.array(vMessage)),
       system: v.optional(v.string()),
     },
-    handler: async (ctx, args) => {
+    handler: async (ctx: GenericActionCtx<DataModel>, args) => {
       const {
         apiKey,
         agentName,
@@ -240,8 +263,13 @@ export function definePlaygroundAPI(
         ...rest
       } = args;
       await validateApiKey(ctx, apiKey);
-      const agent = agentMap[agentName];
-      if (!agent) throw new Error(`Unknown agent: ${agentName}`);
+      const agents = await getAgents(ctx, {
+        userId: args.userId,
+        threadId: args.threadId,
+      });
+      const namedAgent = agents.find(({ name }) => name === args.agentName);
+      if (!namedAgent) throw new Error(`Unknown agent: ${args.agentName}`);
+      const { agent } = namedAgent;
       const { thread } = await agent.continueThread(ctx, { threadId, userId });
       const { messageId, text } = await thread.generateText(
         { ...rest, ...(system ? { system } : {}) },
@@ -267,8 +295,13 @@ export function definePlaygroundAPI(
     },
     handler: async (ctx, args) => {
       await validateApiKey(ctx, args.apiKey);
-      const agent = agentMap[args.agentName];
-      if (!agent) throw new Error(`Unknown agent: ${args.agentName}`);
+      const agents = await getAgents(ctx, {
+        userId: args.userId,
+        threadId: args.threadId,
+      });
+      const namedAgent = agents.find(({ name }) => name === args.agentName);
+      if (!namedAgent) throw new Error(`Unknown agent: ${args.agentName}`);
+      const { agent } = namedAgent;
       const contextOptions =
         args.contextOptions ??
         agent.options.contextOptions ??

--- a/playground/src/pages/Play.tsx
+++ b/playground/src/pages/Play.tsx
@@ -66,7 +66,11 @@ const Play = ({ apiKey, api }: PlayProps) => {
     }
   }, [messages.results, selectedMessageId]);
 
-  const agents = useQuery(api.listAgents, { apiKey });
+  const agents = useQuery(api.listAgents, {
+    apiKey,
+    threadId: selectedThreadId,
+    userId: selectedUserId,
+  });
   useEffect(() => {
     if (agents && agents.length > 0 && !selectedAgent) {
       setSelectedAgent(agents[0]);
@@ -75,6 +79,18 @@ const Play = ({ apiKey, api }: PlayProps) => {
       }
       if (agents[0].storageOptions) {
         setStorageOptions(agents[0].storageOptions);
+      }
+    } else if (agents && selectedAgent) {
+      const newAgent = agents.find(
+        (agent) => agent.name === selectedAgent.name
+      );
+      if (newAgent) {
+        if (JSON.stringify(selectedAgent) !== JSON.stringify(newAgent)) {
+          setSelectedAgent(newAgent);
+        }
+      } else {
+        // The selected agent is no longer in the list of agents, so clear it
+        setSelectedAgent(undefined);
       }
     }
   }, [agents, selectedAgent]);
@@ -106,7 +122,11 @@ const Play = ({ apiKey, api }: PlayProps) => {
   const handleSelectMessage = (messageId: string) => {
     setSelectedMessageId(messageId);
     const message = messages.results.find((m) => m._id === messageId);
-    if (message && message.agentName && selectedAgent !== message.agentName) {
+    if (
+      message &&
+      message.agentName &&
+      selectedAgent?.name !== message.agentName
+    ) {
       const agent = agents?.find((a) => a.name === message.agentName);
       if (agent) {
         setSelectedAgent(agent);
@@ -127,7 +147,7 @@ const Play = ({ apiKey, api }: PlayProps) => {
           agentName: selectedAgent.name,
           threadId: selectedThreadId,
           userId: selectedUserId,
-          messages: [selectedMessage.message],
+          messages: selectedMessage.message ? [selectedMessage.message] : [],
           contextOptions,
           beforeMessageId: selectedMessage._id,
         });
@@ -214,7 +234,7 @@ const Play = ({ apiKey, api }: PlayProps) => {
         </div>
         <div className="w-2/5 h-full">
           <RightPanel
-            selectedMessage={selectedMessage}
+            selectedMessage={selectedMessage ?? null}
             contextMessages={contextMessages}
             contextOptions={contextOptions}
             setContextOptions={setContextOptions}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -110,7 +110,7 @@ export type {
   UsageHandler,
 };
 
-export class Agent<AgentTools extends ToolSet> {
+export class Agent<AgentTools extends ToolSet = ToolSet> {
   constructor(
     public component: AgentComponent,
     public options: {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes #72 

Allows passing `async (ctx, { userId, threadId }) => Agent[]` instead of a static list.
Note:
- userId & threadId will both be undefined when there isn't a selected user / thread
- ctx will be a `QueryCtx` when listing agents, but an `ActionCtx` when generating text / fetching context. If this is too limiting we can try a non-reactive approach where we run an action on each user/thread selection.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
