### PR TITLE
fix: handle tool validation errors in stopWhen and willContinue

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -99,9 +99,10 @@ import type {
   Output,
 } from "./types.js";
 import { streamText } from "./streamText.js";
-import { errorToString, willContinue } from "./utils.js";
+import { errorToString, hasSuccessfulToolCall, willContinue } from "./utils.js";
 
 export { stepCountIs } from "ai";
+export { hasSuccessfulToolCall };
 export {
   docsToModelMessages,
   toModelMessage,

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,19 @@
 import type { StepResult, StopCondition } from "ai";
 
+/**
+ * A stop condition that only matches tool calls which completed
+ * successfully (i.e. produced a `tool-result`, not a `tool-error`).
+ *
+ * Use this instead of the AI SDK's `hasToolCall` when you want the
+ * agent to retry on argument validation failures rather than stopping.
+ */
+export function hasSuccessfulToolCall(toolName: string): StopCondition<any> {
+  return ({ steps }) =>
+    steps[steps.length - 1]?.toolResults?.some(
+      (result) => result.toolName === toolName,
+    ) ?? false;
+}
+
 export async function willContinue(
   steps: StepResult<any>[],
 
@@ -9,8 +23,15 @@ export async function willContinue(
   // we aren't doing another round after a tool result
   // TODO: whether to handle continuing after too much context used..
   if (step.finishReason !== "tool-calls") return false;
+  // Count both successful results and errors as completed outputs.
+  // In AI SDK v6, failed tool calls produce tool-error content parts
+  // instead of tool-result, so only checking toolResults misses them.
+  const completedOutputs =
+    step.content?.filter(
+      (p) => p.type === "tool-result" || p.type === "tool-error",
+    ).length ?? step.toolResults.length;
   // we don't have a tool result, so we'll wait for more
-  if (step.toolCalls.length > step.toolResults.length) return false;
+  if (step.toolCalls.length > completedOutputs) return false;
   if (Array.isArray(stopWhen)) {
     return (await Promise.all(stopWhen.map(async (s) => s({ steps })))).every(
       (stop) => !stop,


### PR DESCRIPTION
## Summary
- **`hasSuccessfulToolCall(toolName)`** — new stop condition that only matches tool calls which produced a `tool-result` (not `tool-error`). Use instead of the AI SDK's `hasToolCall` when agents should retry on argument validation failures.
- **`willContinue` fix** — counts `tool-error` content parts as completed outputs. In AI SDK v6, failed tool calls produce `tool-error` instead of `tool-result`, causing `willContinue` to incorrectly treat them as pending and stop prematurely.

## Context
When a tool call fails Zod argument validation in AI SDK v6, the result is a `tool-error` content part (not `tool-result`). Two problems occurred:
1. `willContinue` checked `step.toolCalls.length > step.toolResults.length` — since `tool-error` isn't in `toolResults`, it looked like a pending result, returning `false` (stop)
2. The AI SDK's `hasToolCall` matches any tool call regardless of success, so `stopWhen: [hasToolCall("myTool")]` would stop even on validation failures

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (262/262)
- [x] Impact analysis: `willContinue` has a single caller (`streamText.ts:143`), change is backwards-compatible

Fixes #172

Orchestrator: Zeta — VantageOS Team Dev | 2026-04-06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to check whether a specific tool call completed successfully.

* **Bug Fixes**
  * Enhanced tool call completion detection to properly recognize and handle both successful results and error responses in tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->