### PR TITLE
fix: persist final step when saveStreamDeltas.returnImmediately is true (#265)

### DIFF
--- a/example/convex/setup.test.ts
+++ b/example/convex/setup.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { test } from "vitest";
-import { convexTest } from "convex-test";
+import { convexTest, type TestConvex } from "convex-test";
+import type { GenericSchema, SchemaDefinition } from "convex/server";
 import schema from "./schema.js";
 import agent from "@convex-dev/agent/test";
 import workflow from "@convex-dev/workflow/test";
@@ -10,8 +11,15 @@ export const modules = import.meta.glob("./**/*.*s");
 export function initConvexTest() {
   const t = convexTest(schema, modules);
   agent.register(t);
-  workflow.register(t);
-  rateLimiter.register(t);
+  // workflow and rate-limiter still type their `register` against the
+  // pre-generic SchemaDefinition<GenericSchema, boolean>. Cast through
+  // the broader type so this file typechecks regardless of which version
+  // of those packages is resolved.
+  const generic = t as unknown as TestConvex<
+    SchemaDefinition<GenericSchema, boolean>
+  >;
+  workflow.register(generic);
+  rateLimiter.register(generic);
   return t;
 }
 

--- a/src/client/streamText.test.ts
+++ b/src/client/streamText.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import { Agent, createThread } from "./index.js";
+import {
+  defineSchema,
+  type DataModelFromSchemaDefinition,
+  type ApiFromModules,
+  type ActionBuilder,
+  actionGeneric,
+  anyApi,
+} from "convex/server";
+import { v } from "convex/values";
+import { components, initConvexTest } from "./setup.test.js";
+import { mockModel } from "./mockModel.js";
+
+const schema = defineSchema({});
+type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+const action = actionGeneric as ActionBuilder<DataModel, "public">;
+
+const FINAL_TEXT = "Hello from the model";
+
+const agent = new Agent(components.agent, {
+  name: "stream-test",
+  languageModel: mockModel({
+    content: [{ type: "text", text: FINAL_TEXT }],
+  }),
+});
+
+// Action that exercises streamText with saveStreamDeltas.returnImmediately=true.
+// It consumes the stream after streamText returns, simulating the HTTP response
+// path described in issue #265.
+export const streamTextReturnImmediately = action({
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    const result = await agent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "Test" },
+      {
+        saveStreamDeltas: {
+          returnImmediately: true,
+          chunking: "word",
+          throttleMs: 0,
+        },
+      },
+    );
+    // Drain the stream the way an HTTP response would. This triggers
+    // onStepFinish for every step, including the final one.
+    await result.consumeStream();
+    return { ok: true };
+  },
+});
+
+const testApi: ApiFromModules<{
+  fns: { streamTextReturnImmediately: typeof streamTextReturnImmediately };
+}>["fns"] = anyApi["streamText.test"] as any;
+
+describe("streamText with saveStreamDeltas.returnImmediately (issue #265)", () => {
+  test("persists the final assistant text to the messages table", async () => {
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "u1" }),
+    );
+
+    await t.action(testApi.streamTextReturnImmediately, { threadId });
+
+    // Allow any background work scheduled by consumeStream to settle.
+    await t.finishAllScheduledFunctions(() => {});
+
+    const messages = await t.run(async (ctx) =>
+      agent.listMessages(ctx, {
+        threadId,
+        paginationOpts: { cursor: null, numItems: 50 },
+      }),
+    );
+
+    const assistantTextMessages = messages.page.filter(
+      (m) =>
+        m.message?.role === "assistant" &&
+        typeof m.text === "string" &&
+        m.text.length > 0,
+    );
+    expect(
+      assistantTextMessages.length,
+      "expected at least one persisted assistant message with text",
+    ).toBeGreaterThan(0);
+
+    const combined = assistantTextMessages.map((m) => m.text).join("");
+    expect(combined).toContain(FINAL_TEXT);
+
+    // The stream should be marked finished, not stuck in "streaming".
+    const stillStreaming = await t.run(async (ctx) =>
+      ctx.runQuery(components.agent.streams.list, {
+        threadId,
+        statuses: ["streaming"],
+      }),
+    );
+    expect(
+      stillStreaming,
+      "stream should not be stuck in 'streaming' status",
+    ).toHaveLength(0);
+  });
+});

--- a/src/client/streamText.ts
+++ b/src/client/streamText.ts
@@ -80,8 +80,20 @@ export async function streamText<
 
   const steps: StepResult<TOOLS>[] = [];
 
-  // Track the final step for atomic save with stream finish (issue #181)
+  // Track the final step for atomic save with stream finish (issue #181).
+  // Only used when streamText awaits stream consumption itself; the
+  // `returnImmediately` path saves inline instead (see onStepFinish below).
   let pendingFinalStep: StepResult<TOOLS> | undefined;
+
+  // Whether streamText will await stream consumption before returning.
+  // When false (saveStreamDeltas.returnImmediately === true), we cannot
+  // defer the final-step save to a post-await block — the function has
+  // already returned by the time onStepFinish fires. See issue #265.
+  const willAwaitStream =
+    Boolean(threadId) &&
+    (options.saveStreamDeltas === true ||
+      (typeof options.saveStreamDeltas === "object" &&
+        !options.saveStreamDeltas.returnImmediately));
 
   const streamer =
     threadId && options.saveStreamDeltas
@@ -142,10 +154,19 @@ export async function streamText<
       steps.push(step);
       const createPendingMessage = await willContinue(steps, args.stopWhen);
       if (!createPendingMessage && streamer) {
-        // This is the final step with streaming enabled.
-        // Defer saving until stream consumption completes for atomic finish (issue #181).
+        // Final step with streaming enabled.
         streamer.markFinishedExternally();
-        pendingFinalStep = step;
+        if (willAwaitStream) {
+          // We're about to `await stream` below — defer the save so it
+          // happens atomically with stream finish (issue #181).
+          pendingFinalStep = step;
+        } else {
+          // returnImmediately path: streamText is about to return without
+          // awaiting consumption, so the deferred-save block below won't
+          // see this step. Save inline now (issue #265).
+          const finishStreamId = await streamer.getOrCreateStreamId();
+          await call.save({ step }, false, finishStreamId);
+        }
       } else {
         await call.save({ step }, createPendingMessage);
       }
@@ -155,11 +176,7 @@ export async function streamText<
   const stream = streamer?.consumeStream(
     result.toUIMessageStream<AIUIMessage<TOOLS>>(),
   );
-  if (
-    (typeof options?.saveStreamDeltas === "object" &&
-      !options.saveStreamDeltas.returnImmediately) ||
-    options?.saveStreamDeltas === true
-  ) {
+  if (willAwaitStream) {
     try {
       await stream;
       await result.consumeStream();

--- a/src/client/streaming.ts
+++ b/src/client/streaming.ts
@@ -287,6 +287,13 @@ export class DeltaStreamer<T> {
     if (this.abortController.signal.aborted) {
       return;
     }
+    // Once the stream has been finished externally (e.g. by the inline
+    // save in streamText's onStepFinish for the returnImmediately path),
+    // the stream record is already "finished" in the DB. Late deltas
+    // would be silently dropped by streams.addDelta — skip the work.
+    if (this.#finishedExternally) {
+      return;
+    }
     await this.getStreamId();
     this.#nextParts.push(...parts);
     if (

--- a/src/client/streaming.ts
+++ b/src/client/streaming.ts
@@ -349,6 +349,13 @@ export class DeltaStreamer<T> {
         delta,
       );
       if (!success) {
+        // An in-flight #sendDelta started before markFinishedExternally()
+        // will get `success === false` because the stream row is already
+        // "finished". That's a benign late-write miss, not a failure —
+        // don't convert it into an abort.
+        if (this.#finishedExternally) {
+          return;
+        }
         await this.config.onAsyncAbort("async abort");
         this.abortController.abort();
         return;


### PR DESCRIPTION
## Summary

Fixes #265: when `streamText` is called with `saveStreamDeltas: { returnImmediately: true }`, the final assistant message was never persisted and the stream stayed stuck in `"streaming"` status forever. Only intermediate (tool-call) steps were saved.

## Root cause

The deferred-save path added for atomic stream finish (#181) doesn't work when `streamText` returns without awaiting stream consumption:

1. `onStepFinish` runs only when the caller later drains the stream (e.g. via `result.toTextStreamResponse()`).
2. With `returnImmediately: true`, `streamText` skips its own `await stream` block and exits.
3. The post-await `if (pendingFinalStep && streamer)` block runs synchronously after exit — but `onStepFinish` hasn't fired yet, so `pendingFinalStep` is still `undefined`.
4. The caller drains the stream later, `onStepFinish` fires, sets `pendingFinalStep` and calls `markFinishedExternally()` — but no one is reading `pendingFinalStep` anymore, and `consumeStream` skips `finish()` due to the external-finish flag.
5. Net effect: final message dropped, stream stuck.

## Fix

Branch on a new `willAwaitStream` flag in `onStepFinish`:

- If `streamText` will await consumption (`saveStreamDeltas === true` or `returnImmediately: false`): defer the save via `pendingFinalStep` as before (preserves the atomic-finish behavior from #181).
- If not (`returnImmediately: true`): save the final step **inline** using `streamer.getOrCreateStreamId()` so the message persistence and stream-finish land atomically — before `streamText` returns.

Also guards `DeltaStreamer.addParts` against late deltas after `markFinishedExternally`. The stream record is already in `"finished"` state and `streams.addDelta` would silently drop those writes anyway; skipping them is just an optimization, but it avoids racing the inline save.

## Provenance

These two pieces (the `willAwaitStream` branch and the `addParts` guard) are lifted from the open PR #259 ("Add httpStreamText and useHttpStream"), which bundles them with a larger HTTP streaming surface (~2,800 LOC across 21 files). This PR cherry-picks just the bug fix so #265 can ship independently of that feature work — which is also currently blocked on merge conflicts with `main`.

## Notes for reviewers

- **Minor behavioral nuance worth knowing:** with the new `addParts` guard, delta chunks emitted by the model after `onStepFinish` fires but before `consumeStream` has finished pumping them are silently dropped on the `returnImmediately` path. The persisted **message** is unaffected — it carries the complete final-step text via `call.save({step})`. A UI subscribed to live deltas could see slightly-truncated streaming content until it reconciles against the saved message, but no canonical data is lost.
- The fix preserves the #181 atomic-finish guarantee for the original path (when we do await stream consumption).
- The full HTTP streaming PR #259 should still land for its other improvements, but is intentionally out of scope here.

## Test plan

- [x] New regression test `src/client/streamText.test.ts` reproduces the issue: calls `streamText` with `returnImmediately: true`, drains the result, then asserts (a) a persisted assistant message exists with the model's text and (b) no stream is left in `"streaming"` status.
- [x] Test fails on `main` with `expected 0 to be greater than 0` (no assistant message persisted).
- [x] Test passes with the fix applied.
- [x] `npm run lint` clean.
- [x] `npx tsc --noEmit` clean.
- [x] Full vitest suite: 257/257 unit tests pass. (The 3 `example/convex/*.test.ts` failures are pre-existing on `main` — they need `npm run build` to populate `dist/` first; unrelated to this change.)