### PR TITLE
making sure the links in the readme point to the correct place

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,34 +21,39 @@ The Agent component is a core building block for building AI agents. It manages
 threads and messages, around which you Agents can cooperate in static or dynamic
 workflows.
 
-- [Agents](./docs/getting-started.mdx) provide an abstraction for using LLMs to
-  represent units of use-case-specific prompting with associated models,
-  prompts, [Tool Calls](./docs/tools.mdx), and behavior in relation to other
-  Agents, functions, APIs, and more.
-- [Threads](./docs/threads.mdx) persist [messages](./docs/messages.mdx) and can
-  be shared by multiple users and agents (including
-  [human agents](./docs/human-agents.mdx)).
+- [Agents](https://docs.convex.dev/agents/agent-usage) provide an abstraction
+  for using LLMs to represent units of use-case-specific prompting with
+  associated models, prompts,
+  [Tool Calls](https://docs.convex.dev/agents/tools), and behavior in relation
+  to other Agents, functions, APIs, and more.
+- [Threads](https://docs.convex.dev/agents/threads) persist
+  [messages](https://docs.convex.dev/agents/messages) and can be shared by
+  multiple users and agents (including
+  [human agents](https://docs.convex.dev/agents/human-agents)).
 - Streaming text and objects using deltas over websockets so all clients stay in
   sync efficiently, without http streaming. Enables streaming from async
   functions.
-- [Conversation context](./docs/context.mdx) is automatically included in each
-  LLM call, including built-in hybrid vector/text search for messages in the
-  thread and opt-in search for messages from other threads (for the same
-  specified user).
-- [RAG](./docs/rag.mdx) techniques are supported for prompt augmentation from
-  other sources, either up front in the prompt or as tool calls. Integrates with
-  the [RAG Component](https://www.convex.dev/components/rag), or DIY.
-- [Workflows](./docs/workflows.mdx) allow building multi-step operations that
-  can span agents, users, durably and reliably.
-- [Files](./docs/files.mdx) are supported in thread history with automatic
-  saving to [file storage](https://docs.convex.dev/file-storage) and
-  ref-counting.
-- [Debugging](./docs/debugging.mdx) is enabled by callbacks, the
-  [agent playground](./docs/playground.mdx) where you can inspect all metadata
-  and iterate on prompts and context settings, and inspection in the dashboard.
-- [Usage tracking](./docs/usage-tracking.mdx) is easy to set up, enabling usage
-  attribution per-provider, per-model, per-user, per-agent, for billing & more.
-- [Rate limiting](./docs/rate-limiting.mdx), powered by the
+- [Conversation context](https://docs.convex.dev/agents/context) is
+  automatically included in each LLM call, including built-in hybrid vector/text
+  search for messages in the thread and opt-in search for messages from other
+  threads (for the same specified user).
+- [RAG](https://docs.convex.dev/agents/rag) techniques are supported for prompt
+  augmentation from other sources, either up front in the prompt or as tool
+  calls. Integrates with the
+  [RAG Component](https://www.convex.dev/components/rag), or DIY.
+- [Workflows](https://docs.convex.dev/agents/workflows) allow building
+  multi-step operations that can span agents, users, durably and reliably.
+- [Files](https://docs.convex.dev/agents/files) are supported in thread history
+  with automatic saving to [file storage](https://docs.convex.dev/file-storage)
+  and ref-counting.
+- [Debugging](https://docs.convex.dev/agents/debugging) is enabled by callbacks,
+  the [agent playground](https://docs.convex.dev/agents/playground) where you
+  can inspect all metadata and iterate on prompts and context settings, and
+  inspection in the dashboard.
+- [Usage tracking](https://docs.convex.dev/agents/usage-tracking) is easy to set
+  up, enabling usage attribution per-provider, per-model, per-user, per-agent,
+  for billing & more.
+- [Rate limiting](https://docs.convex.dev/agents/rate-limiting), powered by the
   [Rate Limiter Component](https://www.convex.dev/components/rate-limiter),
   helps control the rate at which users can interact with agents and keep you
   from exceeding your LLM provider's limits.


### PR DESCRIPTION
The links were pointing to the mdx files on github which were not rendering the html correctly, its bettter they point to the docs