### PR TITLE
Fix missing storageOptions check in streamText onStepFinish

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -625,7 +625,7 @@ export class Agent<AgentTools extends ToolSet = ToolSet> {
       },
       onStepFinish: async (step) => {
         // console.log("onStepFinish", step);
-        if (threadId && messageId) {
+        if (threadId && messageId && saveOutputMessages) {
           const saved = await this.saveStep(ctx, {
             userId,
             threadId,


### PR DESCRIPTION
## Summary
- Added missing `saveOutputMessages` check in the `onStepFinish` callback of `streamText` method
- This brings consistency with other generation methods (`generateText`, `generateObject`, `streamObject`) and the `onError` callback

## The Issue
As described in #99, the `streamText` method was missing a check for `saveOutputMessages` in its `onStepFinish` callback. This could cause steps to be saved even when `storageOptions.saveMessages` is set to `'none'`.

## The Fix
Changed line 628 from:
```typescript
if (threadId && messageId) {
```

To:
```typescript
if (threadId && messageId && saveOutputMessages) {
```

This matches the pattern used in:
- The `onError` callback in the same method (line 617)
- The `generateText` method (line 459)  
- The `generateObject` method (line 715)
- The `streamObject` method (line 808)

## Test plan
- [ ] Verify that steps are not saved when `storageOptions.saveMessages` is set to `'none'`
- [ ] Verify that steps are saved when `storageOptions.saveMessages` is not `'none'`
- [ ] Run existing tests to ensure no regression

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)