### PR TITLE
strip out old streams when they are no longer present

### DIFF
--- a/src/react/useDeltaStreams.ts
+++ b/src/react/useDeltaStreams.ts
@@ -103,36 +103,51 @@ export function useDeltaStreams<
     | undefined;
 
   const newDeltas = cursorQuery?.streams.deltas;
-  if (newDeltas?.length && streamMessages) {
+  if (streamMessages) {
     const newDeltasByStreamId = new Map<string, StreamDelta[]>();
-    for (const delta of newDeltas) {
-      const oldCursor = cursors[delta.streamId];
-      if (oldCursor && delta.start < oldCursor) continue;
-      const existing = newDeltasByStreamId.get(delta.streamId);
-      if (existing) {
-        const previousEnd = existing.at(-1)!.end;
-        assert(
-          previousEnd === delta.start,
-          `Gap found in deltas for ${delta.streamId} jumping to ${delta.start} from ${previousEnd}`,
-        );
-        existing.push(delta);
-      } else {
-        assert(
-          !oldCursor || oldCursor === delta.start,
-          `Gap found - first delta after ${oldCursor} is ${delta.start} for stream ${delta.streamId}`,
-        );
-        newDeltasByStreamId.set(delta.streamId, [delta]);
+    if (newDeltas?.length) {
+      for (const delta of newDeltas) {
+        const oldCursor = cursors[delta.streamId];
+        if (oldCursor && delta.start < oldCursor) continue;
+        const existing = newDeltasByStreamId.get(delta.streamId);
+        if (existing) {
+          const previousEnd = existing.at(-1)!.end;
+          assert(
+            previousEnd === delta.start,
+            `Gap found in deltas for ${delta.streamId} jumping to ${delta.start} from ${previousEnd}`,
+          );
+          existing.push(delta);
+        } else {
+          assert(
+            !oldCursor || oldCursor === delta.start,
+            `Gap found - first delta after ${oldCursor} is ${delta.start} for stream ${delta.streamId}`,
+          );
+          newDeltasByStreamId.set(delta.streamId, [delta]);
+        }
       }
     }
     const newCursors: Record<string, number> = {};
+    let cursorsChanged = false;
     for (const { streamId } of streamMessages) {
       const cursor =
         newDeltasByStreamId.get(streamId)?.at(-1)?.end ?? cursors[streamId];
       if (cursor !== undefined) {
         newCursors[streamId] = cursor;
+        if (cursors[streamId] !== cursor) {
+          cursorsChanged = true;
+        }
       }
     }
-    setCursors(newCursors);
+    // Also check if any streams were removed from cursors
+    for (const streamId in cursors) {
+      if (!(streamId in newCursors)) {
+        cursorsChanged = true;
+        break;
+      }
+    }
+    if (cursorsChanged) {
+      setCursors(newCursors);
+    }
 
     // we defensively create a new object so object identity matches contents
     state.deltaStreams = streamMessages.map((streamMessage) => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Cleans up streaming messages from the list when no new deltas arrive but a stream is no longer present.

Fixes #185 
Fixes #187 
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved stream message processing to avoid work when no new updates are present, reduce redundant state changes, and minimize churn when streams are removed—resulting in more efficient and stable stream handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->