### PR TITLE
Fix tool calls not being persisted when tools error  

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -204,7 +204,7 @@ export async function serializeNewMessagesInStep<TOOLS extends ToolSet>(
   } satisfies Omit<MessageWithMetadata, "message" | "text" | "fileIds">;
   const toolFields = { sources: step.sources };
   const messages: MessageWithMetadata[] = await Promise.all(
-    (step.toolResults.length > 0
+    (step.finishReason === "tool-calls"
       ? step.response.messages.slice(-2)
       : step.content.length
         ? step.response.messages.slice(-1)


### PR DESCRIPTION
**Problem:**

When a tool execution throws an error, the assistant message containing the tool-call is not saved to the database. Only the tool-result message with the error is persisted, breaking the message chain.

**Root Cause:**

In `src/mapping.ts`, the `serializeNewMessagesInStep` function uses `step.toolResults.length` to determine which messages to save:

```ts
const messages: MessageWithMetadata[] = await Promise.all(
  (step.toolResults.length > 0
    ? step.response.messages.slice(-2)  // assistant + tool messages
    : step.content.length
      ? step.response.messages.slice(-1)  // Only last message
      : [{ role: "assistant" as const, content: [] }]
  ).map(...)
);
```

When a tool fails:
- `step.toolResults` is empty (no successful execution result)
- `step.response.messages` contains both the assistant message with tool-call AND the tool message with error
- The code incorrectly takes only the last message, missing the assistant message

What gets saved to the database (example):
```js
[
  {
    content: "list the datasets",
    role: "user",
  },
  // MISSING: assistant message with tool-call
  {
    content: [
      {
        output: {
          type: "error-text",
          value: "Your request couldn't be completed. Try again later.",
        },
        toolCallId: "call_somehash",
        toolName: "datasets_listDatasetsTool",
        type: "tool-result",
      },
    ],
    role: "tool",
  },
]
```

After all of this we see warnings like:
```
[WARN] 'Tool result without preceding tool call.. adding anyways'
```

**Proposed Fix:**

Check if there are tool messages in `step.response.messages` instead of relying solely on the length

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
