### PR TITLE
Update backend setup to use 'inherit' for stdio in setup script

### DIFF
--- a/setup.cjs
+++ b/setup.cjs
@@ -36,7 +36,7 @@ if (initFlag) {
     console.log("Checking backend configuration...");
     execSync("npm run dev:backend -- --once", {
       cwd: exampleDir,
-      stdio: "pipe",
+      stdio: "inherit",
     });
     console.log("✅ Backend setup complete! No API key needed.\n");
   } catch (error) {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes https://github.com/get-convex/agent/issues/134

Setting `stdio` to `inherit` makes the terminal interactive which is required by `npm run dev:backend`
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
