### PR TITLE
Add userId field to UIMessage type

### DIFF
--- a/src/UIMessages.ts
+++ b/src/UIMessages.ts
@@ -42,6 +42,7 @@ export type UIMessage<
   stepOrder: number;
   status: UIStatus;
   agentName?: string;
+  userId?: string;
   text: string;
   _creationTime: number;
 };
@@ -75,7 +76,8 @@ export function fromUIMessages<METADATA = unknown>(
         "providerOptions",
         "metadata",
       ]),
-      ...omit(uiMessage, ["parts", "role", "key", "text"]),
+      ...omit(uiMessage, ["parts", "role", "key", "text", "userId"]),
+      userId: uiMessage.userId ?? meta.userId,
       status: uiMessage.status === "streaming" ? "pending" : "success",
       streaming: uiMessage.status === "streaming",
       // to override
@@ -288,6 +290,7 @@ function createSystemUIMessage<
     text,
     role: "system",
     agentName: message.agentName,
+    userId: message.userId,
     parts: [{ type: "text", text, ...partCommon } satisfies TextUIPart],
     metadata: message.metadata,
   };
@@ -347,6 +350,7 @@ function createUserUIMessage<
     key: `${message.threadId}-${message.order}-${message.stepOrder}`,
     text,
     role: "user",
+    userId: message.userId,
     parts,
     metadata: message.metadata,
   };
@@ -370,6 +374,7 @@ function createAssistantUIMessage<
     stepOrder: firstMessage.stepOrder,
     key: `${firstMessage.threadId}-${firstMessage.order}-${firstMessage.stepOrder}`,
     agentName: firstMessage.agentName,
+    userId: firstMessage.userId,
   };
 
   // Get status from last message

--- a/src/toUIMessages.test.ts
+++ b/src/toUIMessages.test.ts
@@ -728,4 +728,131 @@ describe("toUIMessages", () => {
     expect(textParts).toHaveLength(1);
     expect(textParts[0].text).toBe("The result is 42.");
   });
+
+  describe("userId preservation", () => {
+    it("preserves userId in user messages", () => {
+      const messages = [
+        baseMessageDoc({
+          userId: "user123",
+          message: {
+            role: "user",
+            content: "Hello!",
+          },
+          text: "Hello!",
+        }),
+      ];
+      const uiMessages = toUIMessages(messages);
+      expect(uiMessages).toHaveLength(1);
+      expect(uiMessages[0].role).toBe("user");
+      expect(uiMessages[0].userId).toBe("user123");
+    });
+
+    it("preserves userId in system messages", () => {
+      const messages = [
+        baseMessageDoc({
+          userId: "user456",
+          message: {
+            role: "system",
+            content: "System prompt",
+          },
+          text: "System prompt",
+        }),
+      ];
+      const uiMessages = toUIMessages(messages);
+      expect(uiMessages).toHaveLength(1);
+      expect(uiMessages[0].role).toBe("system");
+      expect(uiMessages[0].userId).toBe("user456");
+    });
+
+    it("preserves userId in assistant messages", () => {
+      const messages = [
+        baseMessageDoc({
+          userId: "user789",
+          message: {
+            role: "assistant",
+            content: "Hi there!",
+          },
+          text: "Hi there!",
+        }),
+      ];
+      const uiMessages = toUIMessages(messages);
+      expect(uiMessages).toHaveLength(1);
+      expect(uiMessages[0].role).toBe("assistant");
+      expect(uiMessages[0].userId).toBe("user789");
+    });
+
+    it("preserves userId from first message in grouped assistant messages", () => {
+      const messages = [
+        baseMessageDoc({
+          _id: "msg1",
+          userId: "userA",
+          order: 1,
+          stepOrder: 1,
+          tool: true,
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolName: "myTool",
+                toolCallId: "call1",
+                args: {},
+              },
+            ],
+          },
+          text: "",
+        }),
+        baseMessageDoc({
+          _id: "msg2",
+          userId: "userA",
+          order: 1,
+          stepOrder: 2,
+          tool: true,
+          message: {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call1",
+                toolName: "myTool",
+                output: { type: "text", value: "result" },
+              },
+            ],
+          },
+          text: "",
+        }),
+        baseMessageDoc({
+          _id: "msg3",
+          userId: "userA",
+          order: 1,
+          stepOrder: 3,
+          message: {
+            role: "assistant",
+            content: "Done!",
+          },
+          text: "Done!",
+        }),
+      ];
+      const uiMessages = toUIMessages(messages);
+      expect(uiMessages).toHaveLength(1);
+      expect(uiMessages[0].role).toBe("assistant");
+      expect(uiMessages[0].userId).toBe("userA");
+    });
+
+    it("handles undefined userId gracefully", () => {
+      const messages = [
+        baseMessageDoc({
+          // No userId provided
+          message: {
+            role: "user",
+            content: "Hello!",
+          },
+          text: "Hello!",
+        }),
+      ];
+      const uiMessages = toUIMessages(messages);
+      expect(uiMessages).toHaveLength(1);
+      expect(uiMessages[0].userId).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The `UIMessage` type did not include a `userId` field, making it impossible to identify which user a message belongs to in the UI layer. This information was available in the underlying `MessageDoc` but was not propagated to `UIMessage`.

## Solution

Add `userId` field to the `UIMessage` type and propagate it during message creation:

```typescript
// src/UIMessages.ts - UIMessage type
export type UIMessage<...> = {
  id: string;
  key: string;
  order: number;
  stepOrder: number;
  status: UIStatus;
  agentName?: string;
  userId?: string;  // NEW
  text: string;
  _creationTime: number;
};
```

Propagate in each message type creator:

```typescript
// System messages
function createSystemUIMessage(...) {
  return {
    ...
    userId: message.userId,  // NEW
    ...
  };
}

// User messages  
function createUserUIMessage(...) {
  return {
    ...
    userId: message.userId,  // NEW
    ...
  };
}

// Assistant messages (uses first message's userId)
function createAssistantUIMessage(...) {
  const common = {
    ...
    userId: firstMessage.userId,  // NEW
  };
  ...
}
```

Fixes #188

## Test plan
- [x] Test: preserves userId in user messages
- [x] Test: preserves userId in system messages
- [x] Test: preserves userId in assistant messages
- [x] Test: preserves userId from first message in grouped assistant messages
- [x] Test: handles undefined userId gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now include an optional userId so system, user, and assistant messages preserve and carry a message-level user identifier across flows.

* **Tests**
  * Added tests to verify userId preservation across roles and grouped assistant messages, including edge cases where userId is undefined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->