### PR TITLE
Fixed initial prompt message pending bug

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1706,8 +1706,8 @@ export class Agent<AgentTools extends ToolSet> {
         metadata: coreMessages.map((_, i) =>
           i === coreMessages.length - 1 ? { id: args.id } : {}
         ),
-        pending: true,
-        failPendingSteps: true,
+        pending: !args.prompt,
+        failPendingSteps: !args.prompt,
       });
       messageId = saved.lastMessageId;
       order = saved.messages.at(-1)?.order;


### PR DESCRIPTION
<!-- Describe your PR here. -->
When sending prompts they would hang in the pending state since they aren't tool calls. This fixes that.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
