### PR TITLE
Ian/start overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ react/package.json
 *.tgz
 
 *.tsbuildinfo
+.claude

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,6 @@ npm run alpha
 # Idea/ feature backlog:
 
 - Convenience function to create a thread by copying an existing thread (fork)
-- Add a `contextHandler` option to the Agent component, that can be used to see
-  and modify the context passed to the LLM before it's called.
-  - take in { searchMessages, recentMessages, systemMessage, promptMessage }
-  - returns single message[]? - can add / prune / modify or { searchMessages,
-    recentMessages, systemMessage, promptMessage } or something else?
 - Allow aborting normal generateText
 - Improve the demo to show more of the features & have nicer UI
   - Add an example of using tracing / telemetry.

--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -120,19 +120,24 @@ and use them for vector search.
 When you change models or decide to start or stop using embeddings for vector
 search, you can manage the embeddings manually.
 
-Generate embeddings for a set of messages.
+Generate embeddings for a set of messages. Optionally pass `config` with a usage
+handler, which can be a globally shared `Config`.
 
 ```ts
-const embeddings = await supportAgent.generateEmbeddings([
-  { role: "user", content: "What is love?" },
-]);
+import { embedMessages } from "@convex-dev/agent";
+
+const embeddings = await embedMessages(
+  ctx,
+  { userId, threadId, textEmbeddingModel, ...config },
+  [{ role: "user", content: "What is love?" }],
+);
 ```
 
 Generate and save embeddings for existing messages.
 
 ```ts
 const embeddings = await supportAgent.generateAndSaveEmbeddings(ctx, {
-  messageIds
+  messageIds,
 });
 ```
 

--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -55,15 +55,21 @@ const result = await agent.generateText(
 This is what the agent does automatically, but it can be useful to do manually,
 e.g. to find custom context to include.
 
-If you provide a `beforeMessageId`, it will only fetch messages from before that
-message.
+For text and vector search, you can provide a `targetMessageId` and/or
+`searchText`. It will embed the text for vector search. If `searchText` is
+not provided, it will use the target message's text.
+
+If `targetMessageId` is provided, it will only fetch search messages previous to
+that message, and recent messages up to and including that message's "order".
+This enables re-generating a response for an earlier message.
 
 ```ts
 import type { MessageDoc } from "@convex-dev/agent";
 
 const messages: MessageDoc[] = await agent.fetchContextMessages(ctx, {
   threadId,
-  messages: [{ role: "user", content: prompt }],
+  searchText: prompt, // Optional unless you want text/vector search.
+  targetMessageId: promptMessageId, // Optionally target the search.
   userId, // Optional, unless `searchOtherThreads` is true.
   contextOptions, // Optional, defaults are used if not provided.
 });
@@ -78,7 +84,8 @@ import { fetchContextMessages } from "@convex-dev/agent";
 
 const messages = await fetchContextMessages(ctx, components.agent, {
   threadId,
-  messages: [{ role: "user", content: prompt }],
+  searchText: prompt, // Optional unless you want text/vector search.
+  targetMessageId: promptMessageId, // Optionally target the search.
   getEmbedding: async (text) => {
     const embedding = await textEmbeddingModel.embed(text);
     return { embedding, textEmbeddingModel };

--- a/docs/rate-limiting.mdx
+++ b/docs/rate-limiting.mdx
@@ -287,7 +287,7 @@ export async function estimateTokens(
   const estimatedOutputTokens = promptTokens * 3 + 1;
   const latestMessages = await fetchContextMessages(ctx, components.agent, {
     threadId,
-    messages: [{ role: "user" as const, content: question }],
+    searchText: question,
     contextOptions: { recentMessages: 2 },
   });
   // Our new usage will roughly be the previous tokens + the question.

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -861,6 +861,12 @@ export declare const components: {
         },
         null
       >;
+      getMessageSearchFields: FunctionReference<
+        "query",
+        "internal",
+        { messageId: string },
+        { embedding?: Array<number>; embeddingModel?: string; text?: string }
+      >;
       getMessagesByIds: FunctionReference<
         "query",
         "internal",
@@ -1460,15 +1466,17 @@ export declare const components: {
         "action",
         "internal",
         {
-          beforeMessageId?: string;
           embedding?: Array<number>;
           embeddingModel?: string;
           limit: number;
           messageRange?: { after: number; before: number };
           searchAllMessagesForUserId?: string;
+          targetMessageId?: string;
           text?: string;
+          textSearch?: boolean;
           threadId?: string;
           vectorScoreThreshold?: number;
+          vectorSearch?: boolean;
         },
         Array<{
           _creationTime: number;
@@ -1737,10 +1745,10 @@ export declare const components: {
         "query",
         "internal",
         {
-          beforeMessageId?: string;
           limit: number;
           searchAllMessagesForUserId?: string;
-          text: string;
+          targetMessageId?: string;
+          text?: string;
           threadId?: string;
         },
         Array<{

--- a/example/convex/chat/streaming.ts
+++ b/example/convex/chat/streaming.ts
@@ -90,7 +90,7 @@ export const listThreadMessages = query({
     streamArgs: vStreamArgs, // Used to stream messages.
   },
   handler: async (ctx, args) => {
-    const { threadId, paginationOpts, streamArgs } = args;
+    const { threadId, streamArgs } = args;
     await authorizeThreadAccess(ctx, threadId);
     const streams = await syncStreams(ctx, components.agent, {
       threadId,
@@ -100,10 +100,7 @@ export const listThreadMessages = query({
     // Here you could filter out / modify the stream of deltas / filter out
     // deltas.
 
-    const paginated = await listMessages(ctx, components.agent, {
-      threadId,
-      paginationOpts,
-    });
+    const paginated = await listMessages(ctx, components.agent, args);
 
     // Here you could filter out metadata that you don't want from any optional
     // fields on the messages.

--- a/example/convex/debugging/rawRequestResponseHandler.ts
+++ b/example/convex/debugging/rawRequestResponseHandler.ts
@@ -5,6 +5,8 @@ export const rawRequestResponseHandler: RawRequestResponseHandler = async (
   ctx,
   { request, response, agentName, threadId, userId },
 ) => {
+  // Optionally dump debug logs without pushing code
+  if (process.env.DEBUG !== "true") return;
   // Logging it here, to look up in the logs.
   // Note: really long requests & responses may end up truncated.
   console.log({

--- a/example/convex/rate_limiting/utils.ts
+++ b/example/convex/rate_limiting/utils.ts
@@ -37,7 +37,7 @@ export async function estimateTokens(
   const latestMessages = await fetchContextMessages(ctx, components.agent, {
     threadId,
     userId: await getAuthUserId(ctx),
-    messages: [{ role: "user" as const, content: question }],
+    searchText: question,
     contextOptions: { recentMessages: 2 },
   });
   // Our new usage will roughly be the previous tokens + the question.

--- a/example/convex/tools/searchMessages.ts
+++ b/example/convex/tools/searchMessages.ts
@@ -18,7 +18,7 @@ export const searchMessages = createTool({
     return fetchContextMessages(ctx, components.agent, {
       userId: ctx.userId,
       threadId: ctx.threadId,
-      messages: [{ role: "user", content: query }],
+      searchText: query,
       contextOptions: {
         searchOtherThreads: !!ctx.userId, // search other threads if the user is logged in
         recentMessages: 0, // only search older messages

--- a/playground/src/pages/Play.tsx
+++ b/playground/src/pages/Play.tsx
@@ -6,7 +6,11 @@ import { useToast } from "@/components/ui/use-toast";
 import { Switch } from "@/components/ui/switch";
 import { useQuery, useAction } from "convex/react";
 import { usePaginatedQuery } from "convex-helpers/react";
-import { type MessageDoc, type PlaygroundAPI } from "@convex-dev/agent";
+import {
+  extractText,
+  type MessageDoc,
+  type PlaygroundAPI,
+} from "@convex-dev/agent";
 import { ContextMessage, Thread, Agent } from "@/types";
 import { ContextOptions, StorageOptions } from "@convex-dev/agent";
 import { useThreadMessages } from "@convex-dev/agent/react";
@@ -164,9 +168,10 @@ function Play({ apiKey, api }: PlayProps) {
           agentName: selectedAgent.name,
           threadId: selectedThreadId,
           userId: selectedUserId,
-          messages: selectedMessage.message ? [selectedMessage.message] : [],
+          searchText:
+            selectedMessage.message && extractText(selectedMessage.message),
+          targetMessageId: selectedMessage._id,
           contextOptions,
-          beforeMessageId: selectedMessage._id,
         });
         setContextMessages(context);
       } catch (err) {

--- a/src/client/definePlaygroundAPI.ts
+++ b/src/client/definePlaygroundAPI.ts
@@ -29,7 +29,7 @@ import {
   type MessageDoc,
 } from "./index.js";
 import { serializeNewMessagesInStep } from "../mapping.js";
-import { getModelName, getProviderName } from "./search.js";
+import { getModelName, getProviderName } from "../shared.js";
 
 export type PlaygroundAPI = ApiFromModules<{
   playground: ReturnType<typeof definePlaygroundAPI>;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1788,19 +1788,20 @@ export class Agent<
       handler: async (ctx_, args) => {
         const stream =
           args.stream === true ? spec?.stream || true : (spec?.stream ?? false);
-        const targetArgs = { userId: args.userId, threadId: args.threadId };
+        const { userId, threadId, prompt, messages, maxSteps, ...rest } = args;
+        const targetArgs = { userId, threadId };
         const llmArgs = {
-          stopWhen: spec?.stopWhen ?? this.options.stopWhen,
+          stopWhen: spec?.stopWhen,
           ...overrides,
-          ...omit(args, ["storageOptions", "contextOptions"]),
-          messages: args.messages?.map(deserializeMessage),
-          prompt: Array.isArray(args.prompt)
-            ? args.prompt.map(deserializeMessage)
-            : args.prompt,
+          ...omit(rest, ["storageOptions", "contextOptions", "stream"]),
+          messages: messages?.map(deserializeMessage),
+          prompt: Array.isArray(prompt)
+            ? prompt.map(deserializeMessage)
+            : prompt,
           toolChoice: args.toolChoice as ToolChoice<AgentTools>,
         } satisfies StreamingTextArgs<AgentTools>;
-        if (args.maxSteps) {
-          llmArgs.stopWhen = stepCountIs(args.maxSteps);
+        if (maxSteps) {
+          llmArgs.stopWhen = stepCountIs(maxSteps);
         }
         const opts = {
           ...pick(spec, ["contextOptions", "storageOptions"]),

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -46,7 +46,12 @@ import {
   serializeNewMessagesInStep,
   serializeObjectResult,
 } from "../mapping.js";
-import { extractText, isTool } from "../shared.js";
+import {
+  extractText,
+  getModelName,
+  getProviderName,
+  isTool,
+} from "../shared.js";
 import {
   vMessageEmbeddings,
   vMessageWithMetadata,
@@ -65,13 +70,7 @@ import {
   type SaveMessageArgs,
   type SaveMessagesArgs,
 } from "./messages.js";
-import {
-  embedMany,
-  embedMessages,
-  fetchContextMessages,
-  getModelName,
-  getProviderName,
-} from "./search.js";
+import { embedMany, embedMessages, fetchContextMessages } from "./search.js";
 import {
   DeltaStreamer,
   syncStreams,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1857,7 +1857,7 @@ export class Agent<
    * the normal parameters to {@link generateObject}, plus {@link ContextOptions}
    * and stopWhen.
    */
-  asObjectAction<T>(
+  asObjectAction<T, DataModel extends GenericDataModel>(
     objectArgs: Omit<
       Parameters<typeof generateObject<FlexibleSchema<T>>>[0],
       "model"

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1625,11 +1625,16 @@ export class Agent<
           ?.userId) ??
       undefined;
     // If only a messageId is provided, this will add that message to the end.
+    const searchMsg =
+      promptArray.at(-1) ??
+      (args.promptMessageId ? undefined : messages.at(-1));
+    const searchText = searchMsg ? extractText(searchMsg) : undefined;
+
     const contextMessages: MessageDoc[] = await this.fetchContextMessages(ctx, {
       userId,
       threadId,
-      upToAndIncludingMessageId: args.promptMessageId,
-      messages,
+      targetMessageId: args.promptMessageId,
+      searchText,
       contextOptions,
     });
     // If it was a promptMessageId, pop it off context messages

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -96,7 +96,6 @@ import type {
   UserActionCtx,
   Config,
 } from "./types.js";
-import type { DataModel } from "../component/_generated/dataModel.js";
 import { start } from "./start.js";
 
 export { stepCountIs } from "ai";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -152,6 +152,10 @@ export {
 export {
   fetchContextMessages,
   filterOutOrphanedToolMessages,
+  fetchContextWithPrompt,
+  generateAndSaveEmbeddings,
+  embedMessages,
+  embedMany,
 } from "./search.js";
 export {
   abortStream,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -34,7 +34,6 @@ import {
   type WithoutSystemFields,
 } from "convex/server";
 import { convexToJson, v, type Value } from "convex/values";
-import type { MessageDoc, ThreadDoc } from "../component/schema.js";
 import type { threadFieldsSupportingPatch } from "../component/threads.js";
 import {
   validateVectorDimension,
@@ -58,10 +57,12 @@ import {
   vSafeObjectArgs,
   vTextArgs,
   type Message,
+  type MessageDoc,
   type MessageStatus,
   type MessageWithMetadata,
   type ProviderMetadata,
   type StreamArgs,
+  type ThreadDoc,
 } from "../validators.js";
 import { wrapTools, type ToolCtx } from "./createTool.js";
 import {
@@ -110,7 +111,6 @@ import { inlineMessagesFiles } from "./files.js";
 import type { DataModel } from "../component/_generated/dataModel.js";
 
 export { stepCountIs } from "ai";
-export { vMessageDoc, vThreadDoc } from "../component/schema.js";
 export {
   deserializeMessage,
   serializeDataOrUrl,
@@ -124,18 +124,22 @@ export {
   vAssistantMessage,
   vContextOptions,
   vMessage,
+  vMessageDoc,
   vPaginationResult,
   vProviderMetadata,
   vStorageOptions,
   vStreamArgs,
   vSystemMessage,
+  vThreadDoc,
   vToolMessage,
   vUsage,
   vUserMessage,
   vSource,
   vContent,
-  type SourcePart,
   type Message,
+  type MessageDoc,
+  type SourcePart,
+  type ThreadDoc,
   type Usage,
 } from "../validators.js";
 export type { ToolCtx } from "./createTool.js";
@@ -174,14 +178,12 @@ export type {
   AgentComponent,
   Config,
   ContextOptions,
-  MessageDoc,
   ProviderMetadata,
   RawRequestResponseHandler,
   StorageOptions,
   StreamArgs,
   SyncStreamsReturnValue,
   Thread,
-  ThreadDoc,
   UsageHandler,
 };
 export { mockModel } from "./mockModel.js";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -104,6 +104,7 @@ import type {
   Thread,
   UsageHandler,
   UserActionCtx,
+  Config,
 } from "./types.js";
 import { inlineMessagesFiles } from "./files.js";
 import type { DataModel } from "../component/_generated/dataModel.js";
@@ -171,6 +172,7 @@ export { extractText, isTool, sorted } from "../shared.js";
 export { createTool } from "./createTool.js";
 export type {
   AgentComponent,
+  Config,
   ContextOptions,
   MessageDoc,
   ProviderMetadata,
@@ -187,78 +189,6 @@ export { mockModel } from "./mockModel.js";
 // 10k characters should be more than enough for most cases, and stays under
 // the 8k token limit for some models.
 const MAX_EMBEDDING_TEXT_LENGTH = 10_000;
-
-export type Config = {
-  /**
-   * The LLM model to use for generating / streaming text and objects.
-   * e.g.
-   * import { openai } from "@ai-sdk/openai"
-   * const myAgent = new Agent(components.agent, {
-   *   languageModel: openai.chat("gpt-4o-mini"),
-   */
-  languageModel?: LanguageModel;
-  /**
-   * The model to use for text embeddings. Optional.
-   * If specified, it will use this for generating vector embeddings
-   * of chats, and can opt-in to doing vector search for automatic context
-   * on generateText, etc.
-   * e.g.
-   * import { openai } from "@ai-sdk/openai"
-   * const myAgent = new Agent(components.agent, {
-   *   ...
-   *   textEmbeddingModel: openai.embedding("text-embedding-3-small")
-   */
-  textEmbeddingModel?: EmbeddingModel<string>;
-  /**
-   * Options to determine what messages are included as context in message
-   * generation. To disable any messages automatically being added, pass:
-   * { recentMessages: 0 }
-   */
-  contextOptions?: ContextOptions;
-  /**
-   * Determines whether messages are automatically stored when passed as
-   * arguments or generated.
-   */
-  storageOptions?: StorageOptions;
-  /**
-   * The usage handler to use for this agent.
-   */
-  usageHandler?: UsageHandler;
-  /**
-   * Called for each LLM request/response, so you can do things like
-   * log the raw request body or response headers to a table, or logs.
-   */
-  rawRequestResponseHandler?: RawRequestResponseHandler;
-  /**
-   * @deprecated Reach out if you use this. Otherwise will be removed soon.
-   * Default provider options to pass for the LLM calls.
-   * This can be overridden at each generate/stream callsite on a per-field
-   * basis. To clear a default setting, you'll need to pass `undefined`.
-   */
-  providerOptions?: ProviderOptions;
-  /**
-   * The default settings to use for the LLM calls.
-   * This can be overridden at each generate/stream callsite on a per-field
-   * basis. To clear a default setting, you'll need to pass `undefined`.
-   */
-  callSettings?: CallSettings;
-  /**
-   * The maximum number of steps to allow for a single generation.
-   *
-   * For example, if an agent wants to call a tool, that call and tool response
-   * will be one step. Generating a response based on the tool call & response
-   * will be a second step.
-   * If it runs out of steps, it will return the last step result, which may
-   * not be an assistant message.
-
-   * This becomes the default value when `stopWhen` is not specified in the
-   * Agent or generation callsite.
-   * AI SDK v5 removed the `maxSteps` argument, but this is kept here for
-   * convenience and backwards compatibility.
-   * Defaults to 1.
-   */
-  maxSteps?: number;
-};
 
 export class Agent<
   /**

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -242,7 +242,7 @@ export class Agent<
       tools?: AgentTools;
       /**
        * When generating or streaming text with tools available, this
-       * determines when to stop. Defaults to stepCountIs(1).
+       * determines when to stop. Defaults to the AI SDK default.
        */
       stopWhen?: StopCondition<AgentTools> | Array<StopCondition<AgentTools>>;
       /**
@@ -502,7 +502,9 @@ export class Agent<
       stopWhen:
         args.stopWhen ??
         this.options.stopWhen ??
-        stepCountIs(this.options.maxSteps ?? 1),
+        (this.options.maxSteps
+          ? stepCountIs(this.options.maxSteps)
+          : undefined),
       tools,
     } as T & {
       model: LanguageModel;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -186,10 +186,6 @@ export type {
 };
 export { mockModel } from "./mockModel.js";
 
-// 10k characters should be more than enough for most cases, and stays under
-// the 8k token limit for some models.
-const MAX_EMBEDDING_TEXT_LENGTH = 10_000;
-
 export class Agent<
   /**
    * You can require that all `ctx` args to generateText & streamText
@@ -1108,11 +1104,22 @@ export class Agent<
     args: {
       userId: string | undefined;
       threadId: string | undefined;
-      messages: (ModelMessage | Message)[];
       /**
-       * If provided, it will search for messages up to and including this message.
-       * Note: if this is far in the past, text and vector search results may be more
-       * limited, as it's post-filtering the results.
+       * If targetMessageId is not provided, this text will be used
+       * for text and vector search
+       */
+      searchText?: string;
+      /**
+       * If provided, it will use this message for text/vector search (if enabled)
+       * and will only fetch messages up to (and including) this message's "order"
+       */
+      targetMessageId?: string;
+      /**
+       * @deprecated use searchText and targetMessageId instead
+       */
+      messages?: (ModelMessage | Message)[];
+      /**
+       * @deprecated use targetMessageId instead
        */
       upToAndIncludingMessageId?: string;
       contextOptions: ContextOptions | undefined;

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "ai";
 import type { PaginationOptions, PaginationResult } from "convex/server";
-import type { MessageDoc } from "../component/schema.js";
+import type { MessageDoc } from "../validators.js";
 import { validateVectorDimension } from "../component/vector/tables.js";
 import {
   vMessageWithMetadata,

--- a/src/client/mockModel.ts
+++ b/src/client/mockModel.ts
@@ -5,13 +5,13 @@ import type {
 import type { ReasoningPart, TextPart } from "@ai-sdk/provider-utils";
 import { simulateReadableStream } from "ai";
 
-const longDefaultText = `
+export const DEFAULT_TEXT = `
 A A A A A A A A A A A A A A A
 B B B B B B B B B B B B B B B
 C C C C C C C C C C C C C C C
 D D D D D D D D D D D D D D D
 `;
-const defaultUsage = { outputTokens: 10, inputTokens: 3, totalTokens: 13 };
+const DEFAULT_USAGE = { outputTokens: 10, inputTokens: 3, totalTokens: 13 };
 
 export type MockModelArgs = {
   provider?: LanguageModelV2["provider"];
@@ -55,7 +55,7 @@ export class MockLanguageModel implements LanguageModelV2 {
     this.provider = args.provider || "mock-provider";
     this.modelId = args.modelId || "mock-model-id";
     const {
-      content = [{ type: "text", text: longDefaultText }],
+      content = [{ type: "text", text: DEFAULT_TEXT }],
       chunkDelayInMs = 200,
       initialDelayInMs = 1000,
       supportedUrls = {},
@@ -125,7 +125,7 @@ export class MockLanguageModel implements LanguageModelV2 {
     chunks.push({
       type: "finish",
       finishReason: fail ? "error" : "stop",
-      usage: defaultUsage,
+      usage: DEFAULT_USAGE,
       providerMetadata: {
         mockProvider: { mock: "mock metadata" },
       },
@@ -144,7 +144,7 @@ export class MockLanguageModel implements LanguageModelV2 {
         return {
           content,
           finishReason: "stop",
-          usage: defaultUsage,
+          usage: DEFAULT_USAGE,
           providerMetadata: { mockProvider: { mock: "mock metadata" } },
           warnings: [],
         };

--- a/src/client/mockModel.ts
+++ b/src/client/mockModel.ts
@@ -82,8 +82,7 @@ export class MockLanguageModel implements LanguageModelV2 {
         if (c.type === "reasoning") {
           parts.push({
             type: "reasoning-start",
-
-            id: `${ci}-reasoning`,
+            id: `reasoning-${ci}`,
           });
           parts.push(
             ...deltas.map(
@@ -91,7 +90,7 @@ export class MockLanguageModel implements LanguageModelV2 {
                 ({
                   type: "reasoning-delta",
                   delta: (di ? " " : "") + delta,
-                  id: `${ci}-reasoning`,
+                  id: `reasoning-${ci}`,
                   providerMetadata: {
                     mockProvider: { mock: { reasoningDetails: null } },
                   },
@@ -100,12 +99,12 @@ export class MockLanguageModel implements LanguageModelV2 {
           );
           parts.push({
             type: "reasoning-end",
-            id: `${ci}-reasoning`,
+            id: `reasoning-${ci}`,
           });
         } else if (c.type === "text") {
           parts.push({
             type: "text-start",
-            id: `${ci}-text`,
+            id: `txt-${ci}`,
           });
           parts.push(
             ...deltas.map(
@@ -113,13 +112,13 @@ export class MockLanguageModel implements LanguageModelV2 {
                 ({
                   type: "text-delta",
                   delta: (di ? " " : "") + delta,
-                  id: `${ci}-text`,
+                  id: `txt-${ci}`,
                 }) satisfies LanguageModelV2StreamPart,
             ),
           );
           parts.push({
             type: "text-end",
-            id: `${ci}-text`,
+            id: `txt-${ci}`,
           });
         }
         return parts;
@@ -178,8 +177,11 @@ export class MockLanguageModel implements LanguageModelV2 {
           initialDelayInMs,
           chunkDelayInMs,
         });
+
         if (options.abortSignal) {
-          throw new Error("abortSignal in mock model");
+          options.abortSignal.addEventListener("abort", () => {
+            console.warn("abortSignal in mock model not supported");
+          });
         }
         return {
           stream,

--- a/src/client/saveInputMessages.test.ts
+++ b/src/client/saveInputMessages.test.ts
@@ -1,0 +1,576 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { saveInputMessages } from "./saveInputMessages.js";
+import type { MessageDoc } from "../validators.js";
+import type { RunActionCtx } from "./types.js";
+import { defineSchema } from "convex/server";
+import { initConvexTest } from "./setup.test.js";
+import { components } from "./setup.test.js";
+
+const schema = defineSchema({});
+
+// Hoisted mock functions
+const { mockSaveMessages, mockEmbedMessages } = vi.hoisted(() => ({
+  mockSaveMessages: vi.fn(),
+  mockEmbedMessages: vi.fn(),
+}));
+
+vi.mock("./messages.js", () => ({
+  saveMessages: mockSaveMessages,
+}));
+
+vi.mock("./search.js", async () => {
+  const actual = await vi.importActual("./search.js");
+  return {
+    ...actual,
+    embedMessages: mockEmbedMessages,
+  };
+});
+
+// Helper to create mock MessageDoc
+const createMockMessageDoc = (
+  id: string,
+  role: "user" | "assistant" | "tool" | "system",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any,
+): MessageDoc => ({
+  _id: id,
+  _creationTime: Date.now(),
+  userId: "test-user",
+  threadId: "test-thread",
+  order: 1,
+  stepOrder: 1,
+  status: role === "assistant" ? "pending" : "success",
+  tool: false,
+  message: { role, content },
+});
+
+describe("saveInputMessages", () => {
+  const defaultArgs = {
+    threadId: "test-thread",
+    userId: "test-user",
+    promptMessageId: undefined,
+    agentName: "test-agent",
+    storageOptions: { saveMessages: "promptAndOutput" as const },
+    usageHandler: undefined,
+    textEmbeddingModel: undefined,
+    callSettings: undefined,
+  };
+
+  const mockComponent = components.agent;
+
+  let t = initConvexTest(schema);
+  let ctx: RunActionCtx;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    t = initConvexTest(schema);
+    ctx = {
+      runQuery: t.query,
+      runAction: t.action,
+      runMutation: t.mutation,
+    } as RunActionCtx;
+
+    mockSaveMessages.mockResolvedValue({
+      messages: [
+        createMockMessageDoc("saved-1", "user", "Test prompt"),
+        createMockMessageDoc("pending-1", "assistant", []),
+      ],
+    });
+
+    mockEmbedMessages.mockResolvedValue({
+      vectors: [[0.1, 0.2, 0.3], null],
+      dimension: 3,
+      model: "test-model",
+    });
+  });
+
+  describe("saveMessages: 'all' scenarios", () => {
+    test("should save all messages and prompt when storageOptions.saveMessages is 'all'", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = "Test prompt";
+        const messages = [
+          { role: "user" as const, content: "Previous message 1" },
+          { role: "assistant" as const, content: "Response 1" },
+        ];
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          storageOptions: { saveMessages: "all" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            threadId: "test-thread",
+            userId: "test-user",
+            messages: [
+              ...messages,
+              { role: "user", content: "Test prompt" },
+              { role: "assistant", content: [] },
+            ],
+            metadata: expect.arrayContaining([
+              {},
+              {},
+              {},
+              { status: "pending" },
+            ]),
+            failPendingSteps: false,
+          }),
+        );
+
+        expect(result.promptMessageId).toBe("saved-1");
+        expect(result.pendingMessage?._id).toBe("pending-1");
+        expect(result.savedMessages).toHaveLength(1);
+        expect(result.savedMessages[0]._id).toBe("saved-1");
+      });
+    });
+
+    test("should save all with promptMessageId provided (no new messages saved)", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        // Mock saveMessages to return only pending message
+        mockSaveMessages.mockResolvedValueOnce({
+          messages: [createMockMessageDoc("pending-1", "assistant", [])],
+        });
+
+        const prompt = "Test prompt";
+        const messages = [
+          { role: "user" as const, content: "Previous message" },
+        ];
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          promptMessageId: "existing-prompt-id",
+          storageOptions: { saveMessages: "all" },
+        });
+
+        // Should not save any input messages when promptMessageId is provided
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [{ role: "assistant", content: [] }],
+            metadata: [{ status: "pending" }],
+            failPendingSteps: true,
+          }),
+        );
+
+        expect(result.promptMessageId).toBe("existing-prompt-id");
+        expect(result.savedMessages).toHaveLength(0);
+      });
+    });
+
+    test("should save all with only prompt messages provided", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = [
+          { role: "user" as const, content: "Multi-part prompt 1" },
+          { role: "user" as const, content: "Multi-part prompt 2" },
+        ];
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages: undefined,
+          storageOptions: { saveMessages: "all" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [...prompt, { role: "assistant", content: [] }],
+          }),
+        );
+
+        expect(result.savedMessages).toHaveLength(1);
+      });
+    });
+
+    test("should save all with both prompt and messages provided", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = "Single prompt";
+        const messages = [
+          { role: "user" as const, content: "Context message" },
+        ];
+
+        await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          storageOptions: { saveMessages: "all" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [
+              ...messages,
+              { role: "user", content: "Single prompt" },
+              { role: "assistant", content: [] },
+            ],
+          }),
+        );
+      });
+    });
+  });
+
+  describe("saveMessages: 'promptAndOutput' scenarios", () => {
+    test("should save only prompt when storageOptions.saveMessages is 'promptAndOutput'", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = "Test prompt";
+        const messages = [
+          { role: "user" as const, content: "Previous message" },
+        ];
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [
+              { role: "user", content: "Test prompt" },
+              { role: "assistant", content: [] },
+            ],
+            metadata: [{}, { status: "pending" }],
+          }),
+        );
+
+        expect(result.promptMessageId).toBe("saved-1");
+        expect(result.savedMessages).toHaveLength(1);
+      });
+    });
+
+    test("should save prompt array when provided with promptAndOutput", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = [
+          { role: "user" as const, content: "Part 1" },
+          { role: "user" as const, content: "Part 2" },
+        ];
+        const messages = [
+          { role: "user" as const, content: "Context message" },
+        ];
+
+        await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [...prompt, { role: "assistant", content: [] }],
+          }),
+        );
+      });
+    });
+
+    test("should save last message when no prompt provided with promptAndOutput", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const messages = [
+          { role: "user" as const, content: "First message" },
+          { role: "user" as const, content: "Last message" },
+        ];
+
+        await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: undefined,
+          messages,
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [
+              { role: "user", content: "Last message" },
+              { role: "assistant", content: [] },
+            ],
+          }),
+        );
+      });
+    });
+
+    test("should handle promptMessageId with promptAndOutput (no new messages saved)", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        // Mock saveMessages to return only pending message
+        mockSaveMessages.mockResolvedValueOnce({
+          messages: [createMockMessageDoc("pending-1", "assistant", [])],
+        });
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: "Test prompt",
+          messages: [{ role: "user" as const, content: "Context" }],
+          promptMessageId: "existing-prompt-id",
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [{ role: "assistant", content: [] }],
+            failPendingSteps: true,
+          }),
+        );
+
+        expect(result.promptMessageId).toBe("existing-prompt-id");
+        expect(result.savedMessages).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("embedding generation scenarios", () => {
+    test("should generate embeddings when textEmbeddingModel is provided (action context)", async () => {
+      // Create action context with runAction method
+      const actionCtx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn(),
+      } as RunActionCtx;
+
+      await saveInputMessages(actionCtx, mockComponent, {
+        ...defaultArgs,
+        prompt: "Test prompt",
+        messages: undefined,
+        textEmbeddingModel: "test-embedding-model",
+        storageOptions: { saveMessages: "promptAndOutput" },
+      });
+
+      // Verify embedMessages was called
+      expect(mockEmbedMessages).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          userId: "test-user",
+          threadId: "test-thread",
+          textEmbeddingModel: "test-embedding-model",
+        }),
+        [{ role: "user", content: "Test prompt" }],
+      );
+
+      // Verify saveMessages was called with embeddings
+      expect(mockSaveMessages).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          embeddings: expect.objectContaining({
+            vectors: expect.arrayContaining([[0.1, 0.2, 0.3], null]),
+            dimension: 3,
+            model: "test-model",
+          }),
+        }),
+      );
+    });
+
+    test("should not generate embeddings in mutation context even with textEmbeddingModel", async () => {
+      await expect(
+        t.run(async (ctx) => {
+          return saveInputMessages(ctx, mockComponent, {
+            ...defaultArgs,
+            prompt: "Test prompt",
+            messages: undefined,
+            textEmbeddingModel: "test-embedding-model",
+            storageOptions: { saveMessages: "promptAndOutput" },
+          });
+        }),
+      ).rejects.toThrow(
+        "You must be in an action context to generate embeddings",
+      );
+    });
+
+    test("should not generate embeddings when no textEmbeddingModel provided", async () => {
+      await saveInputMessages(ctx, mockComponent, {
+        ...defaultArgs,
+        prompt: "Test prompt",
+        messages: undefined,
+        textEmbeddingModel: undefined,
+        storageOptions: { saveMessages: "promptAndOutput" },
+      });
+
+      expect(mockEmbedMessages).not.toHaveBeenCalled();
+    });
+
+    test("should not generate embeddings when no messages to save", async () => {
+      await saveInputMessages(ctx, mockComponent, {
+        ...defaultArgs,
+        prompt: undefined,
+        messages: undefined,
+        promptMessageId: "existing-id",
+        textEmbeddingModel: "test-model",
+        storageOptions: { saveMessages: "promptAndOutput" },
+      });
+
+      expect(mockEmbedMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases and validation", () => {
+    test("should handle empty prompt and messages gracefully", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        // Mock saveMessages to return only pending message
+        mockSaveMessages.mockResolvedValueOnce({
+          messages: [createMockMessageDoc("pending-1", "assistant", [])],
+        });
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: undefined,
+          messages: undefined,
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [{ role: "assistant", content: [] }],
+            metadata: [{ status: "pending" }],
+          }),
+        );
+
+        expect(result.promptMessageId).toBeUndefined();
+        expect(result.savedMessages).toHaveLength(0);
+      });
+    });
+
+    test("should default to 'promptAndOutput' when storageOptions.saveMessages is not specified", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const prompt = "Test prompt";
+        const messages = [
+          { role: "user" as const, content: "Context message" },
+        ];
+
+        await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt,
+          messages,
+          storageOptions: undefined,
+        });
+
+        // Should behave like promptAndOutput - only save prompt
+        expect(mockSaveMessages).toHaveBeenCalledWith(
+          ctx,
+          mockComponent,
+          expect.objectContaining({
+            messages: [
+              { role: "user", content: "Test prompt" },
+              { role: "assistant", content: [] },
+            ],
+          }),
+        );
+      });
+    });
+
+    test("should always include pending message in saved messages", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: "Test prompt",
+          messages: undefined,
+          storageOptions: { saveMessages: "all" },
+        });
+
+        expect(result.pendingMessage.status).toBe("pending");
+        expect(result.pendingMessage.message?.role).toBe("assistant");
+        expect(result.pendingMessage.message?.content).toEqual([]);
+
+        // Pending message should NOT be included in savedMessages
+        expect(result.savedMessages).not.toContainEqual(
+          expect.objectContaining({ status: "pending" }),
+        );
+      });
+    });
+
+    test("should return correct promptMessageId when messages are saved", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        // Mock saveMessages to return multiple messages
+        mockSaveMessages.mockResolvedValueOnce({
+          messages: [
+            createMockMessageDoc("msg-1", "user", "First"),
+            createMockMessageDoc(
+              "msg-2",
+              "user",
+              "Second - this should be the prompt",
+            ),
+            createMockMessageDoc("pending-1", "assistant", []),
+          ],
+        });
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: "Test prompt",
+          messages: [{ role: "user" as const, content: "Context" }],
+          storageOptions: { saveMessages: "all" },
+        });
+
+        // promptMessageId should be the second-to-last message (before pending)
+        expect(result.promptMessageId).toBe("msg-2");
+        expect(result.savedMessages).toHaveLength(2);
+        expect(result.savedMessages.map((m) => m._id)).toEqual([
+          "msg-1",
+          "msg-2",
+        ]);
+      });
+    });
+
+    test("should use provided promptMessageId when no new messages are saved", async () => {
+      const t = initConvexTest(schema);
+
+      await t.run(async (ctx) => {
+        mockSaveMessages.mockResolvedValueOnce({
+          messages: [createMockMessageDoc("pending-1", "assistant", [])],
+        });
+
+        const result = await saveInputMessages(ctx, mockComponent, {
+          ...defaultArgs,
+          prompt: "Test prompt",
+          messages: undefined,
+          promptMessageId: "existing-prompt-123",
+          storageOptions: { saveMessages: "promptAndOutput" },
+        });
+
+        expect(result.promptMessageId).toBe("existing-prompt-123");
+        expect(result.savedMessages).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/src/client/saveInputMessages.ts
+++ b/src/client/saveInputMessages.ts
@@ -34,7 +34,7 @@ export async function saveInputMessages(
   } & Pick<Config, "usageHandler" | "textEmbeddingModel" | "callSettings">,
 ): Promise<{
   promptMessageId: string | undefined;
-  pendingMessage: MessageDoc | undefined;
+  pendingMessage: MessageDoc;
   savedMessages: MessageDoc[];
 }> {
   const shouldSave = args.storageOptions?.saveMessages ?? "promptAndOutput";

--- a/src/client/saveInputMessages.ts
+++ b/src/client/saveInputMessages.ts
@@ -1,0 +1,100 @@
+import { type ModelMessage } from "ai";
+import type { MessageDoc } from "../validators.js";
+import { embedMessages, getPromptArray } from "./search.js";
+import type {
+  AgentComponent,
+  Config,
+  RunActionCtx,
+  RunMutationCtx,
+} from "./types.js";
+import { saveMessages } from "./messages.js";
+import type { Message } from "../validators.js";
+import { assert } from "convex-helpers";
+import type { VectorDimension } from "../component/vector/tables.js";
+
+export async function saveInputMessages(
+  ctx: RunMutationCtx | RunActionCtx,
+  component: AgentComponent,
+  {
+    threadId,
+    userId,
+    prompt,
+    messages,
+    ...args
+  }: {
+    prompt: string | (ModelMessage | Message)[] | undefined;
+    messages: (ModelMessage | Message)[] | undefined;
+    promptMessageId: string | undefined;
+    userId: string | undefined;
+    threadId: string;
+    agentName?: string;
+    storageOptions?: {
+      saveMessages?: "all" | "promptAndOutput";
+    };
+  } & Pick<Config, "usageHandler" | "textEmbeddingModel" | "callSettings">,
+): Promise<{
+  promptMessageId: string | undefined;
+  pendingMessage: MessageDoc | undefined;
+  savedMessages: MessageDoc[];
+}> {
+  const shouldSave = args.storageOptions?.saveMessages ?? "promptAndOutput";
+  // If only a promptMessageId is provided, this will be empty.
+  const promptArray = getPromptArray(prompt);
+
+  const toSave: (ModelMessage | Message)[] = [];
+  if (args.promptMessageId) {
+    // We don't save any inputs if a promptMessageId is provided.
+    // It's unclear where they'd want to save the new messages.
+  } else if (shouldSave === "all") {
+    if (messages) toSave.push(...messages);
+    toSave.push(...promptArray);
+  } else {
+    if (promptArray.length) {
+      // We treat the whole promptArray as the prompt message to save.
+      toSave.push(...promptArray);
+    } else if (messages) {
+      // Otherwise, treat the last message as the prompt message to save.
+      toSave.push(...messages.slice(-1));
+    }
+  }
+  let embeddings:
+    | {
+        vectors: (number[] | null)[];
+        dimension: VectorDimension;
+        model: string;
+      }
+    | undefined;
+  if (args.textEmbeddingModel && toSave.length) {
+    assert(
+      "runAction" in ctx,
+      "You must be in an action context to generate embeddings",
+    );
+    embeddings = await embedMessages(
+      ctx,
+      { ...args, userId: userId ?? undefined, threadId },
+      toSave,
+    );
+    if (embeddings) {
+      // for the pending message
+      embeddings.vectors.push(null);
+    }
+  }
+  const saved = await saveMessages(ctx, component, {
+    threadId,
+    userId,
+    messages: [...toSave, { role: "assistant", content: [] }],
+    metadata: [
+      ...Array.from({ length: toSave.length }, () => ({})),
+      { status: "pending" },
+    ],
+    failPendingSteps: !!args.promptMessageId,
+    embeddings,
+  });
+  return {
+    promptMessageId: toSave.length
+      ? saved.messages.at(-2)!._id
+      : args.promptMessageId,
+    pendingMessage: saved.messages.at(-1)!,
+    savedMessages: saved.messages.slice(0, -1),
+  };
+}

--- a/src/client/search.test.ts
+++ b/src/client/search.test.ts
@@ -1,0 +1,726 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+} from "vitest";
+import type { ModelMessage } from "ai";
+import { defineSchema } from "convex/server";
+import type { MessageDoc } from "../validators.js";
+import type { RunActionCtx, RunQueryCtx } from "./types.js";
+import {
+  fetchContextWithPrompt,
+  fetchContextMessages,
+  filterOutOrphanedToolMessages,
+  getPromptArray,
+} from "./search.js";
+import { components, initConvexTest } from "./setup.test.js";
+import { createThread } from "./threads.js";
+import { saveMessages } from "./messages.js";
+
+// Helper to create mock MessageDoc
+const createMockMessageDoc = (
+  id: string,
+  role: "user" | "assistant" | "tool" | "system",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any,
+  order: number = 1,
+): MessageDoc => ({
+  _id: id,
+  _creationTime: Date.now(),
+  userId: "test-user",
+  threadId: "test-thread",
+  order,
+  stepOrder: order,
+  status: "success",
+  tool: false,
+  message: { role, content },
+});
+
+const schema = defineSchema({});
+
+describe("search.ts", () => {
+  let t = initConvexTest(schema);
+  let mockCtx: RunActionCtx;
+  let ctx: RunActionCtx;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    t = initConvexTest(schema);
+    ctx = {
+      runQuery: t.query,
+      runAction: t.action,
+      runMutation: t.mutation,
+    } as RunActionCtx;
+
+    mockCtx = {
+      runQuery: vi.fn(),
+      runAction: vi.fn(),
+      runMutation: vi.fn(),
+    } satisfies RunActionCtx;
+
+    // Mock process.env to avoid file inlining in tests
+    process.env.CONVEX_CLOUD_URL = "https://example.convex.cloud";
+  });
+
+  describe("getPromptArray", () => {
+    it("should return empty array for undefined prompt", () => {
+      expect(getPromptArray(undefined)).toEqual([]);
+    });
+
+    it("should return array as-is for array prompt", () => {
+      const prompt: ModelMessage[] = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+      ];
+      expect(getPromptArray(prompt)).toEqual(prompt);
+    });
+
+    it("should convert string prompt to user message", () => {
+      const prompt = "Hello world";
+      expect(getPromptArray(prompt)).toEqual([
+        { role: "user", content: "Hello world" },
+      ]);
+    });
+  });
+
+  describe("filterOutOrphanedToolMessages", () => {
+    it("should keep non-tool messages", () => {
+      const messages: MessageDoc[] = [
+        {
+          _id: "1",
+          message: { role: "user", content: "Hello" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "2",
+          message: { role: "assistant", content: "Hi!" },
+          order: 2,
+        } as MessageDoc,
+      ];
+
+      const result = filterOutOrphanedToolMessages(messages);
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(messages);
+    });
+
+    it("should keep tool messages with corresponding tool calls", () => {
+      const messages: MessageDoc[] = [
+        {
+          _id: "1",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I'll help you with that" },
+              {
+                type: "tool-call",
+                toolCallId: "call_123",
+                toolName: "test",
+                args: {},
+              },
+            ],
+          },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "2",
+          message: {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call_123",
+                result: "success",
+              },
+            ],
+          },
+          order: 2,
+        } as MessageDoc,
+      ];
+
+      const result = filterOutOrphanedToolMessages(messages);
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(messages);
+    });
+
+    it("should filter out orphaned tool messages", () => {
+      const messages: MessageDoc[] = [
+        {
+          _id: "1",
+          message: { role: "user", content: "Hello" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "2",
+          message: {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call_orphaned",
+                result: "orphaned",
+              },
+            ],
+          },
+          order: 2,
+        } as MessageDoc,
+      ];
+
+      const result = filterOutOrphanedToolMessages(messages);
+      expect(result).toHaveLength(1);
+      expect(result[0]._id).toBe("1");
+    });
+  });
+
+  describe("fetchContextMessages", () => {
+    it("should throw error if neither userId nor threadId provided", async () => {
+      await expect(
+        fetchContextMessages(mockCtx, components.agent, {
+          userId: undefined,
+          threadId: undefined,
+          contextOptions: {},
+        }),
+      ).rejects.toThrow("Specify userId or threadId");
+    });
+
+    it("should fetch recent messages when threadId provided", async () => {
+      const mockPage = [
+        createMockMessageDoc("2", "assistant", "Hi!", 2),
+        createMockMessageDoc("1", "user", "Hello", 1),
+      ];
+
+      (
+        mockCtx.runQuery as MockedFunction<RunActionCtx["runQuery"]>
+      ).mockResolvedValue({
+        page: mockPage,
+      });
+
+      const result = await fetchContextMessages(mockCtx, components.agent, {
+        userId: undefined,
+        threadId: "thread123",
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(mockCtx.runQuery).toHaveBeenCalledWith(expect.anything(), {
+        threadId: "thread123",
+        paginationOpts: { numItems: 10, cursor: null },
+        order: "desc",
+        excludeToolMessages: undefined,
+        statuses: ["success"],
+        upToAndIncludingMessageId: undefined,
+      });
+
+      expect(result.length).toBe(2);
+      expect(result[0]._id).toBe("1"); // Should be reversed back to asc order
+      expect(result[1]._id).toBe("2");
+    });
+
+    it("should skip recent messages when recentMessages is 0", async () => {
+      const result = await fetchContextMessages(mockCtx, components.agent, {
+        userId: "user123",
+        threadId: "thread123",
+        contextOptions: { recentMessages: 0 },
+      });
+
+      expect(mockCtx.runQuery).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("should perform search when searchOptions provided", async () => {
+      const searchResults = [
+        createMockMessageDoc("search1", "user", "Search result", 0),
+      ];
+
+      (
+        mockCtx.runAction as MockedFunction<RunActionCtx["runAction"]>
+      ).mockResolvedValue(searchResults);
+
+      const result = await fetchContextMessages(mockCtx, components.agent, {
+        userId: "user123",
+        threadId: "thread123",
+        searchText: "test query",
+        contextOptions: {
+          recentMessages: 0,
+          searchOptions: {
+            textSearch: true,
+            limit: 5,
+          },
+        },
+      });
+
+      expect(result.length).toBe(1);
+      expect(result[0]._id).toBe("search1");
+    });
+
+    it("should throw error when trying to search in non-action context", async () => {
+      const mockQueryCtx = {
+        runQuery: vi.fn().mockResolvedValue({ page: [] }),
+        // No runAction method
+      } as RunQueryCtx;
+
+      await expect(
+        fetchContextMessages(mockQueryCtx, components.agent, {
+          userId: "user123",
+          threadId: "thread123",
+          contextOptions: {
+            searchOptions: {
+              textSearch: true,
+              limit: 5,
+            },
+          },
+        }),
+      ).rejects.toThrow("searchUserMessages only works in an action");
+    });
+  });
+
+  describe("fetchContextWithPrompt", () => {
+    const baseArgs = {
+      userId: "user123",
+      threadId: "thread123",
+      agentName: "test-agent",
+      contextOptions: {},
+      usageHandler: undefined,
+      callSettings: {},
+    };
+
+    beforeEach(() => {
+      // Mock fetchContextMessages to return empty array by default
+      vi.mocked(mockCtx.runQuery).mockResolvedValue({ page: [] });
+      vi.mocked(mockCtx.runAction).mockResolvedValue([]);
+    });
+
+    it("should handle string prompt correctly", async () => {
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: "Hello, how are you?",
+        messages: undefined,
+        promptMessageId: undefined,
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: "Hello, how are you?",
+      });
+      expect(result.order).toBeUndefined();
+      expect(result.stepOrder).toBeUndefined();
+    });
+
+    it("should handle array prompt correctly", async () => {
+      const promptMessages: ModelMessage[] = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+        { role: "user", content: "How are you?" },
+      ];
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: promptMessages,
+        messages: undefined,
+        promptMessageId: undefined,
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages).toEqual(promptMessages);
+    });
+
+    it("should combine context messages with prompt", async () => {
+      const contextMessages: MessageDoc[] = [
+        {
+          _id: "ctx1",
+          message: { role: "user", content: "Context message 1" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "ctx2",
+          message: { role: "assistant", content: "Context response 1" },
+          order: 2,
+        } as MessageDoc,
+      ];
+
+      // Mock the internal fetchContextMessages call
+      vi.mocked(mockCtx.runQuery).mockResolvedValue({
+        page: [...contextMessages].reverse(),
+      });
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: "New prompt",
+        messages: undefined,
+        promptMessageId: undefined,
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].content).toBe("Context message 1");
+      expect(result.messages[1].content).toBe("Context response 1");
+      expect(result.messages[2]).toEqual({
+        role: "user",
+        content: "New prompt",
+      });
+    });
+
+    it("should handle input messages correctly", async () => {
+      const inputMessages: ModelMessage[] = [
+        { role: "user", content: "Input message 1" },
+        { role: "assistant", content: "Input response 1" },
+      ];
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: "Final prompt",
+        messages: inputMessages,
+        promptMessageId: undefined,
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0]).toEqual(inputMessages[0]);
+      expect(result.messages[1]).toEqual(inputMessages[1]);
+      expect(result.messages[2]).toEqual({
+        role: "user",
+        content: "Final prompt",
+      });
+    });
+
+    it("should splice prompt messages when promptMessageId provided", async () => {
+      const contextMessages: MessageDoc[] = [
+        {
+          _id: "msg1",
+          message: { role: "user", content: "Before prompt" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "prompt-msg",
+          message: { role: "user", content: "Original prompt" },
+          order: 2,
+        } as MessageDoc,
+        {
+          _id: "msg3",
+          message: { role: "assistant", content: "After prompt" },
+          order: 3,
+        } as MessageDoc,
+      ];
+
+      vi.mocked(mockCtx.runQuery).mockResolvedValue({
+        page: [...contextMessages].reverse(),
+      });
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: "New replacement prompt",
+        messages: undefined,
+        promptMessageId: "prompt-msg",
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].content).toBe("Before prompt");
+      expect(result.messages[1]).toEqual({
+        role: "user",
+        content: "New replacement prompt",
+      });
+      expect(result.messages[2].content).toBe("After prompt");
+      expect(result.order).toBe(2);
+    });
+
+    it("should use original prompt message when no new prompt provided", async () => {
+      const contextMessages: MessageDoc[] = [
+        {
+          _id: "msg1",
+          message: { role: "user", content: "Before prompt" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "prompt-msg",
+          message: { role: "user", content: "Original prompt" },
+          order: 2,
+        } as MessageDoc,
+        {
+          _id: "msg3",
+          message: { role: "assistant", content: "After prompt" },
+          order: 3,
+        } as MessageDoc,
+      ];
+
+      vi.mocked(mockCtx.runQuery).mockResolvedValue({
+        page: [...contextMessages].reverse(),
+      });
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: undefined,
+        messages: undefined,
+        promptMessageId: "prompt-msg",
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].content).toBe("Before prompt");
+      expect(result.messages[1].content).toBe("Original prompt");
+      expect(result.messages[2].content).toBe("After prompt");
+    });
+
+    it("should handle complex message ordering correctly", async () => {
+      const contextMessages: MessageDoc[] = [
+        {
+          _id: "ctx1",
+          message: { role: "user", content: "Context 1" },
+          order: 1,
+        } as MessageDoc,
+        {
+          _id: "prompt-msg",
+          message: { role: "user", content: "Prompt" },
+          order: 3,
+        } as MessageDoc,
+        {
+          _id: "ctx2",
+          message: { role: "assistant", content: "Context 2" },
+          order: 5,
+        } as MessageDoc,
+      ];
+
+      vi.mocked(mockCtx.runQuery).mockResolvedValue({
+        page: [...contextMessages].reverse(),
+      });
+
+      const inputMessages: ModelMessage[] = [
+        { role: "user", content: "Input message" },
+      ];
+
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: "New prompt",
+        messages: inputMessages,
+        promptMessageId: "prompt-msg",
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(4);
+      expect(result.messages[0].content).toBe("Context 1"); // Pre-prompt
+      expect(result.messages[1].content).toBe("Input message"); // Input messages
+      expect(result.messages[2].content).toBe("New prompt"); // New prompt
+      expect(result.messages[3].content).toBe("Context 2"); // Post-prompt
+    });
+
+    it("should handle empty context and messages", async () => {
+      const result = await fetchContextWithPrompt(mockCtx, components.agent, {
+        ...baseArgs,
+        prompt: undefined,
+        messages: undefined,
+        promptMessageId: undefined,
+      });
+
+      expect(result.messages).toHaveLength(0);
+      expect(result.order).toBeUndefined();
+      expect(result.stepOrder).toBeUndefined();
+    });
+  });
+
+  describe("fetchContextWithPrompt - Integration Tests", () => {
+    const baseArgs = {
+      userId: "user123",
+      threadId: "thread123",
+      agentName: "test-agent",
+      contextOptions: {},
+      usageHandler: undefined,
+      callSettings: {},
+    };
+
+    async function createTestThread(userId: string) {
+      return await t.run(async (mutCtx) => {
+        return await createThread(mutCtx, components.agent, {
+          userId,
+        });
+      });
+    }
+
+    async function createTestMessages(
+      threadId: string,
+      userId: string,
+      messages: Array<{
+        role: "user" | "assistant";
+        content: string;
+        order: number;
+      }>,
+    ) {
+      await t.run(async (mutCtx) => {
+        await saveMessages(mutCtx, components.agent, {
+          threadId,
+          userId,
+          messages: messages.map((msg) => ({
+            role: msg.role,
+            content: msg.content,
+          })),
+          metadata: messages.map((msg) => ({
+            order: msg.order,
+            stepOrder: msg.order,
+            status: "success" as const,
+          })),
+        });
+      });
+    }
+
+    it("should fetch and combine real messages with prompt", async () => {
+      const threadId = await createTestThread("user123");
+
+      await createTestMessages(threadId, "user123", [
+        { role: "user", content: "Hello", order: 1 },
+        { role: "assistant", content: "Hi there!", order: 2 },
+        { role: "user", content: "How are you?", order: 3 },
+      ]);
+
+      const result = await fetchContextWithPrompt(ctx, components.agent, {
+        ...baseArgs,
+        threadId,
+        prompt: "What's the weather?",
+        messages: undefined,
+        promptMessageId: undefined,
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(4);
+      expect(result.messages[0].content).toBe("Hello");
+      expect(result.messages[1].content).toBe("Hi there!");
+      expect(result.messages[2].content).toBe("How are you?");
+      expect(result.messages[3]).toEqual({
+        role: "user",
+        content: "What's the weather?",
+      });
+    });
+
+    it("should handle prompt message replacement in real data", async () => {
+      const threadId = await createTestThread("user456");
+
+      // Create messages and capture the prompt message ID
+      const messages = [
+        { role: "user" as const, content: "Before prompt" },
+        { role: "user" as const, content: "Original prompt" },
+        { role: "assistant" as const, content: "Assistant response" },
+      ];
+
+      const { messages: savedMessages } = await t.run(async (mutCtx) => {
+        return await saveMessages(mutCtx, components.agent, {
+          threadId,
+          userId: "user456",
+          messages: messages.map((msg) => ({
+            role: msg.role,
+            content: msg.content,
+          })),
+          metadata: messages.map(() => ({})),
+        });
+      });
+
+      const promptMessageId = savedMessages[1]._id; // The prompt message
+
+      const result = await fetchContextWithPrompt(ctx, components.agent, {
+        ...baseArgs,
+        userId: "user456",
+        threadId,
+        prompt: "New replacement prompt",
+        messages: undefined,
+        promptMessageId,
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].content).toBe("Before prompt");
+      expect(result.messages[1]).toEqual({
+        role: "user",
+        content: "New replacement prompt",
+      });
+      expect(result.messages[2].content).toBe("Assistant response");
+      // The prompt is the second user message, each on a new order.
+      expect(result.order).toBe(1);
+      expect(result.stepOrder).toBe(0);
+    });
+
+    it("should combine input messages with context and prompt", async () => {
+      const threadId = await createTestThread("user789");
+
+      await createTestMessages(threadId, "user789", [
+        { role: "user", content: "Context message", order: 1 },
+        { role: "assistant", content: "Context response", order: 2 },
+      ]);
+
+      const inputMessages: ModelMessage[] = [
+        { role: "user", content: "Input message 1" },
+        { role: "user", content: "Input message 2" },
+      ];
+
+      const result = await fetchContextWithPrompt(ctx, components.agent, {
+        ...baseArgs,
+        userId: "user789",
+        threadId,
+        prompt: "Final prompt",
+        messages: inputMessages,
+        promptMessageId: undefined,
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(5);
+      expect(result.messages[0].content).toBe("Context message");
+      expect(result.messages[1].content).toBe("Context response");
+      expect(result.messages[2].content).toBe("Input message 1");
+      expect(result.messages[3].content).toBe("Input message 2");
+      expect(result.messages[4]).toEqual({
+        role: "user",
+        content: "Final prompt",
+      });
+    });
+
+    it("should respect recentMessages limit", async () => {
+      const threadId = await createTestThread("user999");
+
+      // Create 5 messages but only fetch the most recent 2
+      await createTestMessages(threadId, "user999", [
+        { role: "user", content: "Message 1", order: 1 },
+        { role: "assistant", content: "Response 1", order: 2 },
+        { role: "user", content: "Message 2", order: 3 },
+        { role: "assistant", content: "Response 2", order: 4 },
+        { role: "user", content: "Message 3", order: 5 },
+      ]);
+
+      const result = await fetchContextWithPrompt(ctx, components.agent, {
+        ...baseArgs,
+        userId: "user999",
+        threadId,
+        prompt: "New prompt",
+        messages: undefined,
+        promptMessageId: undefined,
+        contextOptions: { recentMessages: 2 }, // Only fetch 2 most recent
+      });
+
+      expect(result.messages).toHaveLength(3); // 2 context + 1 prompt
+      expect(result.messages[0].content).toBe("Response 2"); // 4th message
+      expect(result.messages[1].content).toBe("Message 3"); // 5th message
+      expect(result.messages[2]).toEqual({
+        role: "user",
+        content: "New prompt",
+      });
+    });
+
+    it("should handle empty thread gracefully", async () => {
+      const threadId = await createTestThread("user000");
+
+      // Don't create any messages
+
+      const result = await fetchContextWithPrompt(ctx, components.agent, {
+        ...baseArgs,
+        userId: "user000",
+        threadId,
+        prompt: "Only prompt",
+        messages: undefined,
+        promptMessageId: undefined,
+        contextOptions: { recentMessages: 10 },
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: "Only prompt",
+      });
+    });
+  });
+});

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -1,7 +1,6 @@
 import {
   embedMany as embedMany_,
   type EmbeddingModel,
-  type LanguageModel,
   type ModelMessage,
 } from "ai";
 import { assert } from "convex-helpers";
@@ -14,6 +13,8 @@ import {
   DEFAULT_MESSAGE_RANGE,
   DEFAULT_RECENT_MESSAGES,
   extractText,
+  getModelName,
+  getProviderName,
   isTool,
   sorted,
 } from "../shared.js";
@@ -186,27 +187,6 @@ export function filterOutOrphanedToolMessages(docs: MessageDoc[]) {
     }
   }
   return result;
-}
-
-export function getModelName(
-  embeddingModel: string | EmbeddingModel<string> | LanguageModel,
-): string {
-  if (typeof embeddingModel === "string") {
-    if (embeddingModel.includes("/")) {
-      return embeddingModel.split("/").slice(1).join("/");
-    }
-    return embeddingModel;
-  }
-  return embeddingModel.modelId;
-}
-
-export function getProviderName(
-  embeddingModel: string | EmbeddingModel<string> | LanguageModel,
-): string {
-  if (typeof embeddingModel === "string") {
-    return embeddingModel.split("/").at(0)!;
-  }
-  return embeddingModel.provider;
 }
 
 export async function embedMessages(

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -221,9 +221,11 @@ export async function embedMessages(
     userId,
     threadId,
     ...options
-  }: { userId: string | undefined; threadId: string | undefined } & Config & {
-      agentName?: string;
-    },
+  }: {
+    userId: string | undefined;
+    threadId: string | undefined;
+    agentName?: string;
+  } & Pick<Config, "usageHandler" | "textEmbeddingModel" | "callSettings">,
   messages: (ModelMessage | Message)[],
 ): Promise<
   | {

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -4,7 +4,7 @@ import {
   type ModelMessage,
 } from "ai";
 import { assert } from "convex-helpers";
-import type { MessageDoc } from "../component/schema.js";
+import type { MessageDoc } from "../validators.js";
 import {
   validateVectorDimension,
   type VectorDimension,

--- a/src/client/search.ts
+++ b/src/client/search.ts
@@ -28,7 +28,7 @@ import type {
   RunQueryCtx,
 } from "./types.js";
 import { inlineMessagesFiles } from "./files.js";
-import { deserializeMessage } from "./index.js";
+import { deserializeMessage } from "../mapping.js";
 
 const DEFAULT_VECTOR_SCORE_THRESHOLD = 0.0;
 // 10k characters should be more than enough for most cases, and stays under

--- a/src/client/start.ts
+++ b/src/client/start.ts
@@ -152,7 +152,7 @@ export async function start<
       : {
           promptMessageId: args.promptMessageId,
           pendingMessage: undefined,
-          savedMessages: [],
+          savedMessages: [] as MessageDoc[],
         };
 
   const order = pendingMessage?.order ?? context.order;

--- a/src/client/start.ts
+++ b/src/client/start.ts
@@ -1,0 +1,492 @@
+import {
+  stepCountIs,
+  type CallSettings,
+  type GenerateObjectResult,
+  type IdGenerator,
+  type LanguageModel,
+  type ModelMessage,
+  type StepResult,
+  type StopCondition,
+  type ToolSet,
+} from "ai";
+import {
+  deserializeMessage,
+  serializeNewMessagesInStep,
+  serializeObjectResult,
+} from "../mapping.js";
+import { embedMany, embedMessages, fetchContextMessages } from "./search.js";
+import type {
+  ActionCtx,
+  AgentComponent,
+  Config,
+  Options,
+  RunActionCtx,
+  UserActionCtx,
+} from "./types.js";
+import { saveMessages } from "./messages.js";
+import type { Message, MessageDoc } from "../validators.js";
+import {
+  extractText,
+  getModelName,
+  getProviderName,
+  type ModelOrMetadata,
+} from "../shared.js";
+import { wrapTools, type ToolCtx } from "./createTool.js";
+import type { Agent } from "./index.js";
+import { assert } from "convex-helpers";
+import { inlineMessagesFiles } from "./files.js";
+
+export async function start<
+  T,
+  Tools extends ToolSet = ToolSet,
+  CustomCtx extends object = object,
+>(
+  ctx: ActionCtx & CustomCtx,
+  component: AgentComponent,
+  /**
+   * These are the arguments you'll pass to the LLM call such as
+   * `generateText` or `streamText`. This function will look up the context
+   * and provide functions to save the steps, abort the generation, and more.
+   * The type of the arguments returned infers from the type of the arguments
+   * you pass here.
+   */
+  {
+    messages: argsMessages,
+    prompt: argsPrompt,
+    promptMessageId: argsPromptMessageId,
+    ...args
+  }: T & {
+    /**
+     * If provided, this message will be used as the "prompt" for the LLM call,
+     * instead of the prompt or messages.
+     * This is useful if you want to first save a user message, then use it as
+     * the prompt for the LLM call in another call.
+     */
+    promptMessageId?: string;
+    /**
+     * The model to use for the LLM calls. This will override the model specified
+     * in the Agent constructor.
+     */
+    model?: LanguageModel;
+    /**
+     * The tools to use for the tool calls. This will override tools specified
+     * in the Agent constructor or createThread / continueThread.
+     */
+    tools?: Tools;
+    /**
+     * The single prompt message to use for the LLM call. This will be the
+     * last message in the context. If it's a string, it will be a user role.
+     */
+    prompt?: string | (ModelMessage | Message)[];
+    /**
+     * If provided alongside prompt, the ordering will be:
+     * 1. system prompt
+     * 2. search context
+     * 3. recent messages
+     * 4. these messages
+     * 5. prompt messages, including those already on the same `order` as
+     *   the promptMessageId message, if provided.
+     */
+    messages?: (ModelMessage | Message)[];
+    /**
+     * The abort signal to be passed to the LLM call. If triggered, it will
+     * mark the pending message as failed. If the generation is asynchronously
+     * aborted, it will trigger this signal when detected.
+     */
+    abortSignal?: AbortSignal;
+    stopWhen?: StopCondition<Tools> | Array<StopCondition<Tools>>;
+    _internal?: { generateId?: IdGenerator };
+  },
+  {
+    threadId,
+    ...opts
+  }: Options &
+    Config & {
+      userId?: string | null;
+      threadId?: string;
+      languageModel: LanguageModel;
+      agentName: string;
+      agentForToolCtx?: Agent;
+    },
+): Promise<{
+  args: T & {
+    system?: string;
+    model: LanguageModel;
+    messages: ModelMessage[];
+    tools?: Tools;
+  } & CallSettings;
+  order: number;
+  stepOrder: number;
+  userId: string | undefined;
+  promptMessageId: string | undefined;
+  updateModel: (model: ModelOrMetadata | undefined) => void;
+  save: <TOOLS extends ToolSet>(
+    toSave:
+      | { step: StepResult<TOOLS> }
+      | { object: GenerateObjectResult<unknown> },
+    createPendingMessage?: boolean,
+  ) => Promise<void>;
+  fail: (reason: string) => Promise<void>;
+  getSavedMessages: () => MessageDoc[];
+}> {
+  const model = args.model ?? opts.languageModel;
+  const context = await _saveMessagesAndFetchContext(ctx, component, {
+    userId: opts.userId,
+    threadId,
+    messages: argsMessages,
+    prompt: argsPrompt,
+    promptMessageId: argsPromptMessageId,
+    ...opts,
+  });
+
+  const { messages, promptMessageId, order, stepOrder, userId } = context;
+
+  let pendingMessageId = context.pendingMessageId;
+  const savedMessages = context.savedMessages ?? [];
+  const saveOutput = opts.storageOptions?.saveMessages !== "none";
+  let activeModel: ModelOrMetadata = model;
+  const fail = async (reason: string) => {
+    if (threadId && promptMessageId) {
+      console.error(
+        `Message failed in thread ${threadId} with promptMessageId ${promptMessageId}: ${reason}`,
+      );
+    }
+    if (pendingMessageId) {
+      await ctx.runMutation(component.messages.finalizeMessage, {
+        messageId: pendingMessageId,
+        result: { status: "failed", error: reason },
+      });
+    }
+  };
+  if (args.abortSignal) {
+    const abortSignal = args.abortSignal;
+    abortSignal.addEventListener(
+      "abort",
+      async () => {
+        await fail(abortSignal.reason ?? "abortSignal");
+      },
+      { once: true },
+    );
+  }
+  const toolCtx = {
+    ...(ctx as UserActionCtx & CustomCtx),
+    userId,
+    threadId,
+    promptMessageId,
+    agent: opts.agentForToolCtx,
+  } satisfies ToolCtx;
+  const tools = wrapTools(toolCtx, args.tools) as Tools;
+  const aiArgs = {
+    ...opts.callSettings,
+    providerOptions: opts.providerOptions,
+    ...args,
+    model,
+    messages,
+    stopWhen:
+      args.stopWhen ?? (opts.maxSteps ? stepCountIs(opts.maxSteps) : undefined),
+    tools,
+  } as T & {
+    model: LanguageModel;
+    messages: ModelMessage[];
+    tools?: Tools;
+    _internal?: { generateId?: IdGenerator };
+  } & CallSettings;
+  if (pendingMessageId) {
+    if (!aiArgs._internal?.generateId) {
+      aiArgs._internal = {
+        ...aiArgs._internal,
+        generateId: pendingMessageId
+          ? () => pendingMessageId ?? crypto.randomUUID()
+          : undefined,
+      };
+    }
+  }
+  return {
+    args: aiArgs,
+    order: order ?? 0,
+    stepOrder: stepOrder ?? 0,
+    userId,
+    promptMessageId,
+    getSavedMessages: () => savedMessages,
+    updateModel: (model: ModelOrMetadata | undefined) => {
+      if (model) {
+        activeModel = model;
+      }
+    },
+    fail,
+    save: async <TOOLS extends ToolSet>(
+      toSave:
+        | { step: StepResult<TOOLS> }
+        | { object: GenerateObjectResult<unknown> },
+      createPendingMessage?: boolean,
+    ) => {
+      if (threadId && promptMessageId && saveOutput) {
+        const serialized =
+          "object" in toSave
+            ? await serializeObjectResult(
+                ctx,
+                component,
+                toSave.object,
+                activeModel,
+              )
+            : await serializeNewMessagesInStep(
+                ctx,
+                component,
+                toSave.step,
+                activeModel,
+              );
+        const embeddings = await embedMessages(
+          ctx,
+          { threadId, ...opts, userId },
+          serialized.messages.map((m) => m.message),
+        );
+        if (createPendingMessage) {
+          serialized.messages.push({
+            message: { role: "assistant", content: [] },
+            status: "pending",
+          });
+          embeddings?.vectors.push(null);
+        }
+        const saved = await ctx.runMutation(component.messages.addMessages, {
+          userId,
+          threadId,
+          agentName: opts.agentName,
+          promptMessageId,
+          pendingMessageId,
+          messages: serialized.messages,
+          embeddings,
+          failPendingSteps: false,
+        });
+        const lastMessage = saved.messages.at(-1)!;
+        if (createPendingMessage) {
+          if (lastMessage.status === "failed") {
+            pendingMessageId = undefined;
+            savedMessages.push(...saved.messages);
+            await fail(
+              lastMessage.error ??
+                "Aborting - the pending message was marked as failed",
+            );
+          } else {
+            pendingMessageId = lastMessage._id;
+            savedMessages.push(...saved.messages.slice(0, -1));
+          }
+        } else {
+          pendingMessageId = undefined;
+          savedMessages.push(...saved.messages);
+        }
+      }
+      const output = "object" in toSave ? toSave.object : toSave.step;
+      if (opts.rawRequestResponseHandler) {
+        await opts.rawRequestResponseHandler(ctx, {
+          userId,
+          threadId,
+          agentName: opts.agentName,
+          request: output.request,
+          response: output.response,
+        });
+      }
+      if (opts.usageHandler && output.usage) {
+        await opts.usageHandler(ctx, {
+          userId,
+          threadId,
+          agentName: opts.agentName,
+          model: getModelName(activeModel),
+          provider: getProviderName(activeModel),
+          usage: output.usage,
+          providerMetadata: output.providerMetadata,
+        });
+      }
+    },
+  };
+}
+
+async function _saveMessagesAndFetchContext(
+  ctx: RunActionCtx,
+  component: AgentComponent,
+  {
+    userId: argsUserId,
+    threadId,
+    contextOptions,
+    storageOptions,
+    textEmbeddingModel,
+    ...args
+  }: {
+    prompt: string | (ModelMessage | Message)[] | undefined;
+    messages: (ModelMessage | Message)[] | undefined;
+    promptMessageId: string | undefined;
+    userId: string | null | undefined;
+    threadId: string | undefined;
+  } & Options &
+    Config & { agentName?: string },
+): Promise<{
+  messages: ModelMessage[];
+  userId: string | undefined;
+  promptMessageId: string | undefined;
+  pendingMessageId: string | undefined;
+  order: number | undefined;
+  stepOrder: number | undefined;
+  savedMessages: MessageDoc[] | undefined;
+}> {
+  // If only a promptMessageId is provided, this will be empty.
+  const messages: (ModelMessage | Message)[] = args.messages ?? [];
+  const promptArray: ModelMessage[] = !args.prompt
+    ? []
+    : Array.isArray(args.prompt)
+      ? args.prompt.map((p) => deserializeMessage(p))
+      : [{ role: "user", content: args.prompt }];
+  const userId =
+    argsUserId ??
+    (threadId &&
+      (await ctx.runQuery(component.threads.getThread, { threadId }))
+        ?.userId) ??
+    undefined;
+  // If only a messageId is provided, this will add that message to the end.
+  const searchMsg =
+    promptArray.at(-1) ?? (args.promptMessageId ? undefined : messages.at(-1));
+  const searchText = searchMsg ? extractText(searchMsg) : undefined;
+
+  const contextMessages: MessageDoc[] = await fetchContextMessages(
+    ctx,
+    component,
+    {
+      userId,
+      threadId,
+      targetMessageId: args.promptMessageId,
+      searchText,
+      contextOptions: contextOptions ?? {},
+      getEmbedding: async (text) => {
+        assert(
+          textEmbeddingModel,
+          "A textEmbeddingModel is required to be set on the Agent that you're doing vector search with",
+        );
+        return {
+          embedding: (
+            await embedMany(ctx, {
+              ...args,
+              userId,
+              threadId,
+              values: [text],
+              textEmbeddingModel,
+            })
+          ).embeddings[0],
+          textEmbeddingModel,
+        };
+      },
+    },
+  );
+  // If it was a promptMessageId, pop it off context messages
+  // and add to the end of messages.
+  const promptMessageIndex = args.promptMessageId
+    ? contextMessages.findIndex((m) => m._id === args.promptMessageId)
+    : -1;
+  const promptMessage: MessageDoc | undefined =
+    promptMessageIndex !== -1
+      ? contextMessages.splice(promptMessageIndex, 1)[0]
+      : undefined;
+
+  let promptMessageId = promptMessage?._id;
+  let order = promptMessage?.order;
+  let stepOrder = promptMessage?.stepOrder;
+  let savedMessages = undefined;
+  let pendingMessageId = undefined;
+  if (threadId && storageOptions?.saveMessages !== "none") {
+    let toSave: (ModelMessage | Message)[] = [];
+    if (
+      messages.length + promptArray.length &&
+      // If it was a promptMessageId, we don't want to save it again.
+      (!args.promptMessageId || storageOptions?.saveMessages === "all")
+    ) {
+      const saveAll = storageOptions?.saveMessages === "all";
+      const coreMessages: (ModelMessage | Message)[] = [
+        ...messages,
+        ...promptArray,
+      ];
+      toSave = saveAll ? coreMessages : coreMessages.slice(-1);
+    }
+    const saved = await saveMessages(ctx, component, {
+      threadId,
+      userId,
+      messages: [...toSave, { role: "assistant", content: [] }],
+      metadata: [
+        ...Array.from({ length: toSave.length }, () => ({})),
+        { status: "pending" },
+      ],
+      failPendingSteps: !!args.promptMessageId,
+      embeddings: await embedMessages(
+        ctx,
+        { threadId, ...args, userId },
+        messages,
+      ),
+    });
+    promptMessageId = toSave.length
+      ? saved.messages.at(-2)!._id
+      : args.promptMessageId;
+    pendingMessageId = saved.messages.at(-1)!._id;
+    order = saved.messages.at(-1)!.order;
+    stepOrder = saved.messages.at(-1)!.stepOrder;
+    // Don't return the pending message
+    savedMessages = saved.messages.slice(0, -1);
+  }
+
+  if (promptMessage?.message) {
+    if (!args.prompt) {
+      // If they override the prompt, we skip the existing prompt message.
+      messages.push(promptMessage.message);
+    }
+    // Lazily generate embeddings for the prompt message, if it doesn't have
+    // embeddings yet. This can happen if the message was saved in a mutation
+    // where the LLM is not available.
+    if (!promptMessage.embeddingId && textEmbeddingModel) {
+      const embeddings = await embedMessages(
+        ctx,
+        { threadId, ...args, textEmbeddingModel, userId },
+        [promptMessage.message],
+      );
+      if (embeddings && embeddings.vectors[0]) {
+        await ctx.runMutation(component.vector.index.insertBatch, {
+          vectorDimension: embeddings.dimension,
+          vectors: [
+            {
+              messageId: promptMessage._id,
+              model: embeddings.model,
+              table: "messages",
+              userId,
+              threadId,
+              vector: embeddings.vectors[0]!,
+            },
+          ],
+        });
+      }
+    }
+  }
+
+  const prePrompt = contextMessages.map((m) => m.message).filter((m) => !!m);
+  let existingResponses: (ModelMessage | Message)[] = [];
+  if (promptMessageIndex !== -1) {
+    // pull any messages that already responded to the prompt off
+    // and add them after the prompt
+    existingResponses = prePrompt.splice(promptMessageIndex);
+  }
+
+  let processedMessages: ModelMessage[] = [
+    ...prePrompt,
+    ...messages,
+    ...promptArray,
+    ...existingResponses,
+  ].map((m) => deserializeMessage(m));
+
+  // Process messages to inline localhost files (if not, file urls pointing to localhost will be sent to LLM providers)
+  if (process.env.CONVEX_CLOUD_URL?.startsWith("http://127.0.0.1")) {
+    processedMessages = await inlineMessagesFiles(processedMessages);
+  }
+
+  return {
+    messages: processedMessages,
+    userId,
+    promptMessageId,
+    pendingMessageId,
+    savedMessages,
+    order,
+    stepOrder,
+  };
+}

--- a/src/client/streaming.ts
+++ b/src/client/streaming.ts
@@ -10,7 +10,6 @@ import {
 } from "../validators.js";
 import type {
   AgentComponent,
-  RunActionCtx,
   RunMutationCtx,
   RunQueryCtx,
   SyncStreamsReturnValue,
@@ -175,7 +174,7 @@ export class DeltaStreamer<T> {
 
   constructor(
     public readonly component: AgentComponent,
-    public readonly ctx: RunActionCtx,
+    public readonly ctx: RunMutationCtx,
     config: {
       stream: true | StreamingOptions;
       onAsyncAbort: (reason: string) => Promise<void>;

--- a/src/client/streaming.ts
+++ b/src/client/streaming.ts
@@ -298,6 +298,7 @@ export class DeltaStreamer<T> {
       return;
     }
     await this.#ongoingWrite;
+    await this.#sendDelta();
     await this.ctx.runMutation(this.component.streams.finish, {
       streamId: this.streamId,
     });

--- a/src/client/streaming.ts
+++ b/src/client/streaming.ts
@@ -15,7 +15,7 @@ import type {
   SyncStreamsReturnValue,
 } from "./types.js";
 import { v } from "convex/values";
-import { vMessageDoc } from "../component/schema.js";
+import { vMessageDoc } from "../validators.js";
 
 export const vStreamMessagesReturnValue = v.object({
   ...vPaginationResult(vMessageDoc).fields,

--- a/src/client/textStreamParts.ts
+++ b/src/client/textStreamParts.ts
@@ -23,21 +23,12 @@ export function serializeTextStreamingPartsV5(
     ) {
       last.text += part.text;
     } else {
-      if (
-        part.type === "start-step" ||
-        part.type === "finish-step" ||
-        part.type === "start" ||
-        part.type === "finish"
-      ) {
-        continue;
-      }
       if (part.type === "file") {
         compressed.push({
           type: "file",
           file: {
-            mediaType: part.file.mediaType,
-            base64: part.file.base64,
-            uint8Array: new Uint8Array([]),
+            ...part.file,
+            uint8Array: undefined as unknown as Uint8Array,
           },
         });
       }

--- a/src/client/threads.ts
+++ b/src/client/threads.ts
@@ -1,5 +1,5 @@
 import type { WithoutSystemFields } from "convex/server";
-import type { ThreadDoc } from "../component/schema.js";
+import type { ThreadDoc } from "../validators.js";
 import type { AgentComponent, RunMutationCtx, RunQueryCtx } from "./types.js";
 
 /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@ai-sdk/provider-utils";
 import type { JSONValue } from "@ai-sdk/provider";
 import type {
+  EmbeddingModel,
   GenerateObjectResult,
   generateText,
   GenerateTextResult,
@@ -45,6 +46,79 @@ import type {
 import type { StreamingOptions } from "./streaming.js";
 import type * as z3 from "zod/v3";
 import type * as z4 from "zod/v4";
+
+export type Config = {
+  /**
+   * The LLM model to use for generating / streaming text and objects.
+   * e.g.
+   * import { openai } from "@ai-sdk/openai"
+   * const myAgent = new Agent(components.agent, {
+   *   languageModel: openai.chat("gpt-4o-mini"),
+   */
+  languageModel?: LanguageModel;
+  /**
+   * The model to use for text embeddings. Optional.
+   * If specified, it will use this for generating vector embeddings
+   * of chats, and can opt-in to doing vector search for automatic context
+   * on generateText, etc.
+   * e.g.
+   * import { openai } from "@ai-sdk/openai"
+   * const myAgent = new Agent(components.agent, {
+   *   ...
+   *   textEmbeddingModel: openai.embedding("text-embedding-3-small")
+   */
+  textEmbeddingModel?: EmbeddingModel<string>;
+  /**
+   * Options to determine what messages are included as context in message
+   * generation. To disable any messages automatically being added, pass:
+   * { recentMessages: 0 }
+   */
+  contextOptions?: ContextOptions;
+  /**
+   * Determines whether messages are automatically stored when passed as
+   * arguments or generated.
+   */
+  storageOptions?: StorageOptions;
+  /**
+   * The usage handler to use for this agent.
+   */
+  usageHandler?: UsageHandler;
+  /**
+   * Called for each LLM request/response, so you can do things like
+   * log the raw request body or response headers to a table, or logs.
+   */
+  rawRequestResponseHandler?: RawRequestResponseHandler;
+  /**
+   * @deprecated Reach out if you use this. Otherwise will be removed soon.
+   * Default provider options to pass for the LLM calls.
+   * This can be overridden at each generate/stream callsite on a per-field
+   * basis. To clear a default setting, you'll need to pass `undefined`.
+   */
+  providerOptions?: ProviderOptions;
+  /**
+   * The default settings to use for the LLM calls.
+   * This can be overridden at each generate/stream callsite on a per-field
+   * basis. To clear a default setting, you'll need to pass `undefined`.
+   */
+  callSettings?: CallSettings;
+  /**
+   * The maximum number of steps to allow for a single generation.
+   *
+   * For example, if an agent wants to call a tool, that call and tool response
+   * will be one step. Generating a response based on the tool call & response
+   * will be a second step.
+   * If it runs out of steps, it will return the last step result, which may
+   * not be an assistant message.
+
+   * This becomes the default value when `stopWhen` is not specified in the
+   * Agent or generation callsite.
+   * AI SDK v5 removed the `maxSteps` argument, but this is kept here for
+   * convenience and backwards compatibility.
+   * Defaults to 1.
+   */
+  maxSteps?: number;
+};
+
 
 /**
  * Options to configure what messages are fetched as context,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -37,11 +37,12 @@ import type {
 } from "convex/server";
 import type { GenericId } from "convex/values";
 import type { Mounts } from "../component/_generated/api.js";
-import type { MessageDoc, ThreadDoc } from "../component/schema.js";
 import type {
+  MessageDoc,
   ProviderMetadata,
   StreamDelta,
   StreamMessage,
+  ThreadDoc,
 } from "../validators.js";
 import type { StreamingOptions } from "./streaming.js";
 import type * as z3 from "zod/v3";

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -689,6 +689,12 @@ export type Mounts = {
       },
       null
     >;
+    getMessageSearchFields: FunctionReference<
+      "query",
+      "public",
+      { messageId: string },
+      { embedding?: Array<number>; embeddingModel?: string; text?: string }
+    >;
     getMessagesByIds: FunctionReference<
       "query",
       "public",
@@ -1217,15 +1223,17 @@ export type Mounts = {
       "action",
       "public",
       {
-        beforeMessageId?: string;
         embedding?: Array<number>;
         embeddingModel?: string;
         limit: number;
         messageRange?: { after: number; before: number };
         searchAllMessagesForUserId?: string;
+        targetMessageId?: string;
         text?: string;
+        textSearch?: boolean;
         threadId?: string;
         vectorScoreThreshold?: number;
+        vectorSearch?: boolean;
       },
       Array<{
         _creationTime: number;
@@ -1464,10 +1472,10 @@ export type Mounts = {
       "query",
       "public",
       {
-        beforeMessageId?: string;
         limit: number;
         searchAllMessagesForUserId?: string;
-        text: string;
+        targetMessageId?: string;
+        text?: string;
         threadId?: string;
       },
       Array<{

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -13,10 +13,12 @@ import {
   sorted,
 } from "../shared.js";
 import {
+  vMessageDoc,
   vMessageEmbeddingsWithDimension,
   vMessageStatus,
   vMessageWithMetadataInternal,
   vPaginationResult,
+  type MessageDoc,
 } from "../validators.js";
 import { api, internal } from "./_generated/api.js";
 import type { Doc, Id } from "./_generated/dataModel.js";
@@ -28,8 +30,7 @@ import {
   query,
   type QueryCtx,
 } from "./_generated/server.js";
-import type { MessageDoc } from "./schema.js";
-import { schema, v, vMessageDoc } from "./schema.js";
+import { schema, v } from "./schema.js";
 import { insertVector, searchVectors } from "./vector/index.js";
 import {
   validateVectorDimension,

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -32,7 +32,7 @@ import type { MessageDoc } from "./schema.js";
 import { schema, v, vMessageDoc } from "./schema.js";
 import { insertVector, searchVectors } from "./vector/index.js";
 import {
-  type VectorDimension,
+  validateVectorDimension,
   VectorDimensions,
   type VectorTableId,
   vVectorId,
@@ -532,7 +532,8 @@ export const searchMessages = action({
       });
     }
     if (args.embedding) {
-      const dimension = args.embedding.length as VectorDimension;
+      const dimension = args.embedding.length;
+      validateVectorDimension(dimension);
       if (!VectorDimensions.includes(dimension)) {
         throw new Error(`Unsupported embedding dimension: ${dimension}`);
       }

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -1,5 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
-import { type Infer, v } from "convex/values";
+import { v } from "convex/values";
 import {
   vThreadStatus,
   vMessage,
@@ -14,7 +14,6 @@ import {
 } from "../validators.js";
 import { typedV } from "convex-helpers/validators";
 import vectorTables, { vVectorId } from "./vector/tables.js";
-import { omit } from "convex-helpers";
 
 export const schema = defineSchema({
   threads: defineTable({
@@ -163,32 +162,5 @@ export const schema = defineSchema({
 
 export const vv = typedV(schema);
 export { vv as v };
-
-// Public
-export const vThreadDoc = v.object({
-  _id: v.string(),
-  _creationTime: v.number(),
-  userId: v.optional(v.string()), // Unset for anonymous
-  title: v.optional(v.string()),
-  summary: v.optional(v.string()),
-  status: vThreadStatus,
-});
-export type ThreadDoc = Infer<typeof vThreadDoc>;
-
-export const vMessageDoc = v.object({
-  _id: v.string(),
-  _creationTime: v.number(),
-  ...omit(schema.tables.messages.validator.fields, [
-    "parentMessageId",
-    "stepId",
-    "files",
-  ]),
-  // Overwrite all the types that have a v.id validator
-  // Outside of the component, they are strings
-  threadId: v.string(),
-  embeddingId: v.optional(v.string()),
-  fileIds: v.optional(v.array(v.string())),
-});
-export type MessageDoc = Infer<typeof vMessageDoc>;
 
 export default schema;

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -46,6 +46,11 @@ import {
   type ReasoningPart,
 } from "@ai-sdk/provider-utils";
 import { parse, validate } from "convex-helpers/validators";
+import {
+  getModelName,
+  getProviderName,
+  type ModelOrMetadata,
+} from "./shared.js";
 export type AIMessageWithoutId = Omit<AIMessage, "id">;
 
 export type SerializeUrlsAndUint8Arrays<T> = T extends URL
@@ -159,13 +164,13 @@ export async function serializeNewMessagesInStep<TOOLS extends ToolSet>(
   ctx: ActionCtx,
   component: AgentComponent,
   step: StepResult<TOOLS>,
-  metadata: { model: string; provider: string },
+  model: ModelOrMetadata | undefined,
 ): Promise<{ messages: MessageWithMetadata[] }> {
   // If there are tool results, there's another message with the tool results
   // ref: https://github.com/vercel/ai/blob/main/packages/ai/core/generate-text/to-response-messages.ts
   const assistantFields = {
-    model: metadata.model,
-    provider: metadata.provider,
+    model: model ? getModelName(model) : undefined,
+    provider: model ? getProviderName(model) : undefined,
     providerMetadata: step.providerMetadata,
     reasoning: step.reasoningText,
     reasoningDetails: step.reasoning,
@@ -198,7 +203,7 @@ export async function serializeObjectResult(
   ctx: ActionCtx,
   component: AgentComponent,
   result: GenerateObjectResult<unknown>,
-  metadata: { model: string; provider: string },
+  model: ModelOrMetadata | undefined,
 ): Promise<{ messages: MessageWithMetadata[] }> {
   const text = JSON.stringify(result.object);
 
@@ -210,8 +215,8 @@ export async function serializeObjectResult(
     messages: [
       {
         message,
-        model: metadata.model,
-        provider: metadata.provider,
+        model: model ? getModelName(model) : undefined,
+        provider: model ? getProviderName(model) : undefined,
         providerMetadata: result.providerMetadata,
         finishReason: result.finishReason,
         text,

--- a/src/react/deltas.ts
+++ b/src/react/deltas.ts
@@ -583,6 +583,7 @@ export function createStreamingMessage(
     _id: `${streamId}-${index}`,
     _creationTime: Date.now(),
     status: statusFromStreamStatus(message.status),
+    stepOrder: message.stepOrder + index,
     threadId,
     tool: false,
   };

--- a/src/react/fromUIMessages.test.ts
+++ b/src/react/fromUIMessages.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect } from "vitest";
+import { toUIMessages } from "./toUIMessages.js";
+import { fromUIMessages } from "./fromUIMessages.js";
+import type { MessageDoc } from "../client/index.js";
+import type { UIMessage } from "./toUIMessages.js";
+
+// Helper to create a base message doc
+function baseMessageDoc<T = unknown>(overrides: Partial<MessageDoc & { streaming?: boolean; metadata?: T }> = {}): MessageDoc & { streaming?: boolean; metadata?: T } {
+  return {
+    _id: "msg1",
+    _creationTime: Date.now(),
+    order: 0,
+    stepOrder: 0,
+    status: "success",
+    threadId: "thread1",
+    tool: false,
+    ...overrides,
+  };
+}
+
+describe("fromUIMessages round-trip tests", () => {
+  it("preserves essential data for simple user message", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "user",
+          content: "Hello world!",
+        },
+        text: "Hello world!",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].role).toBe("user");
+    expect(uiMessages[0].text).toBe("Hello world!");
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].text).toBe("Hello world!");
+    expect(backToMessageDocs[0].threadId).toBe("thread1");
+
+    // Content gets normalized to array format
+    expect(Array.isArray(backToMessageDocs[0].message?.content)).toBe(true);
+    if (Array.isArray(backToMessageDocs[0].message?.content)) {
+      expect(backToMessageDocs[0].message.content[0]).toMatchObject({
+        type: "text",
+        text: "Hello world!",
+      });
+    }
+  });
+
+  it("preserves essential data for assistant message", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "assistant",
+          content: "Hi there! How can I help?",
+        },
+        text: "Hi there! How can I help?",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].role).toBe("assistant");
+    expect(uiMessages[0].text).toBe("Hi there! How can I help?");
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].text).toBe("Hi there! How can I help?");
+  });
+
+  it("preserves system messages correctly", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "system",
+          content: "You are a helpful assistant.",
+        },
+        text: "You are a helpful assistant.",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].role).toBe("system");
+    expect(uiMessages[0].text).toBe("You are a helpful assistant.");
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].text).toBe("You are a helpful assistant.");
+    expect(backToMessageDocs[0].message?.role).toBe("system");
+
+    // System content stays as string
+    expect(backToMessageDocs[0].message?.content).toBe(
+      "You are a helpful assistant.",
+    );
+  });
+
+  it("preserves reasoning in assistant messages", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "Let me think about this...",
+            },
+            {
+              type: "text",
+              text: "Here's my response.",
+            },
+          ],
+        },
+        text: "Here's my response.",
+        reasoning: "Let me think about this...",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].text).toBe("Here's my response.");
+
+    // Check that reasoning parts are preserved in UI message
+    const reasoningParts = uiMessages[0].parts.filter(
+      (part) => part.type === "reasoning",
+    );
+    expect(reasoningParts).toHaveLength(1);
+    expect(reasoningParts[0]).toMatchObject({
+      type: "reasoning",
+      text: "Let me think about this...",
+    });
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].text).toBe("Here's my response.");
+    expect(backToMessageDocs[0].reasoning).toBe("Let me think about this...");
+  });
+
+  it("handles tool calls and groups them correctly", () => {
+    // Tool calls get grouped into single UI message but expanded back to multiple message docs
+    const originalMessages = [
+      baseMessageDoc({
+        _id: "msg1",
+        order: 1,
+        stepOrder: 1,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "calculator",
+              toolCallId: "call1",
+              args: { operation: "add", a: 2, b: 3 },
+            },
+          ],
+        },
+        tool: true,
+      }),
+      baseMessageDoc({
+        _id: "msg2",
+        order: 1,
+        stepOrder: 2,
+        message: {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call1",
+              toolName: "calculator",
+              output: {
+                type: "json",
+                value: { result: 5 },
+              },
+            },
+          ],
+        },
+        tool: true,
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    // Should be grouped into single UI message
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].role).toBe("assistant");
+
+    // Check tool parts exist
+    const toolParts = uiMessages[0].parts.filter(
+      (part) => part.type === "tool-calculator",
+    );
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]).toMatchObject({
+      type: "tool-calculator",
+      toolCallId: "call1",
+      state: "output-available",
+      input: { operation: "add", a: 2, b: 3 },
+      output: { result: 5 },
+    });
+
+    // Should expand back to multiple message docs
+    expect(backToMessageDocs.length).toBeGreaterThanOrEqual(1);
+
+    // Check that tool information is preserved
+    const toolMessages = backToMessageDocs.filter((msg) => msg.tool);
+    expect(toolMessages.length).toBeGreaterThan(0);
+    expect(toolMessages[0].stepOrder).toBe(1);
+    expect(toolMessages[1].stepOrder).toBe(2);
+  });
+
+  it("preserves file attachments in user messages", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "What's in this image?",
+            },
+            {
+              type: "file",
+              mimeType: "image/png",
+              data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            },
+          ],
+        },
+        text: "What's in this image?",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].role).toBe("user");
+    expect(uiMessages[0].text).toBe("What's in this image?");
+
+    // Check file parts exist in UI message
+    const fileParts = uiMessages[0].parts.filter(
+      (part) => part.type === "file",
+    );
+    expect(fileParts).toHaveLength(1);
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].text).toBe("What's in this image?");
+
+    // Check file content is preserved
+    const content = backToMessageDocs[0].message?.content;
+    expect(Array.isArray(content)).toBe(true);
+    if (Array.isArray(content)) {
+      const fileContent = content.find((c) => c.type === "file");
+      expect(fileContent).toBeDefined();
+      expect(fileContent).toMatchObject({
+        type: "file",
+        mimeType: "image/png",
+      });
+    }
+  });
+
+  it("preserves sources correctly", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I found some relevant sources.",
+            },
+          ],
+        },
+        text: "I found some relevant sources.",
+        sources: [
+          {
+            type: "source",
+            sourceType: "url",
+            id: "source1",
+            url: "https://example.com",
+            title: "Example Source",
+          },
+          {
+            type: "source",
+            sourceType: "document",
+            id: "source2",
+            mediaType: "application/pdf",
+            title: "Document Source",
+          },
+        ],
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+
+    // Check source parts exist in UI message
+    const sourceParts = uiMessages[0].parts.filter(
+      (part) => part.type === "source-url" || part.type === "source-document",
+    );
+    expect(sourceParts).toHaveLength(2);
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].sources).toHaveLength(2);
+    expect(backToMessageDocs[0].sources![0]).toMatchObject({
+      type: "source",
+      sourceType: "url",
+      id: "source1",
+      url: "https://example.com",
+      title: "Example Source",
+    });
+  });
+
+  it("preserves metadata when provided", () => {
+    const testMetadata = {
+      customField: "customValue",
+      timestamp: Date.now(),
+    };
+
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "user",
+          content: "Test message",
+        },
+        text: "Test message",
+        metadata: testMetadata,
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].metadata).toEqual(testMetadata);
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].metadata).toEqual(testMetadata);
+  });
+
+  it("handles streaming status correctly", () => {
+    const originalMessages = [
+      baseMessageDoc({
+        message: {
+          role: "assistant",
+          content: "Streaming response...",
+        },
+        text: "Streaming response...",
+        streaming: true,
+        status: "pending",
+      }),
+    ];
+
+    const uiMessages = toUIMessages(originalMessages);
+    const backToMessageDocs = fromUIMessages("thread1", uiMessages);
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].status).toBe("streaming");
+
+    expect(backToMessageDocs).toHaveLength(1);
+    expect(backToMessageDocs[0].streaming).toBe(true);
+    expect(backToMessageDocs[0].status).toBe("pending");
+  });
+});
+
+describe("fromUIMessages functionality tests", () => {
+  it("handles empty messages array", () => {
+    const uiMessages: UIMessage[] = [];
+    const result = fromUIMessages("thread1", uiMessages);
+    expect(result).toHaveLength(0);
+  });
+
+  it("correctly assigns thread ID", () => {
+    const uiMessage: UIMessage = {
+      id: "test-id",
+      _creationTime: Date.now(),
+      order: 0,
+      stepOrder: 0,
+      status: "success",
+      key: "test-key",
+      text: "Hello",
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }],
+    };
+
+    const result = fromUIMessages("custom-thread-id", [uiMessage]);
+    expect(result).toHaveLength(1);
+    expect(result[0].threadId).toBe("custom-thread-id");
+  });
+
+  it("correctly determines tool status", () => {
+    const toolUIMessage: UIMessage = {
+      id: "tool-id",
+      _creationTime: Date.now(),
+      order: 0,
+      stepOrder: 0,
+      status: "success",
+      key: "tool-key",
+      text: "",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-calculator",
+          toolCallId: "call1",
+          input: { a: 1, b: 2 },
+          state: "output-available",
+          output: { result: 3 },
+        },
+      ],
+    };
+
+    const result = fromUIMessages("thread1", [toolUIMessage]);
+    expect(result.length).toBeGreaterThan(0);
+
+    // Should have tool messages
+    const toolMessages = result.filter((msg) => msg.tool);
+    expect(toolMessages.length).toBeGreaterThan(0);
+  });
+});

--- a/src/react/fromUIMessages.ts
+++ b/src/react/fromUIMessages.ts
@@ -1,0 +1,74 @@
+import { convertToModelMessages } from "ai";
+import { extractReasoning, extractText, isTool } from "../shared.js";
+import type { MessageDoc, vSource } from "../validators.js";
+import type { UIMessage } from "./toUIMessages.js";
+import type { ProviderOptions } from "@ai-sdk/provider-utils";
+import { omit } from "convex-helpers";
+import { fromModelMessage } from "../mapping.js";
+import type { Infer } from "convex/values";
+
+export function fromUIMessages<METADATA = unknown>(
+  threadId: string,
+  messages: (UIMessage<METADATA> & {
+    userId?: string;
+    model?: string;
+    provider?: string;
+    providerOptions?: ProviderOptions;
+  })[],
+): (MessageDoc & { streaming: boolean; metadata?: METADATA })[] {
+  return messages.flatMap((uiMessage) => {
+    const stepOrder = uiMessage.stepOrder;
+    const commonFields = {
+      _id: uiMessage.id,
+      ...omit(uiMessage, ["parts", "role", "key", "text"]),
+      threadId,
+      status: uiMessage.status === "streaming" ? "pending" : "success",
+      streaming: uiMessage.status === "streaming",
+      // to override
+      tool: false,
+    } satisfies MessageDoc & { streaming: boolean; metadata?: METADATA };
+    const modelMessages = convertToModelMessages([uiMessage]);
+    return modelMessages.map((modelMessage, i) => {
+      const message = fromModelMessage(modelMessage);
+      const tool = isTool(message);
+      return {
+        ...commonFields,
+        stepOrder: stepOrder + i,
+        message,
+        tool,
+        text: extractText(message),
+        reasoning: extractReasoning(message),
+        finishReason: tool ? "tool-calls" : "stop",
+        sources: fromSourceParts(uiMessage.parts),
+      } satisfies MessageDoc & { streaming: boolean; metadata?: METADATA };
+    });
+  });
+}
+
+function fromSourceParts(parts: UIMessage["parts"]): Infer<typeof vSource>[] {
+  return parts
+    .map((part) => {
+      if (part.type === "source-url") {
+        return {
+          type: "source",
+          sourceType: "url",
+          url: part.url,
+          id: part.sourceId,
+          providerMetadata: part.providerMetadata,
+          title: part.title,
+        } satisfies Infer<typeof vSource>;
+      }
+      if (part.type === "source-document") {
+        return {
+          type: "source",
+          sourceType: "document",
+          mediaType: part.mediaType,
+          id: part.sourceId,
+          providerMetadata: part.providerMetadata,
+          title: part.title,
+        } satisfies Infer<typeof vSource>;
+      }
+      return undefined;
+    })
+    .filter((p) => p !== undefined);
+}

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -37,6 +37,16 @@ export function extractText(message: Message | ModelMessage) {
   return undefined;
 }
 
+export function extractReasoning(message: Message | ModelMessage) {
+  if (typeof message.content === "string") {
+    return undefined;
+  }
+  return message.content
+    .filter((c) => c.type === "reasoning")
+    .map((c) => c.text)
+    .join("");
+}
+
 export const DEFAULT_MESSAGE_RANGE = { before: 2, after: 1 };
 
 export function sorted<T extends { order: number; stepOrder: number }>(

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -49,3 +49,26 @@ export function sorted<T extends { order: number; stepOrder: number }>(
       : (a, b) => b.order - a.order || b.stepOrder - a.stepOrder,
   );
 }
+
+export type ModelOrMetadata =
+  | string
+  | ({ provider: string } & ({ modelId: string } | { model: string }));
+
+export function getModelName(embeddingModel: ModelOrMetadata): string {
+  if (typeof embeddingModel === "string") {
+    if (embeddingModel.includes("/")) {
+      return embeddingModel.split("/").slice(1).join("/");
+    }
+    return embeddingModel;
+  }
+  return "modelId" in embeddingModel
+    ? embeddingModel.modelId
+    : embeddingModel.model;
+}
+
+export function getProviderName(embeddingModel: ModelOrMetadata): string {
+  if (typeof embeddingModel === "string") {
+    return embeddingModel.split("/").at(0)!;
+  }
+  return embeddingModel.provider;
+}

--- a/src/validators.test.ts
+++ b/src/validators.test.ts
@@ -1,12 +1,23 @@
 import type { Infer } from "convex/values";
 import { expectTypeOf, test } from "vitest";
-import type { ContextOptions, StorageOptions } from "./client/types.js";
-import { vContextOptions, vStorageOptions } from "./validators.js";
+import type {
+  ContextOptions,
+  OpaqueIds,
+  StorageOptions,
+} from "./client/types.js";
+import { vContextOptions, vMessageDoc, vStorageOptions } from "./validators.js";
+import type { Doc } from "./component/_generated/dataModel.js";
 
 expectTypeOf<Infer<typeof vContextOptions>>().toExtend<ContextOptions>();
 expectTypeOf<ContextOptions>().toExtend<Infer<typeof vContextOptions>>();
 
 expectTypeOf<Infer<typeof vStorageOptions>>().toExtend<StorageOptions>();
 expectTypeOf<StorageOptions>().toExtend<Infer<typeof vStorageOptions>>();
+
+type MessageBasedOnSchema = OpaqueIds<
+  Omit<Doc<"messages">, "files" | "stepId" | "parentMessageId">
+>;
+expectTypeOf<Infer<typeof vMessageDoc>>().toEqualTypeOf<MessageBasedOnSchema>();
+expectTypeOf<MessageBasedOnSchema>().toEqualTypeOf<Infer<typeof vMessageDoc>>();
 
 test("noop", () => {});

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -460,3 +460,51 @@ export const vStreamDelta = v.object({
   parts: v.array(v.any()),
 });
 export type StreamDelta = Infer<typeof vStreamDelta>;
+
+export const vMessageDoc = v.object({
+  _id: v.string(),
+  _creationTime: v.number(),
+  userId: v.optional(v.string()), // useful for searching across threads
+  threadId: v.string(),
+  order: v.number(),
+  stepOrder: v.number(),
+  embeddingId: v.optional(v.string()),
+  fileIds: v.optional(v.array(v.string())),
+  error: v.optional(v.string()),
+  status: vMessageStatus,
+
+  // Context on how it was generated
+  agentName: v.optional(v.string()),
+  model: v.optional(v.string()),
+  provider: v.optional(v.string()),
+  providerOptions: v.optional(vProviderOptions), // Sent to model
+
+  // The result
+  message: v.optional(vMessage),
+  // Convenience fields extracted from the message
+  tool: v.boolean(), // either tool call (assistant) or tool result (tool)
+  text: v.optional(v.string()),
+
+  // Result metadata
+  usage: v.optional(vUsage),
+  providerMetadata: v.optional(vProviderMetadata), // Received from model
+  sources: v.optional(v.array(vSource)),
+  warnings: v.optional(v.array(vLanguageModelCallWarning)),
+  finishReason: v.optional(vFinishReason),
+  // Likely deprecated soon
+  reasoning: v.optional(v.string()),
+  reasoningDetails: v.optional(vReasoningDetails),
+  // Deprecated
+  id: v.optional(v.string()), // external id, e.g. from Vercel AI SDK
+});
+export type MessageDoc = Infer<typeof vMessageDoc>; // Public
+
+export const vThreadDoc = v.object({
+  _id: v.string(),
+  _creationTime: v.number(),
+  userId: v.optional(v.string()), // Unset for anonymous
+  title: v.optional(v.string()),
+  summary: v.optional(v.string()),
+  status: vThreadStatus,
+});
+export type ThreadDoc = Infer<typeof vThreadDoc>;


### PR DESCRIPTION
<!-- Describe your PR here. -->

Big changes to organizing generation - 
- organizes each generation into "start" with separate "saveInputMessages" and "fetchContextWithPrompt" along with splitting out all the embedding functionality to be separate from any individual Agent.

Also adds a `contextHandler` to control how messages get formatted into the final prompt

Fixes #136 
Fixes #123 
Fixes #94 
Fixes #34

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
