### PR TITLE
Add cache token tracking to Usage (cacheReadTokens/cacheWriteTokens)

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -277,6 +277,9 @@ export const vUsage = v.object({
   totalTokens: v.number(),
   reasoningTokens: v.optional(v.number()),
   cachedInputTokens: v.optional(v.number()),
+  // Cache token details from AI SDK (Anthropic's cacheCreationInputTokens maps to cacheWriteTokens)
+  cacheReadTokens: v.optional(v.number()),
+  cacheWriteTokens: v.optional(v.number()),
 });
 export type Usage = Infer<typeof vUsage>;
 


### PR DESCRIPTION
## Problem

When using Anthropic's prompt caching feature, the cache token usage (`cacheCreationInputTokens` and `cacheReadInputTokens`) was not being persisted to the database. This made it impossible to track cache efficiency or billing for cached prompts.

The AI SDK provides these values via `inputTokenDetails.cacheReadTokens` and `inputTokenDetails.cacheWriteTokens`, but they were being ignored during serialization.

## Solution

Add `cacheReadTokens` and `cacheWriteTokens` fields to the Usage type and serialize them properly:

```typescript
// src/mapping.ts - serializeUsage()
return {
  promptTokens: usage.inputTokens ?? 0,
  completionTokens: usage.outputTokens ?? 0,
  totalTokens: usage.totalTokens ?? 0,
  reasoningTokens: usage.reasoningTokens,
  cachedInputTokens: usage.cachedInputTokens,
  // NEW: Cache token details (Anthropic's cacheCreationInputTokens maps to cacheWriteTokens)
  cacheReadTokens: usage.inputTokenDetails?.cacheReadTokens,
  cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens,
};
```

And restore them when converting back:

```typescript
// src/mapping.ts - toModelMessageUsage()
inputTokenDetails:
  usage.cacheReadTokens !== undefined ||
  usage.cacheWriteTokens !== undefined
    ? {
        cacheReadTokens: usage.cacheReadTokens,
        cacheWriteTokens: usage.cacheWriteTokens,
      }
    : undefined,
```

Fixes #191

## Test plan
- [x] Unit tests for basic usage serialization
- [x] Unit tests for cache-related field serialization  
- [x] Unit tests verifying Anthropic's cacheCreationInputTokens mapping

🤖 Generated with [Claude Code](https://claude.ai/code)