### PR TITLE
Fix stopWhen triggering on tool validation errors

### DIFF
--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { willContinue } from "./utils.js";
+import type { StepResult } from "ai";
+
+describe("willContinue", () => {
+  it("should return false when finishReason is not tool-calls", async () => {
+    const steps = [
+      {
+        finishReason: "stop",
+        toolCalls: [],
+        toolResults: [],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const result = await willContinue(steps, undefined);
+    expect(result).toBe(false);
+  });
+
+  it("should return false when waiting for tool results", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [{ toolCallId: "1", toolName: "test", args: {} }],
+        toolResults: [],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const result = await willContinue(steps, undefined);
+    expect(result).toBe(false);
+  });
+
+  it("should evaluate stopWhen when tool results are present", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [{ toolCallId: "1", toolName: "test", args: {} }],
+        toolResults: [
+          { toolCallId: "1", toolName: "test", result: "success" },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const stopWhen = () => true; // Should stop
+    const result = await willContinue(steps, stopWhen);
+    expect(result).toBe(false); // willContinue returns false when stop is true
+  });
+
+  it("should continue when stopWhen returns false", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [{ toolCallId: "1", toolName: "test", args: {} }],
+        toolResults: [
+          { toolCallId: "1", toolName: "test", result: "success" },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const stopWhen = () => false; // Should not stop
+    const result = await willContinue(steps, stopWhen);
+    expect(result).toBe(true); // willContinue returns true when stop is false
+  });
+
+  it("should continue (not stop) when tool result has an error (issue #172)", async () => {
+    // When a tool call fails Zod validation, the result contains an error message
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [
+          { toolCallId: "1", toolName: "generateImage", args: { id: "invalid" } },
+        ],
+        toolResults: [
+          {
+            toolCallId: "1",
+            toolName: "generateImage",
+            result:
+              'ArgumentValidationError: Value does not match validator.\nPath: .id\nValue: "invalid"\nValidator: v.id("images")',
+            isError: true,
+          },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    // hasToolCall("generateImage") would return true, causing stopWhen to stop
+    const stopWhen = ({ steps }: { steps: StepResult<any>[] }) => {
+      const lastStep = steps.at(-1);
+      return (
+        lastStep?.toolCalls.some((tc) => tc.toolName === "generateImage") ??
+        false
+      );
+    };
+
+    const result = await willContinue(steps, stopWhen);
+    // Should return true (continue) because the tool errored, even though
+    // stopWhen would normally trigger a stop for this tool
+    expect(result).toBe(true);
+  });
+
+  it("should stop when tool succeeds and stopWhen matches", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [
+          { toolCallId: "1", toolName: "generateImage", args: { id: "valid" } },
+        ],
+        toolResults: [
+          {
+            toolCallId: "1",
+            toolName: "generateImage",
+            result: { success: true, imageUrl: "https://example.com/image.png" },
+            isError: false,
+          },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const stopWhen = ({ steps }: { steps: StepResult<any>[] }) => {
+      const lastStep = steps.at(-1);
+      return (
+        lastStep?.toolCalls.some((tc) => tc.toolName === "generateImage") ??
+        false
+      );
+    };
+
+    const result = await willContinue(steps, stopWhen);
+    // Should return false (stop) because the tool succeeded
+    expect(result).toBe(false);
+  });
+
+  it("should handle array of stopWhen conditions", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [{ toolCallId: "1", toolName: "test", args: {} }],
+        toolResults: [
+          { toolCallId: "1", toolName: "test", result: "success" },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const stopWhen = [() => false, () => false];
+    const result = await willContinue(steps, stopWhen);
+    expect(result).toBe(true);
+  });
+
+  it("should stop when any stopWhen condition returns true", async () => {
+    const steps = [
+      {
+        finishReason: "tool-calls",
+        toolCalls: [{ toolCallId: "1", toolName: "test", args: {} }],
+        toolResults: [
+          { toolCallId: "1", toolName: "test", result: "success" },
+        ],
+      },
+    ] as unknown as StepResult<any>[];
+
+    const stopWhen = [() => false, () => true];
+    const result = await willContinue(steps, stopWhen);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

When a tool call fails Zod validation (e.g., invalid ID format), the `stopWhen` condition was still being evaluated and could trigger a stop. This prevented the LLM from seeing the error and retrying with corrected arguments.

For example, with `stopWhen: hasToolCall("generateImage")`:

1. LLM calls `generateImage` with invalid ID
2. Tool returns error: `ArgumentValidationError: Value does not match validator`
3. `stopWhen` sees `generateImage` was called → returns `true` → stops
4. LLM never gets a chance to retry with valid arguments

## Solution

Add a check in `willContinue` to skip `stopWhen` evaluation when any tool result has an error:

```typescript
// src/client/utils.ts - willContinue()
export async function willContinue(steps, stopWhen) {
  const step = steps.at(-1)!;
  if (step.finishReason !== "tool-calls") return false;
  if (step.toolCalls.length > step.toolResults.length) return false;
  
  // NEW: If any tool result has an error, continue without evaluating stopWhen.
  // This allows the LLM to retry or handle the error.
  const hasErrorResult = step.toolResults.some(
    (result: { isError?: boolean }) => result.isError === true,
  );
  if (hasErrorResult) return true;
  
  // ... evaluate stopWhen conditions
}
```

Now when a tool fails:
1. LLM calls `generateImage` with invalid ID  
2. Tool returns error with `isError: true`
3. `willContinue` sees error → returns `true` (continue)
4. LLM receives error, retries with valid arguments

Fixes #172

## Test plan
- [x] Test: continues when tool result has error (even if stopWhen would match)
- [x] Test: stops normally when tool succeeds and stopWhen matches
- [x] Test: handles array of stopWhen conditions
- [x] Test: stops when any stopWhen condition returns true

🤖 Generated with [Claude Code](https://claude.ai/code)