### PR TITLE
Ian/provider metadata

### DIFF
--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -248,6 +248,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -268,6 +272,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -283,6 +291,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -294,6 +306,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -301,6 +317,10 @@ export declare const components: {
                             type: "file";
                           }
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -311,6 +331,10 @@ export declare const components: {
                           }
                         | {
                             data: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -320,6 +344,10 @@ export declare const components: {
                         | {
                             args: any;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -340,6 +368,10 @@ export declare const components: {
                             >;
                             isError?: boolean;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -362,6 +394,7 @@ export declare const components: {
                     >;
                     isError?: boolean;
                     providerExecuted?: boolean;
+                    providerMetadata?: Record<string, Record<string, any>>;
                     providerOptions?: Record<string, Record<string, any>>;
                     result: any;
                     toolCallId: string;
@@ -382,6 +415,7 @@ export declare const components: {
             reasoning?: string;
             reasoningDetails?: Array<
               | {
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   signature?: string;
                   text: string;
@@ -393,6 +427,7 @@ export declare const components: {
             sources?: Array<
               | {
                   id: string;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "url";
                   title?: string;
@@ -404,6 +439,7 @@ export declare const components: {
                   id: string;
                   mediaType: string;
                   providerMetadata?: Record<string, Record<string, any>>;
+                  providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "document";
                   title: string;
                   type: "source";
@@ -456,6 +492,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -476,6 +516,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -491,6 +535,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -502,6 +550,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -509,6 +561,10 @@ export declare const components: {
                             type: "file";
                           }
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -519,6 +575,10 @@ export declare const components: {
                           }
                         | {
                             data: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -528,6 +588,10 @@ export declare const components: {
                         | {
                             args: any;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -548,6 +612,10 @@ export declare const components: {
                             >;
                             isError?: boolean;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -570,6 +638,7 @@ export declare const components: {
                     >;
                     isError?: boolean;
                     providerExecuted?: boolean;
+                    providerMetadata?: Record<string, Record<string, any>>;
                     providerOptions?: Record<string, Record<string, any>>;
                     result: any;
                     toolCallId: string;
@@ -592,6 +661,7 @@ export declare const components: {
             reasoning?: string;
             reasoningDetails?: Array<
               | {
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   signature?: string;
                   text: string;
@@ -603,6 +673,7 @@ export declare const components: {
             sources?: Array<
               | {
                   id: string;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "url";
                   title?: string;
@@ -614,6 +685,7 @@ export declare const components: {
                   id: string;
                   mediaType: string;
                   providerMetadata?: Record<string, Record<string, any>>;
+                  providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "document";
                   title: string;
                   type: "source";
@@ -697,6 +769,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -711,6 +787,10 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -723,6 +803,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -731,10 +815,18 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -742,12 +834,20 @@ export declare const components: {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -761,6 +861,10 @@ export declare const components: {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -780,6 +884,7 @@ export declare const components: {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -802,6 +907,7 @@ export declare const components: {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -813,6 +919,7 @@ export declare const components: {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -824,6 +931,7 @@ export declare const components: {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -892,6 +1000,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -912,6 +1024,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -927,6 +1043,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -938,6 +1058,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -945,6 +1069,10 @@ export declare const components: {
                             type: "file";
                           }
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -955,6 +1083,10 @@ export declare const components: {
                           }
                         | {
                             data: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -964,6 +1096,10 @@ export declare const components: {
                         | {
                             args: any;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -984,6 +1120,10 @@ export declare const components: {
                             >;
                             isError?: boolean;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1006,6 +1146,7 @@ export declare const components: {
                     >;
                     isError?: boolean;
                     providerExecuted?: boolean;
+                    providerMetadata?: Record<string, Record<string, any>>;
                     providerOptions?: Record<string, Record<string, any>>;
                     result: any;
                     toolCallId: string;
@@ -1028,6 +1169,7 @@ export declare const components: {
             reasoning?: string;
             reasoningDetails?: Array<
               | {
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   signature?: string;
                   text: string;
@@ -1039,6 +1181,7 @@ export declare const components: {
             sources?: Array<
               | {
                   id: string;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "url";
                   title?: string;
@@ -1050,6 +1193,7 @@ export declare const components: {
                   id: string;
                   mediaType: string;
                   providerMetadata?: Record<string, Record<string, any>>;
+                  providerOptions?: Record<string, Record<string, any>>;
                   sourceType: "document";
                   title: string;
                   type: "source";
@@ -1118,6 +1262,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1132,6 +1280,10 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -1144,6 +1296,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1152,10 +1308,18 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -1163,12 +1327,20 @@ export declare const components: {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -1182,6 +1354,10 @@ export declare const components: {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -1201,6 +1377,7 @@ export declare const components: {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -1223,6 +1400,7 @@ export declare const components: {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -1234,6 +1412,7 @@ export declare const components: {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -1245,6 +1424,7 @@ export declare const components: {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -1302,6 +1482,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1316,6 +1500,10 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -1328,6 +1516,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1336,10 +1528,18 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -1347,12 +1547,20 @@ export declare const components: {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -1366,6 +1574,10 @@ export declare const components: {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -1385,6 +1597,7 @@ export declare const components: {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -1407,6 +1620,7 @@ export declare const components: {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -1418,6 +1632,7 @@ export declare const components: {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -1429,6 +1644,7 @@ export declare const components: {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -1476,6 +1692,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1496,6 +1716,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1511,6 +1735,10 @@ export declare const components: {
                     | string
                     | Array<
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1522,6 +1750,10 @@ export declare const components: {
                             data: string | ArrayBuffer;
                             filename?: string;
                             mimeType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1529,6 +1761,10 @@ export declare const components: {
                             type: "file";
                           }
                         | {
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1539,6 +1775,10 @@ export declare const components: {
                           }
                         | {
                             data: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1548,6 +1788,10 @@ export declare const components: {
                         | {
                             args: any;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1568,6 +1812,10 @@ export declare const components: {
                             >;
                             isError?: boolean;
                             providerExecuted?: boolean;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
                             providerOptions?: Record<
                               string,
                               Record<string, any>
@@ -1590,6 +1838,7 @@ export declare const components: {
                     >;
                     isError?: boolean;
                     providerExecuted?: boolean;
+                    providerMetadata?: Record<string, Record<string, any>>;
                     providerOptions?: Record<string, Record<string, any>>;
                     result: any;
                     toolCallId: string;
@@ -1632,6 +1881,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1646,6 +1899,10 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -1658,6 +1915,10 @@ export declare const components: {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1666,10 +1927,18 @@ export declare const components: {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -1677,12 +1946,20 @@ export declare const components: {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -1696,6 +1973,10 @@ export declare const components: {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -1715,6 +1996,7 @@ export declare const components: {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -1737,6 +2019,7 @@ export declare const components: {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -1748,6 +2031,7 @@ export declare const components: {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -1759,6 +2043,7 @@ export declare const components: {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";

--- a/src/client/files.ts
+++ b/src/client/files.ts
@@ -200,12 +200,12 @@ async function downloadFile(url: URL): Promise<ArrayBuffer> {
  * by converting them to base64. This solves the problem of LLMs not being
  * able to access localhost URLs.
  */
-export async function inlineMessagesFiles(
-  messages: (ModelMessage | Message)[],
-): Promise<(ModelMessage | Message)[]> {
+export async function inlineMessagesFiles<T extends ModelMessage | Message>(
+  messages: T[],
+): Promise<T[]> {
   // Process each message to convert localhost URLs to base64
   return Promise.all(
-    messages.map(async (message): Promise<ModelMessage | Message> => {
+    messages.map(async (message): Promise<T> => {
       if (
         (message.role !== "user" && message.role !== "assistant") ||
         typeof message.content === "string" ||

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -158,6 +158,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -172,6 +176,10 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -184,6 +192,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -192,10 +204,18 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -203,12 +223,20 @@ export type Mounts = {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -222,6 +250,10 @@ export type Mounts = {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -241,6 +273,7 @@ export type Mounts = {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -261,6 +294,7 @@ export type Mounts = {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -272,6 +306,7 @@ export type Mounts = {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -283,6 +318,7 @@ export type Mounts = {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -331,6 +367,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -345,6 +385,10 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -357,6 +401,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -365,10 +413,18 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -376,12 +432,20 @@ export type Mounts = {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -395,6 +459,10 @@ export type Mounts = {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -414,6 +482,7 @@ export type Mounts = {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -436,6 +505,7 @@ export type Mounts = {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -447,6 +517,7 @@ export type Mounts = {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -458,6 +529,7 @@ export type Mounts = {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -537,6 +609,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -551,6 +624,7 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
@@ -563,6 +637,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -571,10 +646,12 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         signature?: string;
                         text: string;
@@ -582,12 +659,14 @@ export type Mounts = {
                       }
                     | {
                         data: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "redacted-reasoning";
                       }
                     | {
                         args: any;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         toolCallId: string;
                         toolName: string;
@@ -601,6 +680,7 @@ export type Mounts = {
                         >;
                         isError?: boolean;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         result: any;
                         toolCallId: string;
@@ -620,6 +700,7 @@ export type Mounts = {
                 >;
                 isError?: boolean;
                 providerExecuted?: boolean;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 result: any;
                 toolCallId: string;
@@ -642,6 +723,7 @@ export type Mounts = {
         reasoning?: string;
         reasoningDetails?: Array<
           | {
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               signature?: string;
               text: string;
@@ -653,6 +735,7 @@ export type Mounts = {
         sources?: Array<
           | {
               id: string;
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
@@ -664,6 +747,7 @@ export type Mounts = {
               id: string;
               mediaType: string;
               providerMetadata?: Record<string, Record<string, any>>;
+              providerOptions?: Record<string, Record<string, any>>;
               sourceType: "document";
               title: string;
               type: "source";
@@ -732,6 +816,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -746,6 +834,10 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -758,6 +850,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -766,10 +862,18 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -777,12 +881,20 @@ export type Mounts = {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -796,6 +908,10 @@ export type Mounts = {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -815,6 +931,7 @@ export type Mounts = {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -837,6 +954,7 @@ export type Mounts = {
           reasoning?: string;
           reasoningDetails?: Array<
             | {
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 signature?: string;
                 text: string;
@@ -848,6 +966,7 @@ export type Mounts = {
           sources?: Array<
             | {
                 id: string;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "url";
                 title?: string;
@@ -859,6 +978,7 @@ export type Mounts = {
                 id: string;
                 mediaType: string;
                 providerMetadata?: Record<string, Record<string, any>>;
+                providerOptions?: Record<string, Record<string, any>>;
                 sourceType: "document";
                 title: string;
                 type: "source";
@@ -923,6 +1043,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -937,6 +1058,7 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
@@ -949,6 +1071,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -957,10 +1080,12 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         signature?: string;
                         text: string;
@@ -968,12 +1093,14 @@ export type Mounts = {
                       }
                     | {
                         data: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "redacted-reasoning";
                       }
                     | {
                         args: any;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         toolCallId: string;
                         toolName: string;
@@ -987,6 +1114,7 @@ export type Mounts = {
                         >;
                         isError?: boolean;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         result: any;
                         toolCallId: string;
@@ -1006,6 +1134,7 @@ export type Mounts = {
                 >;
                 isError?: boolean;
                 providerExecuted?: boolean;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 result: any;
                 toolCallId: string;
@@ -1028,6 +1157,7 @@ export type Mounts = {
         reasoning?: string;
         reasoningDetails?: Array<
           | {
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               signature?: string;
               text: string;
@@ -1039,6 +1169,7 @@ export type Mounts = {
         sources?: Array<
           | {
               id: string;
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
@@ -1050,6 +1181,7 @@ export type Mounts = {
               id: string;
               mediaType: string;
               providerMetadata?: Record<string, Record<string, any>>;
+              providerOptions?: Record<string, Record<string, any>>;
               sourceType: "document";
               title: string;
               type: "source";
@@ -1107,6 +1239,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -1121,6 +1254,7 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
@@ -1133,6 +1267,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -1141,10 +1276,12 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         signature?: string;
                         text: string;
@@ -1152,12 +1289,14 @@ export type Mounts = {
                       }
                     | {
                         data: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "redacted-reasoning";
                       }
                     | {
                         args: any;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         toolCallId: string;
                         toolName: string;
@@ -1171,6 +1310,7 @@ export type Mounts = {
                         >;
                         isError?: boolean;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         result: any;
                         toolCallId: string;
@@ -1190,6 +1330,7 @@ export type Mounts = {
                 >;
                 isError?: boolean;
                 providerExecuted?: boolean;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 result: any;
                 toolCallId: string;
@@ -1212,6 +1353,7 @@ export type Mounts = {
         reasoning?: string;
         reasoningDetails?: Array<
           | {
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               signature?: string;
               text: string;
@@ -1223,6 +1365,7 @@ export type Mounts = {
         sources?: Array<
           | {
               id: string;
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
@@ -1234,6 +1377,7 @@ export type Mounts = {
               id: string;
               mediaType: string;
               providerMetadata?: Record<string, Record<string, any>>;
+              providerOptions?: Record<string, Record<string, any>>;
               sourceType: "document";
               title: string;
               type: "source";
@@ -1281,6 +1425,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1295,6 +1443,10 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
@@ -1307,6 +1459,10 @@ export type Mounts = {
                   | string
                   | Array<
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           text: string;
                           type: "text";
@@ -1315,10 +1471,18 @@ export type Mounts = {
                           data: string | ArrayBuffer;
                           filename?: string;
                           mimeType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "file";
                         }
                       | {
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           signature?: string;
                           text: string;
@@ -1326,12 +1490,20 @@ export type Mounts = {
                         }
                       | {
                           data: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "redacted-reasoning";
                         }
                       | {
                           args: any;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           toolCallId: string;
                           toolName: string;
@@ -1345,6 +1517,10 @@ export type Mounts = {
                           >;
                           isError?: boolean;
                           providerExecuted?: boolean;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
                           providerOptions?: Record<string, Record<string, any>>;
                           result: any;
                           toolCallId: string;
@@ -1364,6 +1540,7 @@ export type Mounts = {
                   >;
                   isError?: boolean;
                   providerExecuted?: boolean;
+                  providerMetadata?: Record<string, Record<string, any>>;
                   providerOptions?: Record<string, Record<string, any>>;
                   result: any;
                   toolCallId: string;
@@ -1406,6 +1583,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -1420,6 +1598,7 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
@@ -1432,6 +1611,7 @@ export type Mounts = {
                 | string
                 | Array<
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         text: string;
                         type: "text";
@@ -1440,10 +1620,12 @@ export type Mounts = {
                         data: string | ArrayBuffer;
                         filename?: string;
                         mimeType: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "file";
                       }
                     | {
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         signature?: string;
                         text: string;
@@ -1451,12 +1633,14 @@ export type Mounts = {
                       }
                     | {
                         data: string;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         type: "redacted-reasoning";
                       }
                     | {
                         args: any;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         toolCallId: string;
                         toolName: string;
@@ -1470,6 +1654,7 @@ export type Mounts = {
                         >;
                         isError?: boolean;
                         providerExecuted?: boolean;
+                        providerMetadata?: Record<string, Record<string, any>>;
                         providerOptions?: Record<string, Record<string, any>>;
                         result: any;
                         toolCallId: string;
@@ -1489,6 +1674,7 @@ export type Mounts = {
                 >;
                 isError?: boolean;
                 providerExecuted?: boolean;
+                providerMetadata?: Record<string, Record<string, any>>;
                 providerOptions?: Record<string, Record<string, any>>;
                 result: any;
                 toolCallId: string;
@@ -1511,6 +1697,7 @@ export type Mounts = {
         reasoning?: string;
         reasoningDetails?: Array<
           | {
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               signature?: string;
               text: string;
@@ -1522,6 +1709,7 @@ export type Mounts = {
         sources?: Array<
           | {
               id: string;
+              providerMetadata?: Record<string, Record<string, any>>;
               providerOptions?: Record<string, Record<string, any>>;
               sourceType: "url";
               title?: string;
@@ -1533,6 +1721,7 @@ export type Mounts = {
               id: string;
               mediaType: string;
               providerMetadata?: Record<string, Record<string, any>>;
+              providerOptions?: Record<string, Record<string, any>>;
               sourceType: "document";
               title: string;
               type: "source";

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -348,19 +348,29 @@ export function deserializeContent(content: SerializedContent): Content {
     return content;
   }
   return content.map((part) => {
+    const metadata: {
+      providerOptions?: ProviderOptions;
+      providerMetadata?: ProviderMetadata;
+    } = {};
+    if ("providerOptions" in part) {
+      metadata.providerOptions = part.providerOptions;
+    }
+    if ("providerMetadata" in part) {
+      metadata.providerMetadata = part.providerMetadata;
+    }
     switch (part.type) {
       case "text":
         return {
           type: part.type,
           text: part.text,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies TextPart;
       case "image":
         return {
           type: part.type,
           image: deserializeUrl(part.image),
           mediaType: part.mimeType,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies ImagePart;
       case "file":
         return {
@@ -368,7 +378,7 @@ export function deserializeContent(content: SerializedContent): Content {
           data: deserializeUrl(part.data),
           filename: part.filename,
           mediaType: part.mimeType,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies FilePart;
       case "tool-call":
         return {
@@ -377,7 +387,7 @@ export function deserializeContent(content: SerializedContent): Content {
           providerExecuted: part.providerExecuted,
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies ToolCallPart;
       case "tool-result":
         return {
@@ -385,20 +395,20 @@ export function deserializeContent(content: SerializedContent): Content {
           output: part.result ?? null,
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies ToolResultPart;
       case "reasoning":
         return {
           type: part.type,
           text: part.text,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies ReasoningPart;
       case "redacted-reasoning":
         // TODO: should we just drop this?
         return {
           type: "reasoning",
           text: part.data,
-          providerOptions: part.providerOptions,
+          ...metadata,
         } satisfies ReasoningPart;
       default:
         return part satisfies Content;

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -17,18 +17,19 @@ import {
   type ToolCallPart,
   type ToolResultPart,
 } from "ai";
-import type {
-  Message,
-  MessageWithMetadata,
-  Usage,
-  vContent,
-  vFilePart,
-  vImagePart,
-  vReasoningPart,
-  vRedactedReasoningPart,
-  vTextPart,
-  vToolCallPart,
-  vToolResultPart,
+import {
+  vMessageWithMetadata,
+  type Message,
+  type MessageWithMetadata,
+  type Usage,
+  type vContent,
+  type vFilePart,
+  type vImagePart,
+  type vReasoningPart,
+  type vRedactedReasoningPart,
+  type vTextPart,
+  type vToolCallPart,
+  type vToolResultPart,
 } from "./validators.js";
 import type { ActionCtx, AgentComponent } from "./client/types.js";
 import type { RunMutationCtx } from "./client/types.js";
@@ -38,6 +39,7 @@ import {
   convertUint8ArrayToBase64,
   type ReasoningPart,
 } from "@ai-sdk/provider-utils";
+import { parse } from "convex-helpers/validators";
 export type AIMessageWithoutId = Omit<AIMessage, "id">;
 
 export type SerializeUrlsAndUint8Arrays<T> = T extends URL
@@ -171,12 +173,12 @@ export async function serializeNewMessagesInStep<TOOLS extends ToolSet>(
       : step.response.messages.slice(-1)
     ).map(async (msg): Promise<MessageWithMetadata> => {
       const { message, fileIds } = await serializeMessage(ctx, component, msg);
-      return {
+      return parse(vMessageWithMetadata, {
         message,
         ...(message.role === "tool" ? toolFields : assistantFields),
         text: step.text,
         fileIds,
-      };
+      });
     }),
   );
   // TODO: capture step.files separately?

--- a/src/react/toUIMessages.test.ts
+++ b/src/react/toUIMessages.test.ts
@@ -461,4 +461,99 @@ describe("toUIMessages", () => {
     );
     expect(toolCallParts).toHaveLength(0);
   });
+  it("sets text field correctly when message has many parts with text part as final part", () => {
+    const messages = [
+      baseMessageDoc({
+        text: "what time is it in paris?",
+        message: {
+          role: "user",
+          content: "what time is it in paris?",
+        },
+      }),
+      baseMessageDoc({
+        tool: true,
+        finishReason: "tool-calls",
+        text: "",
+        stepOrder: 1,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "**Finding the Time**\n\nI've pinpointed the core task: obtaining the current time in Paris. It involves using the `dateTime` tool. I've identified \"Europe/Paris\" as the necessary timezone identifier to provide to the tool. My next step is to test the tool.\n\n\n",
+            },
+            {
+              args: {
+                timezone: "Europe/Paris",
+              },
+              type: "tool-call",
+              toolName: "dateTime",
+              toolCallId: "tool_0_dateTime",
+            },
+          ],
+        },
+        reasoning:
+          "**Finding the Time**\n\nI've pinpointed the core task: obtaining the current time in Paris. It involves using the `dateTime` tool. I've identified \"Europe/Paris\" as the necessary timezone identifier to provide to the tool. My next step is to test the tool.\n\n\n",
+        reasoningDetails: [
+          {
+            text: "**Finding the Time**\n\nI've pinpointed the core task: obtaining the current time in Paris. It involves using the `dateTime` tool. I've identified \"Europe/Paris\" as the necessary timezone identifier to provide to the tool. My next step is to test the tool.\n\n\n",
+            type: "reasoning",
+          },
+        ],
+        warnings: [],
+      }),
+      baseMessageDoc({
+        tool: true,
+        stepOrder: 2,
+        message: {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "tool_0_dateTime",
+              toolName: "dateTime",
+              result: {
+                type: "json",
+                value: {
+                  day: "20",
+                  hours: 16,
+                  minutes: 3,
+                  month: "August",
+                  year: "2025",
+                },
+              },
+            },
+          ],
+        },
+        sources: [],
+      }),
+      baseMessageDoc({
+        finishReason: "stop",
+        text: "The time in Paris, France is 4:03 PM on August 20, 2025.",
+        stepOrder: 3,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "The time in Paris, France is 4:03 PM on August 20, 2025.",
+            },
+          ],
+        },
+        reasoningDetails: [],
+        sources: [],
+        warnings: [],
+      }),
+    ];
+
+    const uiMessages = toUIMessages(messages);
+
+    expect(uiMessages).toHaveLength(2);
+    expect(uiMessages[0].role).toBe("user");
+    expect(uiMessages[0].text).toBe("what time is it in paris?");
+    expect(uiMessages[1].role).toBe("assistant");
+    expect(uiMessages[1].text).toBe(
+      "The time in Paris, France is 4:03 PM on August 20, 2025.",
+    );
+  });
 });

--- a/src/react/useSmoothText.ts
+++ b/src/react/useSmoothText.ts
@@ -30,7 +30,9 @@ export function useSmoothText(
   text: string,
   { charsPerSec = 256, startStreaming = false }: SmoothTextOptions = {},
 ): [string, { cursor: number; isStreaming: boolean }] {
-  const [visibleText, setVisibleText] = useState(startStreaming ? "" : text);
+  const [visibleText, setVisibleText] = useState(
+    startStreaming ? "" : text || "",
+  );
   const smoothState = useRef({
     tick: Date.now() + (visibleText.length * 1000) / charsPerSec,
     cursor: visibleText.length,

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -36,6 +36,7 @@ export const vTextPart = v.object({
   type: v.literal("text"),
   text: v.string(),
   providerOptions,
+  providerMetadata,
 });
 
 export const vImagePart = v.object({
@@ -51,6 +52,7 @@ export const vFilePart = v.object({
   filename: v.optional(v.string()),
   mimeType: v.string(),
   providerOptions,
+  providerMetadata,
 });
 
 export const vUserContent = v.union(
@@ -63,12 +65,14 @@ export const vReasoningPart = v.object({
   text: v.string(),
   signature: v.optional(v.string()),
   providerOptions,
+  providerMetadata,
 });
 
 export const vRedactedReasoningPart = v.object({
   type: v.literal("redacted-reasoning"),
   data: v.string(),
   providerOptions,
+  providerMetadata,
 });
 
 export const vReasoningDetails = v.array(
@@ -90,6 +94,7 @@ export const vToolCallPart = v.object({
   args: v.any(),
   providerExecuted: v.optional(v.boolean()),
   providerOptions,
+  providerMetadata,
 });
 
 const vToolResultContent = v.array(
@@ -109,6 +114,7 @@ export const vToolResultPart = v.object({
   toolName: v.string(),
   result: v.any(),
   providerOptions,
+  providerMetadata,
   providerExecuted: v.optional(v.boolean()),
 
   // Deprecated in ai v5
@@ -177,6 +183,7 @@ export const vSource = v.union(
     url: v.string(),
     title: v.optional(v.string()),
     providerOptions,
+    providerMetadata,
   }),
   v.object({
     type: v.literal("source"),
@@ -185,6 +192,7 @@ export const vSource = v.union(
     mediaType: v.string(),
     title: v.string(),
     filename: v.optional(v.string()),
+    providerOptions,
     providerMetadata,
   }),
 );


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes #122 

providerMetadata is absent from the AI SDK types but it seems to be there regardless.
This makes the parsing more resilient to extra fields to avoid breakages in the future, as well as adding support for storing providerMetadata whenever possible

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
