### PR TITLE
Fix streaming tool calls being overwritten at index 0

### DIFF
--- a/src/UIMessages.combineUIMessages.test.ts
+++ b/src/UIMessages.combineUIMessages.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from "vitest";
+import { combineUIMessages, type UIMessage } from "./UIMessages.js";
+
+describe("combineUIMessages", () => {
+  it("should preserve all tool calls when combining messages", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolB",
+            toolCallId: "call_B",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+    ];
+
+    const result = combineUIMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(2);
+
+    const toolCallIds = result[0].parts
+      .filter((p) => p.type.startsWith("tool-"))
+      .map((p: any) => p.toolCallId);
+
+    expect(toolCallIds).toContain("call_A");
+    expect(toolCallIds).toContain("call_B");
+  });
+
+  it("should accumulate tool calls progressively (issue #182)", () => {
+    // Simulating: A(started) → B → C → A(result)
+    const messages: UIMessage[] = [
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "input-available",
+            input: {},
+          },
+          {
+            type: "tool-toolB",
+            toolCallId: "call_B",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "input-available",
+            input: {},
+          },
+          {
+            type: "tool-toolB",
+            toolCallId: "call_B",
+            state: "input-available",
+            input: {},
+          },
+          {
+            type: "tool-toolC",
+            toolCallId: "call_C",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "success",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "output-available",
+            input: {},
+            output: "success",
+          },
+          {
+            type: "tool-toolB",
+            toolCallId: "call_B",
+            state: "input-available",
+            input: {},
+          },
+          {
+            type: "tool-toolC",
+            toolCallId: "call_C",
+            state: "input-available",
+            input: {},
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+    ];
+
+    const result = combineUIMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(3);
+
+    const toolCallIds = result[0].parts
+      .filter((p) => p.type.startsWith("tool-"))
+      .map((p: any) => p.toolCallId);
+
+    // All tool calls should be present
+    expect(toolCallIds).toContain("call_A");
+    expect(toolCallIds).toContain("call_B");
+    expect(toolCallIds).toContain("call_C");
+
+    // Tool A should have the final state (output-available)
+    const toolA = result[0].parts.find(
+      (p: any) => p.type === "tool-toolA" && p.toolCallId === "call_A",
+    ) as any;
+    expect(toolA.state).toBe("output-available");
+    expect(toolA.output).toBe("success");
+  });
+
+  it("should merge tool calls with same toolCallId", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "streaming",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "input-available",
+            input: { test: "input" },
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+      {
+        id: "msg1",
+        key: "thread-1-0",
+        order: 1,
+        stepOrder: 0,
+        status: "success",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-toolA",
+            toolCallId: "call_A",
+            state: "output-available",
+            input: { test: "input" },
+            output: "completed",
+          },
+        ],
+        text: "",
+        _creationTime: Date.now(),
+      },
+    ];
+
+    const result = combineUIMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(1);
+
+    const toolCall = result[0].parts[0] as any;
+    expect(toolCall.toolCallId).toBe("call_A");
+    expect(toolCall.state).toBe("output-available");
+    expect(toolCall.output).toBe("completed");
+  });
+});

--- a/src/UIMessages.ts
+++ b/src/UIMessages.ts
@@ -583,11 +583,12 @@ export function combineUIMessages(messages: UIMessage[]): UIMessage[] {
       const previousPartIndex = newParts.findIndex(
         (p) => getToolCallId(p) === toolCallId,
       );
-      const previousPart = newParts.splice(previousPartIndex, 1)[0];
-      if (!previousPart) {
+      if (previousPartIndex === -1) {
+        // Tool call not found in previous parts, add it as new
         newParts.push(part);
         continue;
       }
+      const previousPart = newParts.splice(previousPartIndex, 1)[0];
       newParts.push(mergeParts(previousPart, part));
     }
     acc.push({


### PR DESCRIPTION
## Problem

When streaming multiple tool calls, new tool calls were corrupting existing ones. The bug was in `combineUIMessages`:

```typescript
// BUGGY CODE
const previousPartIndex = newParts.findIndex(
  (p) => getToolCallId(p) === toolCallId,
);
const previousPart = newParts.splice(previousPartIndex, 1)[0];
if (!previousPart) {
  newParts.push(part);
  continue;
}
```

When `findIndex` returns `-1` (tool call ID not found in previous parts):
- `splice(-1, 1)` removes the **last element** of the array (JavaScript quirk!)
- `previousPart` is that removed element (truthy, not undefined)
- The new part incorrectly merges with the last element instead of being added
- This corrupts the parts array, causing tool calls to disappear

## Solution

Check for `-1` explicitly before calling splice:

```typescript
// FIXED CODE
if (previousPartIndex === -1) {
  // Tool call not found, add as new
  newParts.push(part);
  continue;
}
const previousPart = newParts.splice(previousPartIndex, 1)[0];
newParts.push(mergeParts(previousPart, part));
```

Fixes #182

## Test plan
- [x] Test: preserves all tool calls when combining messages
- [x] Test: accumulates tool calls progressively (A → A,B → A,B,C)
- [x] Test: merges tool calls with same toolCallId correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in message combination that could unintentionally remove elements when specific tool calls were not found.

* **Tests**
  * Added comprehensive test suite validating preservation and progressive accumulation of tool calls, state transitions, and deduplication during message combination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->