### PR TITLE
Update a single `tool-[toolName]` part in `toUIMessages`

### DIFF
--- a/src/react/toUIMessages.ts
+++ b/src/react/toUIMessages.ts
@@ -176,7 +176,10 @@ export function toUIMessages(
                 call.output = contentPart.output;
               } else {
                 call.state = "output-available";
-                call.output = contentPart.output;
+                call.output =
+                  contentPart.output?.type === "json"
+                    ? contentPart.output.value
+                    : contentPart.output;
                 // Technically we could pull this from the doc.message
                 // but the ModelMessage doesn't have it
                 // call.providerExecuted = contentPart.providerExecuted;
@@ -204,7 +207,10 @@ export function toUIMessages(
                   toolCallId: contentPart.toolCallId,
                   state: "output-available",
                   input: undefined,
-                  output: contentPart.output,
+                  output:
+                    contentPart.output?.type === "json"
+                      ? contentPart.output.value
+                      : contentPart.output,
                   callProviderMetadata: message.providerMetadata,
                 } satisfies ToolUIPart);
               }

--- a/src/react/toUIMessages.ts
+++ b/src/react/toUIMessages.ts
@@ -155,7 +155,9 @@ export function toUIMessages(
               type: "step-start",
             } satisfies StepStartUIPart);
             assistantMessage.parts.push({
-              ...contentPart,
+              type: `tool-${contentPart.toolName}`,
+              toolCallId: contentPart.toolCallId,
+              input: contentPart.input,
               state: message.streaming ? "input-streaming" : "input-available",
               callProviderMetadata: message.providerMetadata,
             } satisfies ToolUIPart);


### PR DESCRIPTION
This PR updates `toUIMessage` to better match the UI Message format from AI SDK v5.

It does this in two ways.

Firstly by updating a single tool-call part with `type: tool-${toolName}`, rather than a `type: 'tool-call'` for the input and `type: tool-${toolName}` for the output.

Secondarily, I noticed the `output` was in the wrong format. It looked like `{ type: "json", value: { [actual output] }`. This differs from how it's handled in ai sdk v5, which uses the JSON directly on the `output` field similar to `input`.

This PR addresses both issues with accompanying unit tests.

**Note:** I've addressed the `ai-sdk-v5` branch with this PR, since that seems to be the WIO support branch for AI SDK v5.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
