### PR TITLE
Fix message bubble UI for agents + newline wrapping

### DIFF
--- a/playground/src/components/MessageItem.tsx
+++ b/playground/src/components/MessageItem.tsx
@@ -79,9 +79,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
       {message.text && (
         <div
           className={
-            message.message?.role === "user"
-              ? "message-bubble-user"
-              : "message-bubble-agent" + "whitespace-pre-wrap"
+            `${message.message?.role === "user" ? "message-bubble-user" : "message-bubble-agent"} whitespace-pre-wrap`
           }
         >
           <SmoothText


### PR DESCRIPTION
<!-- Describe your PR here. -->

There's a UI bug with the MessageItem component:
1. Message bubble UI doesn't show for agents
2. There's no wrapping of newlines for both agents & users

Before fix:   
<img width="368" height="309" alt="image" src="https://github.com/user-attachments/assets/462ac080-83b7-4f11-9f35-24347b19ec55" />

After fix:  
<img width="372" height="385" alt="image" src="https://github.com/user-attachments/assets/9c939f90-9ee8-4741-8499-615d4de46a61" />

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
