### PR TITLE
omit fileIds in saveMessages

### DIFF
--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -115,14 +115,14 @@ export async function saveMessages(
     messages: await Promise.all(
       args.messages.map(async (m, i) => {
         const { message, fileIds } = await serializeMessage(ctx, component, m);
-        const allFileIds = args.metadata?.[i]?.fileIds ?? [];
-        if (fileIds) {
-          allFileIds.push(...fileIds);
-        }
+        const base = args.metadata?.[i];
+        const allFileIds = [...(base?.fileIds ?? [])];
+        if (fileIds) allFileIds.push(...fileIds);
+    
         return parse(vMessageWithMetadata, {
-          ...args.metadata?.[i],
+          ...base,
           message,
-          fileIds: allFileIds.length > 0 ? allFileIds : undefined,
+          ...(allFileIds.length > 0 ? { fileIds: allFileIds } : {}),
         });
       }),
     ),


### PR DESCRIPTION
### Fix: avoid passing undefined `fileIds` to validator in saveMessages to prevent TypeError

- **Problem**: When saving messages that have no files, the agent supplied `fileIds: undefined` to `parse(vMessageWithMetadata, ...)`. `convex-helpers`’ `stripUnknownFields` assumes arrays are present and calls `value.map(...)`, which throws when `value` is `undefined`.
- **Symptoms**: Action failures during `thread.streamText` or `saveMessages` with:
  - TypeError: Cannot read properties of undefined (reading 'map')
  - stack via `convex-helpers/validators.js` → `@convex-dev/agent/src/client/messages.ts` → `saveMessages`

### Root cause
- `saveMessages` constructed metadata as:
```ts
fileIds: allFileIds.length > 0 ? allFileIds : undefined
```
- This sets an optional array field to `undefined`, which `convex-helpers`’ array handling does not guard against.

### Changes
- In `@convex-dev/agent/src/client/messages.ts`, only include `fileIds` when it is non-empty, avoiding `undefined`:
```ts
messages: await Promise.all(
  args.messages.map(async (m, i) => {
    const { message, fileIds } = await serializeMessage(ctx, component, m);
    const base = args.metadata?.[i];
    const allFileIds = [...(base?.fileIds ?? [])];
    if (fileIds) allFileIds.push(...fileIds);

    return parse(vMessageWithMetadata, {
      ...base,
      message,
      ...(allFileIds.length > 0 ? { fileIds: allFileIds } : {}),
    });
  }),
)
```
- Also avoids mutating `args.metadata?.[i]?.fileIds` by cloning before pushing.

### Why this approach
- Aligns with the validator semantics for optional fields: omit when absent rather than set to `undefined`.
- Prevents `stripUnknownFields` from taking the array code path on an `undefined` value.
- Non-breaking for downstream consumers and keeps stored metadata minimal.

### Reproduction
1. Create/continue a thread and call `thread.streamText({ prompt }, { saveStreamDeltas: true })` (or any path that saves messages).
2. Ensure messages have no files; prior code passes `fileIds: undefined`.
3. Observe error:
   - Uncaught TypeError: Cannot read properties of undefined (reading 'map')
   - at `convex-helpers/validators.js:465` via `parse(vMessageWithMetadata, ...)`.

### Alternatives considered
- Defaulting `fileIds` to `[]`. This also fixes the crash but stores empty arrays unnecessarily.
- Hardening `convex-helpers` by guarding `undefined` in array stripping. Worth a separate upstream PR, but not required for this fix.

### Backward compatibility
- Safe change. Only affects the shape of the saved object when there are no file IDs (field omitted instead of `undefined`), which is compatible with the validator and storage.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
