### PR TITLE
Preserve isError flag for tool error reporting in UIMessages

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -549,6 +549,8 @@ function normalizeToolResult(
       normalizeToolOutput("result" in part ? part.result : undefined),
     toolCallId: part.toolCallId,
     toolName: part.toolName,
+    // Preserve isError flag for error reporting
+    ...("isError" in part && part.isError ? { isError: true } : {}),
     ...metadata,
   } satisfies ToolResultPart;
 }


### PR DESCRIPTION
## Problem

When a tool call fails (e.g., validation error), the error was not being properly displayed in the UI. Tool results have an `isError` flag, but it was being stripped during message mapping, so the UI showed errors as normal output.

The `isError` flag was lost here:

```typescript
// src/mapping.ts - normalizeToolResult() - BEFORE
return {
  type: part.type,
  output: part.output ?? normalizeToolOutput(...),
  toolCallId: part.toolCallId,
  toolName: part.toolName,
  ...metadata,
  // isError was NOT preserved!
};
```

And in UIMessages, only `message.error` was checked, not `contentPart.isError`:

```typescript
// src/UIMessages.ts - BEFORE
if (message.error) {
  call.state = "output-error";
  call.errorText = message.error;
}
```

## Solution

1. Preserve `isError` flag during mapping:

```typescript
// src/mapping.ts - normalizeToolResult() - AFTER
return {
  type: part.type,
  output: ...,
  toolCallId: part.toolCallId,
  toolName: part.toolName,
  // NEW: Preserve isError flag for error reporting
  ...("isError" in part && part.isError ? { isError: true } : {}),
  ...metadata,
};
```

2. Check both `contentPart.isError` and `message.error` in UIMessages:

```typescript
// src/UIMessages.ts - AFTER  
// Check for error at both the content part level (isError) and message level
const hasError = contentPart.isError || message.error;
const errorText = message.error || (hasError ? String(output) : undefined);

if (hasError) {
  call.state = "output-error";
  call.errorText = errorText;
}
```

Now tool errors display correctly with `output-error` state.

Fixes #162

## Test plan
- [x] Test: shows output-error state when tool result has `isError: true`
- [x] Test: shows output-error when tool result has isError without tool call present

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for tool results with improved error detection, consolidated error sources, and fallback error messaging when details are unavailable.

* **Tests**
  * Added test coverage for tool result error handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->