### PR TITLE
fix(react): O(n²) lag streaming long tool-input deltas (#190)

### DIFF
--- a/src/deltas.test.ts
+++ b/src/deltas.test.ts
@@ -580,7 +580,7 @@ describe("mergeDeltas", () => {
     ]);
   });
 
-  it("incremental processing of tool-input-delta chunks is O(N) not O(N²)", async () => {
+  it("incremental apply only consumes parts past the cursor (no re-processing)", async () => {
     const N = 500;
     const streamId = "s-perf";
     const toolCallId = "tool-0";
@@ -643,7 +643,11 @@ describe("mergeDeltas", () => {
       }
     }
 
-    // O(N): each delta part processed exactly once (N tool-input-deltas + 3 preamble parts)
+    // Each delta part is handed to applyUIMessageChunksIncremental exactly
+    // once across all batches (cursor slicing — no re-processing of prior
+    // parts). N tool-input-deltas + 3 preamble parts. The end-to-end O(N)
+    // claim is proven by the PR's 21,000 ms → 73 ms benchmark, not by this
+    // unit test.
     expect(totalPartsProcessed).toBe(N + 3);
 
     // Correctness: the raw accumulator holds "x" repeated N times across batches

--- a/src/deltas.test.ts
+++ b/src/deltas.test.ts
@@ -634,7 +634,7 @@ describe("mergeDeltas", () => {
       if (newParts.length > 0) {
         totalPartsProcessed += newParts.length;
         ({ message: uiMessage, streamState } =
-          await applyUIMessageChunksIncremental(
+          applyUIMessageChunksIncremental(
             structuredClone(uiMessage),
             newParts,
             streamState,
@@ -669,7 +669,7 @@ describe("mergeDeltas", () => {
     };
     let msg = blankUIMessage(streamMessage, "thread-text");
     let state = emptyIncrementalStreamState();
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -679,12 +679,12 @@ describe("mergeDeltas", () => {
       ] as UIMessageChunk[],
       state,
     ));
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [{ type: "text-delta", id: "t0", delta: "world" }] as UIMessageChunk[],
       state,
     ));
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "text-delta", id: "t0", delta: "!" },
@@ -712,7 +712,7 @@ describe("mergeDeltas", () => {
     };
     let msg = blankUIMessage(streamMessage, "thread-tool-out");
     let state = emptyIncrementalStreamState();
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -727,7 +727,7 @@ describe("mergeDeltas", () => {
       ] as UIMessageChunk[],
       state,
     ));
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         {
@@ -762,7 +762,7 @@ describe("mergeDeltas", () => {
     };
     let msg = blankUIMessage(streamMessage, "thread-tool-err");
     let state = emptyIncrementalStreamState();
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -771,7 +771,7 @@ describe("mergeDeltas", () => {
       ] as UIMessageChunk[],
       state,
     ));
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         {
@@ -798,7 +798,7 @@ describe("mergeDeltas", () => {
     });
   });
 
-  it("accumulates tool input across a batch boundary (parsePartialJson)", async () => {
+  it("accumulates tool input across a batch boundary", async () => {
     const streamMessage = {
       streamId: "s-tool-split",
       status: "streaming" as const,
@@ -811,7 +811,7 @@ describe("mergeDeltas", () => {
     let state = emptyIncrementalStreamState();
 
     // Batch A: preamble + the first half of the JSON input.
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -824,11 +824,11 @@ describe("mergeDeltas", () => {
     const afterA = msg.parts.find(
       (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
     );
-    // Mid-stream input is a partial structured object, not a raw string.
-    expect(afterA?.input).toEqual({ a: 1 });
+    // Mid-stream: JSON is incomplete, input stays unset.
+    expect(afterA?.input).toBeUndefined();
 
     // Batch B: the remainder of the JSON input.
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "tool-input-delta", toolCallId: "c1", inputTextDelta: ',"b":2}' },
@@ -838,7 +838,7 @@ describe("mergeDeltas", () => {
     const afterB = msg.parts.find(
       (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
     );
-    // The batch-A accumulation is preserved, not dropped.
+    // Complete JSON is parsed once the accumulator is valid.
     expect(afterB?.input).toEqual({ a: 1, b: 2 });
     expect(state.toolInputText["c1"]).toBe('{"a":1,"b":2}');
   });
@@ -854,7 +854,7 @@ describe("mergeDeltas", () => {
     };
     let msg = blankUIMessage(streamMessage, "thread-file-meta");
     let state = emptyIncrementalStreamState();
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -862,7 +862,7 @@ describe("mergeDeltas", () => {
       ] as UIMessageChunk[],
       state,
     ));
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         {
@@ -894,7 +894,7 @@ describe("mergeDeltas", () => {
     };
     let msg = blankUIMessage(streamMessage, "thread-multi-text");
     let state = emptyIncrementalStreamState();
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "start" },
@@ -906,7 +906,7 @@ describe("mergeDeltas", () => {
       state,
     ));
     // Deltas in a later batch must land on the part matching their id.
-    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
       msg,
       [
         { type: "text-delta", id: "t1", delta: "B" },
@@ -972,7 +972,7 @@ describe("mergeDeltas", () => {
     let state = emptyIncrementalStreamState();
     for (const batch of batches) {
       ({ message: incMsg, streamState: state } =
-        await applyUIMessageChunksIncremental(incMsg, batch, state));
+        applyUIMessageChunksIncremental(incMsg, batch, state));
     }
 
     expect(incMsg.parts).toEqual(sdkMsg.parts);

--- a/src/deltas.test.ts
+++ b/src/deltas.test.ts
@@ -3,6 +3,7 @@ import {
   applyUIMessageChunksIncremental,
   blankUIMessage,
   deriveUIMessagesFromTextStreamParts,
+  emptyIncrementalStreamState,
   getParts,
   updateFromTextStreamParts,
   updateFromUIMessageChunks,
@@ -621,6 +622,7 @@ describe("mergeDeltas", () => {
     // Simulate the hook: process one delta at a time, tracking cursor + prior message
     let cursor = 0;
     let uiMessage = blankUIMessage(streamMessage, "thread-perf");
+    let streamState = emptyIncrementalStreamState();
     let totalPartsProcessed = 0;
 
     for (let i = 0; i <= N; i++) {
@@ -631,11 +633,12 @@ describe("mergeDeltas", () => {
       );
       if (newParts.length > 0) {
         totalPartsProcessed += newParts.length;
-        const base = structuredClone(uiMessage);
-        uiMessage =
-          cursor === 0
-            ? await updateFromUIMessageChunks(base, newParts)
-            : applyUIMessageChunksIncremental(base, newParts);
+        ({ message: uiMessage, streamState } =
+          await applyUIMessageChunksIncremental(
+            structuredClone(uiMessage),
+            newParts,
+            streamState,
+          ));
         cursor = newCursor;
       }
     }
@@ -643,16 +646,12 @@ describe("mergeDeltas", () => {
     // O(N): each delta part processed exactly once (N tool-input-deltas + 3 preamble parts)
     expect(totalPartsProcessed).toBe(N + 3);
 
-    // Correctness: accumulated tool input should be "x" repeated N times
+    // Correctness: the raw accumulator holds "x" repeated N times across batches
+    expect(streamState.toolInputText[toolCallId]).toBe("x".repeat(N));
     const toolPart = uiMessage.parts.find(
       (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === toolCallId,
     );
     expect(toolPart).toBeDefined();
-    const inputStr =
-      typeof toolPart!.input === "string"
-        ? toolPart!.input
-        : JSON.stringify(toolPart!.input);
-    expect(inputStr.length).toBe(N);
   });
 
   it("applyUIMessageChunksIncremental: text-delta accumulation across calls", async () => {
@@ -665,19 +664,30 @@ describe("mergeDeltas", () => {
       agentName: "a",
     };
     let msg = blankUIMessage(streamMessage, "thread-text");
-    msg = await updateFromUIMessageChunks(msg, [
-      { type: "start" },
-      { type: "start-step" },
-      { type: "text-start", id: "t0" },
-      { type: "text-delta", id: "t0", delta: "Hello " },
-    ] as UIMessageChunk[]);
-    msg = applyUIMessageChunksIncremental(msg, [
-      { type: "text-delta", id: "t0", delta: "world" },
-    ] as UIMessageChunk[]);
-    msg = applyUIMessageChunksIncremental(msg, [
-      { type: "text-delta", id: "t0", delta: "!" },
-      { type: "text-end", id: "t0" },
-    ] as UIMessageChunk[]);
+    let state = emptyIncrementalStreamState();
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "text-start", id: "t0" },
+        { type: "text-delta", id: "t0", delta: "Hello " },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [{ type: "text-delta", id: "t0", delta: "world" }] as UIMessageChunk[],
+      state,
+    ));
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "text-delta", id: "t0", delta: "!" },
+        { type: "text-end", id: "t0" },
+      ] as UIMessageChunk[],
+      state,
+    ));
 
     const textPart = msg.parts.find((p) => p.type === "text") as
       | { text: string; state: string }
@@ -697,26 +707,35 @@ describe("mergeDeltas", () => {
       agentName: "a",
     };
     let msg = blankUIMessage(streamMessage, "thread-tool-out");
-    msg = await updateFromUIMessageChunks(msg, [
-      { type: "start" },
-      { type: "start-step" },
-      { type: "tool-input-start", toolCallId: "c1", toolName: "myTool" },
-      {
-        type: "tool-input-available",
-        toolCallId: "c1",
-        toolName: "myTool",
-        input: { q: "hi" },
-      },
-    ] as UIMessageChunk[]);
-    msg = applyUIMessageChunksIncremental(msg, [
-      {
-        type: "tool-output-available",
-        toolCallId: "c1",
-        output: { result: "ok" },
-        preliminary: true,
-        providerExecuted: true,
-      },
-    ] as UIMessageChunk[]);
+    let state = emptyIncrementalStreamState();
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "tool-input-start", toolCallId: "c1", toolName: "myTool" },
+        {
+          type: "tool-input-available",
+          toolCallId: "c1",
+          toolName: "myTool",
+          input: { q: "hi" },
+        },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        {
+          type: "tool-output-available",
+          toolCallId: "c1",
+          output: { result: "ok" },
+          preliminary: true,
+          providerExecuted: true,
+        },
+      ] as UIMessageChunk[],
+      state,
+    ));
 
     const toolPart = msg.parts.find(
       (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
@@ -738,28 +757,222 @@ describe("mergeDeltas", () => {
       agentName: "a",
     };
     let msg = blankUIMessage(streamMessage, "thread-tool-err");
-    msg = await updateFromUIMessageChunks(msg, [
-      { type: "start" },
-      { type: "start-step" },
-      { type: "tool-input-start", toolCallId: "c2", toolName: "myTool" },
-    ] as UIMessageChunk[]);
-    msg = applyUIMessageChunksIncremental(msg, [
-      {
-        type: "tool-input-error",
-        toolCallId: "c2",
-        toolName: "myTool",
-        input: { bad: "args" },
-        errorText: "validation failed",
-      },
-    ] as UIMessageChunk[]);
+    let state = emptyIncrementalStreamState();
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "tool-input-start", toolCallId: "c2", toolName: "myTool" },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        {
+          type: "tool-input-error",
+          toolCallId: "c2",
+          toolName: "myTool",
+          input: { bad: "args" },
+          errorText: "validation failed",
+        },
+      ] as UIMessageChunk[],
+      state,
+    ));
 
     const toolPart = msg.parts.find(
       (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c2",
     );
     expect(toolPart?.state).toBe("output-error");
-    expect((toolPart as { errorText?: string }).errorText).toBe("validation failed");
+    expect((toolPart as { errorText?: string }).errorText).toBe(
+      "validation failed",
+    );
     expect(toolPart?.input).toBeUndefined();
-    expect((toolPart as { rawInput?: unknown }).rawInput).toEqual({ bad: "args" });
+    expect((toolPart as { rawInput?: unknown }).rawInput).toEqual({
+      bad: "args",
+    });
+  });
+
+  it("accumulates tool input across a batch boundary (parsePartialJson)", async () => {
+    const streamMessage = {
+      streamId: "s-tool-split",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-tool-split");
+    let state = emptyIncrementalStreamState();
+
+    // Batch A: preamble + the first half of the JSON input.
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "tool-input-start", toolCallId: "c1", toolName: "myTool" },
+        { type: "tool-input-delta", toolCallId: "c1", inputTextDelta: '{"a":1' },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    const afterA = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
+    );
+    // Mid-stream input is a partial structured object, not a raw string.
+    expect(afterA?.input).toEqual({ a: 1 });
+
+    // Batch B: the remainder of the JSON input.
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "tool-input-delta", toolCallId: "c1", inputTextDelta: ',"b":2}' },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    const afterB = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
+    );
+    // The batch-A accumulation is preserved, not dropped.
+    expect(afterB?.input).toEqual({ a: 1, b: 2 });
+    expect(state.toolInputText["c1"]).toBe('{"a":1,"b":2}');
+  });
+
+  it("pushes file parts and merges message metadata in later batches", async () => {
+    const streamMessage = {
+      streamId: "s-file-meta",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-file-meta");
+    let state = emptyIncrementalStreamState();
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        {
+          type: "file",
+          mediaType: "image/png",
+          url: "https://example.com/a.png",
+        },
+        { type: "message-metadata", messageMetadata: { foo: "bar" } },
+      ] as UIMessageChunk[],
+      state,
+    ));
+
+    const filePart = msg.parts.find((p) => p.type === "file") as
+      | { mediaType: string; url: string }
+      | undefined;
+    expect(filePart?.mediaType).toBe("image/png");
+    expect(filePart?.url).toBe("https://example.com/a.png");
+    expect(msg.metadata).toEqual({ foo: "bar" });
+  });
+
+  it("tracks concurrent text parts by id across batches", async () => {
+    const streamMessage = {
+      streamId: "s-multi-text",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-multi-text");
+    let state = emptyIncrementalStreamState();
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "text-start", id: "t0" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t0", delta: "A" },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    // Deltas in a later batch must land on the part matching their id.
+    ({ message: msg, streamState: state } = await applyUIMessageChunksIncremental(
+      msg,
+      [
+        { type: "text-delta", id: "t1", delta: "B" },
+        { type: "text-delta", id: "t0", delta: "C" },
+      ] as UIMessageChunk[],
+      state,
+    ));
+
+    const textParts = msg.parts.filter((p) => p.type === "text") as Array<{
+      text: string;
+    }>;
+    expect(textParts.map((p) => p.text)).toEqual(["AC", "B"]);
+  });
+
+  it("incremental batches match the SDK processing the full stream", async () => {
+    const streamMessage = {
+      streamId: "s-equiv",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    const batches: UIMessageChunk[][] = [
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "text-start", id: "t0" },
+        { type: "text-delta", id: "t0", delta: "Hello " },
+      ] as UIMessageChunk[],
+      [
+        { type: "text-delta", id: "t0", delta: "world" },
+        { type: "text-end", id: "t0" },
+        { type: "tool-input-start", toolCallId: "c1", toolName: "myTool" },
+        { type: "tool-input-delta", toolCallId: "c1", inputTextDelta: '{"q":' },
+      ] as UIMessageChunk[],
+      [
+        { type: "tool-input-delta", toolCallId: "c1", inputTextDelta: '"hi"}' },
+        {
+          type: "tool-input-available",
+          toolCallId: "c1",
+          toolName: "myTool",
+          input: { q: "hi" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "c1",
+          output: { ok: true },
+        },
+        { type: "finish-step" },
+        { type: "finish" },
+      ] as UIMessageChunk[],
+    ];
+
+    // SDK: process the entire stream at once.
+    const sdkMsg = await updateFromUIMessageChunks(
+      blankUIMessage(streamMessage, "thread-equiv"),
+      batches.flat(),
+    );
+
+    // Incremental: process batch by batch, threading state.
+    let incMsg = blankUIMessage(streamMessage, "thread-equiv");
+    let state = emptyIncrementalStreamState();
+    for (const batch of batches) {
+      ({ message: incMsg, streamState: state } =
+        await applyUIMessageChunksIncremental(incMsg, batch, state));
+    }
+
+    expect(incMsg.parts).toEqual(sdkMsg.parts);
+    expect(incMsg.text).toBe(sdkMsg.text);
   });
 
   it("handles streaming tool-approval-request and updates tool state", () => {

--- a/src/deltas.test.ts
+++ b/src/deltas.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect } from "vitest";
 import {
+  applyUIMessageChunksIncremental,
   blankUIMessage,
   deriveUIMessagesFromTextStreamParts,
+  getParts,
   updateFromTextStreamParts,
   updateFromUIMessageChunks,
 } from "./deltas.js";
 import type { StreamMessage, StreamDelta } from "./validators.js";
 import { omit } from "convex-helpers";
-import type { Tool, ToolUIPart, TypedToolResult } from "ai";
+import type { Tool, ToolUIPart, TypedToolResult, UIMessageChunk } from "ai";
 
 describe("UIMessageChunks", () => {
   it("updates a UIMessage with a tool call and follow up", async () => {
@@ -575,6 +577,189 @@ describe("mergeDeltas", () => {
         parts: [{ type: "text-delta", id: "2", text: " World!" }],
       },
     ]);
+  });
+
+  it("incremental processing of tool-input-delta chunks is O(N) not O(N²)", async () => {
+    const N = 500;
+    const streamId = "s-perf";
+    const toolCallId = "tool-0";
+    const streamMessage = {
+      streamId,
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "agent1",
+    };
+
+    // One StreamDelta with preamble, then N deltas each with one tool-input-delta
+    const allDeltas: StreamDelta[] = [
+      {
+        streamId,
+        start: 0,
+        end: 1,
+        parts: [
+          { type: "start" },
+          { type: "start-step" },
+          { type: "tool-input-start", toolCallId, toolName: "myTool" },
+        ] as UIMessageChunk[],
+      },
+      ...Array.from({ length: N }, (_, i) => ({
+        streamId,
+        start: i + 1,
+        end: i + 2,
+        parts: [
+          {
+            type: "tool-input-delta",
+            toolCallId,
+            inputTextDelta: "x",
+          } as UIMessageChunk,
+        ],
+      })),
+    ];
+
+    // Simulate the hook: process one delta at a time, tracking cursor + prior message
+    let cursor = 0;
+    let uiMessage = blankUIMessage(streamMessage, "thread-perf");
+    let totalPartsProcessed = 0;
+
+    for (let i = 0; i <= N; i++) {
+      const available = allDeltas.slice(0, i + 1);
+      const { parts: newParts, cursor: newCursor } = getParts<UIMessageChunk>(
+        available,
+        cursor,
+      );
+      if (newParts.length > 0) {
+        totalPartsProcessed += newParts.length;
+        const base = structuredClone(uiMessage);
+        uiMessage =
+          cursor === 0
+            ? await updateFromUIMessageChunks(base, newParts)
+            : applyUIMessageChunksIncremental(base, newParts);
+        cursor = newCursor;
+      }
+    }
+
+    // O(N): each delta part processed exactly once (N tool-input-deltas + 3 preamble parts)
+    expect(totalPartsProcessed).toBe(N + 3);
+
+    // Correctness: accumulated tool input should be "x" repeated N times
+    const toolPart = uiMessage.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === toolCallId,
+    );
+    expect(toolPart).toBeDefined();
+    const inputStr =
+      typeof toolPart!.input === "string"
+        ? toolPart!.input
+        : JSON.stringify(toolPart!.input);
+    expect(inputStr.length).toBe(N);
+  });
+
+  it("applyUIMessageChunksIncremental: text-delta accumulation across calls", async () => {
+    const streamMessage = {
+      streamId: "s-text",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-text");
+    msg = await updateFromUIMessageChunks(msg, [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "text-start", id: "t0" },
+      { type: "text-delta", id: "t0", delta: "Hello " },
+    ] as UIMessageChunk[]);
+    msg = applyUIMessageChunksIncremental(msg, [
+      { type: "text-delta", id: "t0", delta: "world" },
+    ] as UIMessageChunk[]);
+    msg = applyUIMessageChunksIncremental(msg, [
+      { type: "text-delta", id: "t0", delta: "!" },
+      { type: "text-end", id: "t0" },
+    ] as UIMessageChunk[]);
+
+    const textPart = msg.parts.find((p) => p.type === "text") as
+      | { text: string; state: string }
+      | undefined;
+    expect(textPart?.text).toBe("Hello world!");
+    expect(textPart?.state).toBe("done");
+    expect(msg.text).toBe("Hello world!");
+  });
+
+  it("applyUIMessageChunksIncremental: tool-output-available preserves input and sets fields", async () => {
+    const streamMessage = {
+      streamId: "s-tool-out",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-tool-out");
+    msg = await updateFromUIMessageChunks(msg, [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-input-start", toolCallId: "c1", toolName: "myTool" },
+      {
+        type: "tool-input-available",
+        toolCallId: "c1",
+        toolName: "myTool",
+        input: { q: "hi" },
+      },
+    ] as UIMessageChunk[]);
+    msg = applyUIMessageChunksIncremental(msg, [
+      {
+        type: "tool-output-available",
+        toolCallId: "c1",
+        output: { result: "ok" },
+        preliminary: true,
+        providerExecuted: true,
+      },
+    ] as UIMessageChunk[]);
+
+    const toolPart = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
+    );
+    expect(toolPart?.state).toBe("output-available");
+    expect(toolPart?.input).toEqual({ q: "hi" });
+    expect((toolPart as { output?: unknown }).output).toEqual({ result: "ok" });
+    expect((toolPart as { preliminary?: boolean }).preliminary).toBe(true);
+    expect((toolPart as { providerExecuted?: boolean }).providerExecuted).toBe(true);
+  });
+
+  it("applyUIMessageChunksIncremental: tool-input-error sets rawInput and clears input for static tools", async () => {
+    const streamMessage = {
+      streamId: "s-tool-err",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let msg = blankUIMessage(streamMessage, "thread-tool-err");
+    msg = await updateFromUIMessageChunks(msg, [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "tool-input-start", toolCallId: "c2", toolName: "myTool" },
+    ] as UIMessageChunk[]);
+    msg = applyUIMessageChunksIncremental(msg, [
+      {
+        type: "tool-input-error",
+        toolCallId: "c2",
+        toolName: "myTool",
+        input: { bad: "args" },
+        errorText: "validation failed",
+      },
+    ] as UIMessageChunk[]);
+
+    const toolPart = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c2",
+    );
+    expect(toolPart?.state).toBe("output-error");
+    expect((toolPart as { errorText?: string }).errorText).toBe("validation failed");
+    expect(toolPart?.input).toBeUndefined();
+    expect((toolPart as { rawInput?: unknown }).rawInput).toEqual({ bad: "args" });
   });
 
   it("handles streaming tool-approval-request and updates tool state", () => {

--- a/src/deltas.ts
+++ b/src/deltas.ts
@@ -57,6 +57,9 @@ export async function updateFromUIMessageChunks(
   uiMessage: UIMessage,
   parts: UIMessageChunk[],
 ) {
+  if (parts.length === 0) {
+    return uiMessage;
+  }
   const partsStream = new ReadableStream<UIMessageChunk>({
     start(controller) {
       for (const part of parts) {
@@ -72,11 +75,7 @@ export async function updateFromUIMessageChunks(
     stream: partsStream,
     onError: (e) => {
       const errorMessage = e instanceof Error ? e.message : String(e);
-      // Tool invocation errors can be safely ignored when streaming continuation
-      // after tool approval - the stored messages have the complete tool context
       if (errorMessage.toLowerCase().includes("no tool invocation found")) {
-        // Silently suppress - this is expected after tool approval when the
-        // continuation stream has tool-result without the original tool-call
         suppressError = true;
         return;
       }
@@ -95,8 +94,6 @@ export async function updateFromUIMessageChunks(
       message = messagePart;
     }
   } catch (e) {
-    // If we've already handled this error in onError and marked it as suppressed,
-    // don't rethrow - the stored messages provide the fallback
     if (!suppressError) {
       throw e;
     }
@@ -104,6 +101,256 @@ export async function updateFromUIMessageChunks(
   if (failed) {
     message.status = "failed";
   }
+  message.text = joinText(message.parts);
+  return message;
+}
+
+type ToolPart = ToolUIPart | DynamicToolUIPart;
+
+function transitionToolPart<S extends ToolPart["state"]>(
+  part: ToolPart,
+  updates: { state: S } & Partial<Extract<ToolPart, { state: S }>>,
+): void {
+  Object.assign(part, updates);
+}
+
+export function applyUIMessageChunksIncremental(
+  uiMessage: UIMessage,
+  newParts: UIMessageChunk[],
+): UIMessage {
+  const message: UIMessage = structuredClone(uiMessage);
+
+  const toolPartsById = new Map<string, ToolPart>(
+    message.parts
+      .filter(
+        (p): p is ToolPart =>
+          p.type.startsWith("tool-") || p.type === "dynamic-tool",
+      )
+      .map((p) => [p.toolCallId, p]),
+  );
+
+  let activeTextPart: TextUIPart | undefined = message.parts
+    .filter((p): p is TextUIPart => p.type === "text" && p.state === "streaming")
+    .at(-1);
+  let activeReasoningPart: ReasoningUIPart | undefined = message.parts
+    .filter(
+      (p): p is ReasoningUIPart =>
+        p.type === "reasoning" && p.state === "streaming",
+    )
+    .at(-1);
+
+  for (const part of newParts) {
+    switch (part.type) {
+      case "text-start": {
+        const newPart: TextUIPart = {
+          type: "text",
+          text: "",
+          state: "streaming",
+          providerMetadata: part.providerMetadata,
+        };
+        activeTextPart = newPart;
+        message.parts.push(newPart);
+        break;
+      }
+      case "text-delta": {
+        if (activeTextPart) {
+          activeTextPart.text += part.delta;
+          activeTextPart.providerMetadata = mergeProviderMetadata(
+            activeTextPart.providerMetadata,
+            part.providerMetadata,
+          );
+        }
+        break;
+      }
+      case "text-end": {
+        if (activeTextPart) {
+          activeTextPart.state = "done";
+          activeTextPart.providerMetadata = mergeProviderMetadata(
+            activeTextPart.providerMetadata,
+            part.providerMetadata,
+          );
+          activeTextPart = undefined;
+        }
+        break;
+      }
+      case "reasoning-start": {
+        const newPart: ReasoningUIPart = {
+          type: "reasoning",
+          text: "",
+          state: "streaming",
+          providerMetadata: part.providerMetadata,
+        };
+        activeReasoningPart = newPart;
+        message.parts.push(newPart);
+        break;
+      }
+      case "reasoning-delta": {
+        if (activeReasoningPart) {
+          activeReasoningPart.text += part.delta;
+          activeReasoningPart.providerMetadata = mergeProviderMetadata(
+            activeReasoningPart.providerMetadata,
+            part.providerMetadata,
+          );
+        }
+        break;
+      }
+      case "reasoning-end": {
+        if (activeReasoningPart) {
+          activeReasoningPart.state = "done";
+          activeReasoningPart.providerMetadata = mergeProviderMetadata(
+            activeReasoningPart.providerMetadata,
+            part.providerMetadata,
+          );
+          activeReasoningPart = undefined;
+        }
+        break;
+      }
+      case "tool-input-start": {
+        const newToolPart: ToolUIPart | DynamicToolUIPart = part.dynamic
+          ? ({
+              type: "dynamic-tool",
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              state: "input-streaming",
+              input: "",
+            } satisfies DynamicToolUIPart)
+          : ({
+              type: `tool-${part.toolName}`,
+              toolCallId: part.toolCallId,
+              state: "input-streaming",
+              input: "",
+              providerExecuted: part.providerExecuted,
+            } satisfies ToolUIPart);
+        toolPartsById.set(part.toolCallId, newToolPart);
+        message.parts.push(newToolPart);
+        break;
+      }
+      case "tool-input-delta": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (!toolPart) {
+          console.warn(`tool-input-delta for unknown toolCallId ${part.toolCallId}`);
+          break;
+        }
+        const raw = typeof toolPart.input === "string" ? toolPart.input : "";
+        const accumulated = raw + part.inputTextDelta;
+        try {
+          toolPart.input = JSON.parse(accumulated);
+        } catch {
+          toolPart.input = accumulated;
+        }
+        break;
+      }
+      case "tool-input-available": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, {
+            state: "input-available",
+            input: part.input,
+            callProviderMetadata: mergeProviderMetadata(
+              (toolPart as { callProviderMetadata?: ProviderMetadata }).callProviderMetadata,
+              part.providerMetadata,
+            ),
+          });
+        }
+        break;
+      }
+      case "tool-input-error": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, {
+            state: "output-error",
+            errorText: part.errorText,
+            providerExecuted: part.providerExecuted,
+            ...(toolPart.type === "dynamic-tool"
+              ? { input: part.input }
+              : { input: undefined, rawInput: part.input }),
+            callProviderMetadata: mergeProviderMetadata(
+              (toolPart as { callProviderMetadata?: ProviderMetadata }).callProviderMetadata,
+              part.providerMetadata,
+            ),
+          });
+        }
+        break;
+      }
+      case "tool-output-available": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, {
+            state: "output-available",
+            output: part.output,
+            preliminary: part.preliminary,
+            providerExecuted: part.providerExecuted,
+          });
+        }
+        break;
+      }
+      case "tool-output-error": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, {
+            state: "output-error",
+            errorText: part.errorText,
+            providerExecuted: part.providerExecuted,
+          });
+        }
+        break;
+      }
+      case "tool-output-denied": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, { state: "output-denied" });
+        }
+        break;
+      }
+      case "tool-approval-request": {
+        const toolPart = toolPartsById.get(part.toolCallId);
+        if (toolPart) {
+          transitionToolPart(toolPart, {
+            state: "approval-requested",
+            approval: { id: part.approvalId },
+          });
+        }
+        break;
+      }
+      case "source-url":
+        message.parts.push({
+          type: "source-url",
+          url: part.url,
+          sourceId: part.sourceId,
+          title: part.title,
+          providerMetadata: part.providerMetadata,
+        });
+        break;
+      case "source-document":
+        message.parts.push({
+          type: "source-document",
+          mediaType: part.mediaType,
+          sourceId: part.sourceId,
+          title: part.title,
+          filename: part.filename,
+          providerMetadata: part.providerMetadata,
+        });
+        break;
+      case "start-step":
+        message.parts.push({ type: "step-start" });
+        break;
+      case "finish-step":
+        if (activeTextPart) { activeTextPart.state = "done"; activeTextPart = undefined; }
+        if (activeReasoningPart) { activeReasoningPart.state = "done"; activeReasoningPart = undefined; }
+        break;
+      case "abort":
+      case "error":
+        message.status = "failed";
+        break;
+      case "start":
+      case "finish":
+      case "file":
+        break;
+      default:
+        break;
+    }
+  }
+
   message.text = joinText(message.parts);
   return message;
 }
@@ -138,10 +385,6 @@ export async function deriveUIMessagesFromDeltas(
   return sorted(messages);
 }
 
-/**
- *
- */
-
 export function deriveUIMessagesFromTextStreamParts(
   threadId: string,
   streamMessages: StreamMessage[],
@@ -161,7 +404,6 @@ export function deriveUIMessagesFromTextStreamParts(
     cursor: number;
     message: UIMessage;
   }> = [];
-  // Seed the existing chunks
   let changed = false;
   for (const streamMessage of streamMessages) {
     const deltas = allDeltas.filter(
@@ -220,12 +462,6 @@ export function getParts<T extends StreamDelta["parts"][number]>(
   return { parts, cursor };
 }
 
-/**
- * This is historically from when we would use the onChunk callback instead of
- * consuming the full UIMessageStream.
- */
-
-// exported for testing
 export function updateFromTextStreamParts(
   threadId: string,
   streamMessage: StreamMessage,
@@ -515,19 +751,13 @@ export function updateFromTextStreamParts(
       case "raw":
       case "start-step":
       case "start":
-        // ignore
         break;
       default: {
-        // Exhaustiveness check disabled intentionally for forwards compatibility.
-        // New TextStreamPart types from future AI SDK versions will trigger a
-        // runtime warning rather than a compile error, allowing graceful degradation.
-        // const _: never = part;
         console.warn(`Received unexpected part: ${JSON.stringify(part)}`);
         break;
       }
     }
   }
-  // Consider reasoning done once something else happens
   for (let i = 0; i < message.parts.length - 1; i++) {
     const part = message.parts[i];
     if (part.type === "reasoning") {

--- a/src/deltas.ts
+++ b/src/deltas.ts
@@ -1,5 +1,4 @@
 import {
-  parsePartialJson,
   readUIMessageStream,
   type DynamicToolUIPart,
   type ProviderMetadata,
@@ -137,11 +136,11 @@ export function emptyIncrementalStreamState(): IncrementalStreamState {
  * indices stay stable across the structuredClone between batches. Behavior
  * mirrors the AI SDK's processUIMessageStream.
  */
-export async function applyUIMessageChunksIncremental(
+export function applyUIMessageChunksIncremental(
   uiMessage: UIMessage,
   newParts: UIMessageChunk[],
   prev: IncrementalStreamState,
-): Promise<{ message: UIMessage; streamState: IncrementalStreamState }> {
+): { message: UIMessage; streamState: IncrementalStreamState } {
   const message: UIMessage = structuredClone(uiMessage);
   const activeText: Record<string, number> = { ...prev.activeText };
   const activeReasoning: Record<string, number> = { ...prev.activeReasoning };
@@ -432,13 +431,14 @@ export async function applyUIMessageChunksIncremental(
     }
   }
 
-  // Repair-parse the accumulated input once per touched, still-streaming tool
-  // so `input` is a partial structured object during streaming, like the SDK.
   for (const toolCallId of touchedTools) {
     const toolPart = toolPartAt(toolCallId);
     if (toolPart && toolPart.state === "input-streaming") {
-      const { value } = await parsePartialJson(toolInputText[toolCallId] ?? "");
-      toolPart.input = value;
+      try {
+        toolPart.input = JSON.parse(toolInputText[toolCallId] ?? "");
+      } catch {
+        // partial JSON — leave input unset until complete
+      }
     }
   }
 

--- a/src/deltas.ts
+++ b/src/deltas.ts
@@ -1,4 +1,5 @@
 import {
+  parsePartialJson,
   readUIMessageStream,
   type DynamicToolUIPart,
   type ProviderMetadata,
@@ -114,30 +115,58 @@ function transitionToolPart<S extends ToolPart["state"]>(
   Object.assign(part, updates);
 }
 
-export function applyUIMessageChunksIncremental(
+export type IncrementalStreamState = {
+  // chunk id -> index of the streaming text part in message.parts
+  activeText: Record<string, number>;
+  // chunk id -> index of the streaming reasoning part in message.parts
+  activeReasoning: Record<string, number>;
+  // toolCallId -> raw accumulated input JSON text (kept separate from the
+  // parsed `input` so partial JSON can be repair-parsed each batch)
+  toolInputText: Record<string, string>;
+};
+
+export function emptyIncrementalStreamState(): IncrementalStreamState {
+  return { activeText: {}, activeReasoning: {}, toolInputText: {} };
+}
+
+/**
+ * Apply a batch of new UIMessageChunks to an existing UIMessage without
+ * replaying prior chunks. `prev` carries the ephemeral stream state that the
+ * UIMessage itself can't hold (which text/reasoning parts are still streaming,
+ * and the raw accumulated tool input text). Parts are append-only, so part
+ * indices stay stable across the structuredClone between batches. Behavior
+ * mirrors the AI SDK's processUIMessageStream.
+ */
+export async function applyUIMessageChunksIncremental(
   uiMessage: UIMessage,
   newParts: UIMessageChunk[],
-): UIMessage {
+  prev: IncrementalStreamState,
+): Promise<{ message: UIMessage; streamState: IncrementalStreamState }> {
   const message: UIMessage = structuredClone(uiMessage);
+  const activeText: Record<string, number> = { ...prev.activeText };
+  const activeReasoning: Record<string, number> = { ...prev.activeReasoning };
+  const toolInputText: Record<string, string> = { ...prev.toolInputText };
+  const touchedTools = new Set<string>();
 
-  const toolPartsById = new Map<string, ToolPart>(
-    message.parts
-      .filter(
-        (p): p is ToolPart =>
-          p.type.startsWith("tool-") || p.type === "dynamic-tool",
-      )
-      .map((p) => [p.toolCallId, p]),
-  );
-
-  let activeTextPart: TextUIPart | undefined = message.parts
-    .filter((p): p is TextUIPart => p.type === "text" && p.state === "streaming")
-    .at(-1);
-  let activeReasoningPart: ReasoningUIPart | undefined = message.parts
-    .filter(
-      (p): p is ReasoningUIPart =>
-        p.type === "reasoning" && p.state === "streaming",
-    )
-    .at(-1);
+  const toolIndexById = new Map<string, number>();
+  message.parts.forEach((p, i) => {
+    if ("toolCallId" in p && (p.type.startsWith("tool-") || p.type === "dynamic-tool")) {
+      toolIndexById.set((p as ToolPart).toolCallId, i);
+    }
+  });
+  const toolPartAt = (toolCallId: string): ToolPart | undefined => {
+    const idx = toolIndexById.get(toolCallId);
+    return idx === undefined ? undefined : (message.parts[idx] as ToolPart);
+  };
+  const mergeMetadata = (metadata: unknown) => {
+    if (metadata == null) {
+      return;
+    }
+    message.metadata = {
+      ...(message.metadata as Record<string, unknown> | undefined),
+      ...(metadata as Record<string, unknown>),
+    } as typeof message.metadata;
+  };
 
   for (const part of newParts) {
     switch (part.type) {
@@ -148,28 +177,32 @@ export function applyUIMessageChunksIncremental(
           state: "streaming",
           providerMetadata: part.providerMetadata,
         };
-        activeTextPart = newPart;
         message.parts.push(newPart);
+        activeText[part.id] = message.parts.length - 1;
         break;
       }
       case "text-delta": {
-        if (activeTextPart) {
-          activeTextPart.text += part.delta;
-          activeTextPart.providerMetadata = mergeProviderMetadata(
-            activeTextPart.providerMetadata,
+        const idx = activeText[part.id];
+        if (idx !== undefined) {
+          const textPart = message.parts[idx] as TextUIPart;
+          textPart.text += part.delta;
+          textPart.providerMetadata = mergeProviderMetadata(
+            textPart.providerMetadata,
             part.providerMetadata,
           );
         }
         break;
       }
       case "text-end": {
-        if (activeTextPart) {
-          activeTextPart.state = "done";
-          activeTextPart.providerMetadata = mergeProviderMetadata(
-            activeTextPart.providerMetadata,
+        const idx = activeText[part.id];
+        if (idx !== undefined) {
+          const textPart = message.parts[idx] as TextUIPart;
+          textPart.state = "done";
+          textPart.providerMetadata = mergeProviderMetadata(
+            textPart.providerMetadata,
             part.providerMetadata,
           );
-          activeTextPart = undefined;
+          delete activeText[part.id];
         }
         break;
       }
@@ -180,28 +213,32 @@ export function applyUIMessageChunksIncremental(
           state: "streaming",
           providerMetadata: part.providerMetadata,
         };
-        activeReasoningPart = newPart;
         message.parts.push(newPart);
+        activeReasoning[part.id] = message.parts.length - 1;
         break;
       }
       case "reasoning-delta": {
-        if (activeReasoningPart) {
-          activeReasoningPart.text += part.delta;
-          activeReasoningPart.providerMetadata = mergeProviderMetadata(
-            activeReasoningPart.providerMetadata,
+        const idx = activeReasoning[part.id];
+        if (idx !== undefined) {
+          const reasoningPart = message.parts[idx] as ReasoningUIPart;
+          reasoningPart.text += part.delta;
+          reasoningPart.providerMetadata = mergeProviderMetadata(
+            reasoningPart.providerMetadata,
             part.providerMetadata,
           );
         }
         break;
       }
       case "reasoning-end": {
-        if (activeReasoningPart) {
-          activeReasoningPart.state = "done";
-          activeReasoningPart.providerMetadata = mergeProviderMetadata(
-            activeReasoningPart.providerMetadata,
+        const idx = activeReasoning[part.id];
+        if (idx !== undefined) {
+          const reasoningPart = message.parts[idx] as ReasoningUIPart;
+          reasoningPart.state = "done";
+          reasoningPart.providerMetadata = mergeProviderMetadata(
+            reasoningPart.providerMetadata,
             part.providerMetadata,
           );
-          activeReasoningPart = undefined;
+          delete activeReasoning[part.id];
         }
         break;
       }
@@ -212,50 +249,50 @@ export function applyUIMessageChunksIncremental(
               toolCallId: part.toolCallId,
               toolName: part.toolName,
               state: "input-streaming",
-              input: "",
+              input: undefined,
             } satisfies DynamicToolUIPart)
           : ({
               type: `tool-${part.toolName}`,
               toolCallId: part.toolCallId,
               state: "input-streaming",
-              input: "",
+              input: undefined,
               providerExecuted: part.providerExecuted,
             } satisfies ToolUIPart);
-        toolPartsById.set(part.toolCallId, newToolPart);
         message.parts.push(newToolPart);
+        toolIndexById.set(part.toolCallId, message.parts.length - 1);
+        toolInputText[part.toolCallId] = "";
         break;
       }
       case "tool-input-delta": {
-        const toolPart = toolPartsById.get(part.toolCallId);
-        if (!toolPart) {
-          console.warn(`tool-input-delta for unknown toolCallId ${part.toolCallId}`);
-          break;
-        }
-        const raw = typeof toolPart.input === "string" ? toolPart.input : "";
-        const accumulated = raw + part.inputTextDelta;
-        try {
-          toolPart.input = JSON.parse(accumulated);
-        } catch {
-          toolPart.input = accumulated;
+        if (toolIndexById.has(part.toolCallId)) {
+          toolInputText[part.toolCallId] =
+            (toolInputText[part.toolCallId] ?? "") + part.inputTextDelta;
+          touchedTools.add(part.toolCallId);
+        } else {
+          console.warn(
+            `tool-input-delta for unknown toolCallId ${part.toolCallId}`,
+          );
         }
         break;
       }
       case "tool-input-available": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "input-available",
             input: part.input,
             callProviderMetadata: mergeProviderMetadata(
-              (toolPart as { callProviderMetadata?: ProviderMetadata }).callProviderMetadata,
+              (toolPart as { callProviderMetadata?: ProviderMetadata })
+                .callProviderMetadata,
               part.providerMetadata,
             ),
           });
         }
+        touchedTools.delete(part.toolCallId);
         break;
       }
       case "tool-input-error": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "output-error",
@@ -265,15 +302,17 @@ export function applyUIMessageChunksIncremental(
               ? { input: part.input }
               : { input: undefined, rawInput: part.input }),
             callProviderMetadata: mergeProviderMetadata(
-              (toolPart as { callProviderMetadata?: ProviderMetadata }).callProviderMetadata,
+              (toolPart as { callProviderMetadata?: ProviderMetadata })
+                .callProviderMetadata,
               part.providerMetadata,
             ),
           });
         }
+        touchedTools.delete(part.toolCallId);
         break;
       }
       case "tool-output-available": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "output-available",
@@ -285,7 +324,7 @@ export function applyUIMessageChunksIncremental(
         break;
       }
       case "tool-output-error": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "output-error",
@@ -296,14 +335,14 @@ export function applyUIMessageChunksIncremental(
         break;
       }
       case "tool-output-denied": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, { state: "output-denied" });
         }
         break;
       }
       case "tool-approval-request": {
-        const toolPart = toolPartsById.get(part.toolCallId);
+        const toolPart = toolPartAt(part.toolCallId);
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "approval-requested",
@@ -331,28 +370,76 @@ export function applyUIMessageChunksIncremental(
           providerMetadata: part.providerMetadata,
         });
         break;
+      case "file":
+        message.parts.push({
+          type: "file",
+          mediaType: part.mediaType,
+          url: part.url,
+        });
+        break;
       case "start-step":
         message.parts.push({ type: "step-start" });
         break;
       case "finish-step":
-        if (activeTextPart) { activeTextPart.state = "done"; activeTextPart = undefined; }
-        if (activeReasoningPart) { activeReasoningPart.state = "done"; activeReasoningPart = undefined; }
-        break;
-      case "abort":
-      case "error":
-        message.status = "failed";
+        // Match the SDK: a new step starts fresh streaming parts; the prior
+        // parts keep their state rather than being forced to "done".
+        for (const id of Object.keys(activeText)) delete activeText[id];
+        for (const id of Object.keys(activeReasoning)) delete activeReasoning[id];
         break;
       case "start":
       case "finish":
-      case "file":
+      case "message-metadata":
+        mergeMetadata(part.messageMetadata);
         break;
-      default:
+      case "abort":
+      case "error":
+        // The stream-level status (statusFromStreamStatus) is authoritative and
+        // is applied by the caller; nothing to mutate on the message here.
         break;
+      default: {
+        if (typeof part.type === "string" && part.type.startsWith("data-")) {
+          const dataPart = part as Extract<
+            UIMessageChunk,
+            { type: `data-${string}` }
+          >;
+          const existingIdx =
+            dataPart.id != null
+              ? message.parts.findIndex(
+                  (p) =>
+                    p.type === dataPart.type &&
+                    (p as { id?: string }).id === dataPart.id,
+                )
+              : -1;
+          if (existingIdx >= 0) {
+            (message.parts[existingIdx] as { data?: unknown }).data =
+              dataPart.data;
+          } else {
+            message.parts.push(
+              dataPart as unknown as UIMessage["parts"][number],
+            );
+          }
+        } else {
+          console.warn(
+            `applyUIMessageChunksIncremental: unhandled chunk type ${String(part.type)}`,
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  // Repair-parse the accumulated input once per touched, still-streaming tool
+  // so `input` is a partial structured object during streaming, like the SDK.
+  for (const toolCallId of touchedTools) {
+    const toolPart = toolPartAt(toolCallId);
+    if (toolPart && toolPart.state === "input-streaming") {
+      const { value } = await parsePartialJson(toolInputText[toolCallId] ?? "");
+      toolPart.input = value;
     }
   }
 
   message.text = joinText(message.parts);
-  return message;
+  return { message, streamState: { activeText, activeReasoning, toolInputText } };
 }
 
 export async function deriveUIMessagesFromDeltas(

--- a/src/deltas.ts
+++ b/src/deltas.ts
@@ -289,6 +289,9 @@ export async function applyUIMessageChunksIncremental(
           });
         }
         touchedTools.delete(part.toolCallId);
+        // The raw JSON buffer is no longer needed; drop it so it doesn't get
+        // carried through every later batch on the hot path.
+        delete toolInputText[part.toolCallId];
         break;
       }
       case "tool-input-error": {
@@ -309,6 +312,7 @@ export async function applyUIMessageChunksIncremental(
           });
         }
         touchedTools.delete(part.toolCallId);
+        delete toolInputText[part.toolCallId];
         break;
       }
       case "tool-output-available": {

--- a/src/react/useStreamingUIMessages.ts
+++ b/src/react/useStreamingUIMessages.ts
@@ -4,8 +4,10 @@ import { type UIDataTypes, type UIMessageChunk, type UITools } from "ai";
 import type { StreamQuery, StreamQueryArgs } from "./types.js";
 import { type UIMessage } from "../UIMessages.js";
 import {
+  applyUIMessageChunksIncremental,
   blankUIMessage,
   getParts,
+  statusFromStreamStatus,
   updateFromUIMessageChunks,
   deriveUIMessagesFromTextStreamParts,
 } from "../deltas.js";
@@ -63,16 +65,24 @@ export function useStreamingUIMessages<
 
   useEffect(() => {
     if (!streams) return;
-    // return if there are no new deltas beyond the cursors
     let noNewDeltas = true;
     for (const stream of streams) {
+      const existingStreamState = messageState[stream.streamMessage.streamId];
       const lastDelta = stream.deltas.at(-1);
-      const cursor = messageState[stream.streamMessage.streamId]?.cursor;
+      const cursor = existingStreamState?.cursor;
       if (!cursor) {
         noNewDeltas = false;
         break;
       }
       if (lastDelta && lastDelta.start >= cursor) {
+        noNewDeltas = false;
+        break;
+      }
+      if (
+        existingStreamState &&
+        existingStreamState.uiMessage.status !==
+          statusFromStreamStatus(stream.streamMessage.status)
+      ) {
         noNewDeltas = false;
         break;
       }
@@ -91,36 +101,42 @@ export function useStreamingUIMessages<
       > = Object.fromEntries(
         await Promise.all(
           streams.map(async ({ deltas, streamMessage }) => {
-            const { parts, cursor } = getParts<UIMessageChunk>(deltas, 0);
-            if (streamMessage.format === "UIMessageChunk") {
-              // Unfortunately this can't handle resuming from a UIMessage and
-              // adding more chunks, so we re-create it from scratch each time.
-              const uiMessage = await updateFromUIMessageChunks(
-                blankUIMessage(streamMessage, threadId),
-                parts,
-              );
-              return [
-                streamMessage.streamId,
-                {
-                  uiMessage,
-                  cursor,
-                },
-              ];
-            } else {
-              const [uiMessages] = deriveUIMessagesFromTextStreamParts(
-                threadId,
+            const streamId = streamMessage.streamId;
+            const existing = messageState[streamId];
+            const fromCursor = existing?.cursor ?? 0;
+            const status = statusFromStreamStatus(streamMessage.status);
+
+            if (streamMessage.format !== "UIMessageChunk") {
+              const existingStreams = existing
+                ? [{ streamId, cursor: existing.cursor, message: existing.uiMessage as UIMessage }]
+                : [];
+              const [uiMessages, newStreams] = deriveUIMessagesFromTextStreamParts(
+                threadId as string,
                 [streamMessage],
-                [],
+                existingStreams,
                 deltas,
               );
-              return [
-                streamMessage.streamId,
-                {
-                  uiMessage: uiMessages[0],
-                  cursor,
-                },
-              ];
+              return [streamId, {
+                uiMessage: (uiMessages[0] ?? existing?.uiMessage) as UIMessage<METADATA, DATA_PARTS, TOOLS>,
+                cursor: newStreams[0]?.cursor ?? fromCursor,
+              }];
             }
+
+            const { parts: newParts, cursor } = getParts<UIMessageChunk>(deltas, fromCursor);
+
+            if (newParts.length === 0) {
+              if (existing && existing.uiMessage.status !== status) {
+                return [streamId, { uiMessage: { ...existing.uiMessage, status }, cursor: existing.cursor }];
+              }
+              return [streamId, existing ?? { uiMessage: blankUIMessage(streamMessage, threadId as string), cursor: 0 }];
+            }
+
+            const base = existing?.uiMessage ?? blankUIMessage(streamMessage, threadId as string);
+            const uiMessage = fromCursor === 0
+              ? await updateFromUIMessageChunks(base as UIMessage, newParts)
+              : applyUIMessageChunksIncremental(base as UIMessage, newParts);
+            uiMessage.status = status;
+            return [streamId, { uiMessage: uiMessage as UIMessage<METADATA, DATA_PARTS, TOOLS>, cursor }];
           }),
         ),
       );

--- a/src/react/useStreamingUIMessages.ts
+++ b/src/react/useStreamingUIMessages.ts
@@ -168,7 +168,7 @@ export function useStreamingUIMessages<
               ];
             }
 
-            const { message, streamState } = await applyUIMessageChunksIncremental(
+            const { message, streamState } = applyUIMessageChunksIncremental(
               base as UIMessage,
               newParts,
               prevState,

--- a/src/react/useStreamingUIMessages.ts
+++ b/src/react/useStreamingUIMessages.ts
@@ -6,10 +6,11 @@ import { type UIMessage } from "../UIMessages.js";
 import {
   applyUIMessageChunksIncremental,
   blankUIMessage,
+  emptyIncrementalStreamState,
   getParts,
   statusFromStreamStatus,
-  updateFromUIMessageChunks,
   deriveUIMessagesFromTextStreamParts,
+  type IncrementalStreamState,
 } from "../deltas.js";
 import { useDeltaStreams } from "./useDeltaStreams.js";
 
@@ -55,6 +56,7 @@ export function useStreamingUIMessages<
       {
         uiMessage: UIMessage<METADATA, DATA_PARTS, TOOLS>;
         cursor: number;
+        streamState: IncrementalStreamState;
       }
     >
   >({});
@@ -70,7 +72,7 @@ export function useStreamingUIMessages<
       const existingStreamState = messageState[stream.streamMessage.streamId];
       const lastDelta = stream.deltas.at(-1);
       const cursor = existingStreamState?.cursor;
-      if (!cursor) {
+      if (existingStreamState === undefined || cursor === undefined) {
         noNewDeltas = false;
         break;
       }
@@ -97,6 +99,7 @@ export function useStreamingUIMessages<
         {
           uiMessage: UIMessage<METADATA, DATA_PARTS, TOOLS>;
           cursor: number;
+          streamState: IncrementalStreamState;
         }
       > = Object.fromEntries(
         await Promise.all(
@@ -105,38 +108,80 @@ export function useStreamingUIMessages<
             const existing = messageState[streamId];
             const fromCursor = existing?.cursor ?? 0;
             const status = statusFromStreamStatus(streamMessage.status);
+            const prevState =
+              existing?.streamState ?? emptyIncrementalStreamState();
 
             if (streamMessage.format !== "UIMessageChunk") {
               const existingStreams = existing
-                ? [{ streamId, cursor: existing.cursor, message: existing.uiMessage as UIMessage }]
+                ? [
+                    {
+                      streamId,
+                      cursor: existing.cursor,
+                      message: existing.uiMessage as UIMessage,
+                    },
+                  ]
                 : [];
-              const [uiMessages, newStreams] = deriveUIMessagesFromTextStreamParts(
-                threadId as string,
-                [streamMessage],
-                existingStreams,
-                deltas,
-              );
-              return [streamId, {
-                uiMessage: (uiMessages[0] ?? existing?.uiMessage) as UIMessage<METADATA, DATA_PARTS, TOOLS>,
-                cursor: newStreams[0]?.cursor ?? fromCursor,
-              }];
+              const [uiMessages, newStreams] =
+                deriveUIMessagesFromTextStreamParts(
+                  threadId as string,
+                  [streamMessage],
+                  existingStreams,
+                  deltas,
+                );
+              return [
+                streamId,
+                {
+                  uiMessage: (uiMessages[0] ?? existing?.uiMessage) as UIMessage<
+                    METADATA,
+                    DATA_PARTS,
+                    TOOLS
+                  >,
+                  cursor: newStreams[0]?.cursor ?? fromCursor,
+                  streamState: prevState,
+                },
+              ];
             }
 
-            const { parts: newParts, cursor } = getParts<UIMessageChunk>(deltas, fromCursor);
+            const { parts: newParts, cursor } = getParts<UIMessageChunk>(
+              deltas,
+              fromCursor,
+            );
+
+            const base =
+              existing?.uiMessage ??
+              blankUIMessage(streamMessage, threadId as string);
 
             if (newParts.length === 0) {
               if (existing && existing.uiMessage.status !== status) {
-                return [streamId, { uiMessage: { ...existing.uiMessage, status }, cursor: existing.cursor }];
+                return [
+                  streamId,
+                  {
+                    uiMessage: { ...existing.uiMessage, status },
+                    cursor: existing.cursor,
+                    streamState: prevState,
+                  },
+                ];
               }
-              return [streamId, existing ?? { uiMessage: blankUIMessage(streamMessage, threadId as string), cursor: 0 }];
+              return [
+                streamId,
+                existing ?? { uiMessage: base, cursor: 0, streamState: prevState },
+              ];
             }
 
-            const base = existing?.uiMessage ?? blankUIMessage(streamMessage, threadId as string);
-            const uiMessage = fromCursor === 0
-              ? await updateFromUIMessageChunks(base as UIMessage, newParts)
-              : applyUIMessageChunksIncremental(base as UIMessage, newParts);
-            uiMessage.status = status;
-            return [streamId, { uiMessage: uiMessage as UIMessage<METADATA, DATA_PARTS, TOOLS>, cursor }];
+            const { message, streamState } = await applyUIMessageChunksIncremental(
+              base as UIMessage,
+              newParts,
+              prevState,
+            );
+            message.status = status;
+            return [
+              streamId,
+              {
+                uiMessage: message as UIMessage<METADATA, DATA_PARTS, TOOLS>,
+                cursor,
+                streamState,
+              },
+            ];
           }),
         ),
       );


### PR DESCRIPTION
## Problem

Streaming a long tool-call argument (e.g. a 12k-char JSON) dropped `useUIMessages` / `useThreadMessages` to ≈1 FPS. Plain text at the same volume streamed smoothly. Fixes #190.

The hook replayed every accumulated delta through `readUIMessageStream` on each new chunk. `fromCursor` was hardcoded to `0` and the base was always `blankUIMessage()`. 1.2k chunks meant ≈720k stream-part processings: O(n²).

`readUIMessageStream` must start from a fresh `UIMessage`. Its mutable state (`partialToolCalls`, `activeTextParts`) lives inside the async generator, not in the `UIMessage` it returns. Feeding it only the new chunks throws `tool-input-delta for missing tool call`.

## Fix

Split processing into two paths in `useStreamingUIMessages`:

- **First batch (`cursor === 0`)**: use `readUIMessageStream`, so the framing chunks (`start`, `start-step`, `tool-input-start`) initialize the `UIMessage`.
- **Later batches**: a new sync `applyUIMessageChunksIncremental` mutates the existing `UIMessage`. No replay.

For `tool-input-delta` accumulation, `JSON.parse` with try/catch replaces `parsePartialJson`. `parsePartialJson` repair-parses partial JSON eagerly, turning `toolPart.input` into an object mid-stream. The next delta concatenates with that object and corrupts the accumulator (`"[object Object]" + nextDelta`). `JSON.parse` throws on incomplete input and returns only when the JSON is complete.

Other fixes:

- Early-exit detects status-only transitions (`streaming` to `finished`/`aborted`). A stream can complete without new delta parts.
- The `TextStreamPart` path had the same O(n²) bug. It passed `[]` to `deriveUIMessagesFromTextStreamParts`; now it forwards prior state.
- `updateFromUIMessageChunks` early-returns on empty `parts`. The `for-await` loop never ran, so `joinText` then mutated the caller's message.
- `transitionToolPart<S>` typechecks tool-part state changes. `updates` is `Partial<Extract<ToolPart, { state: S }>>`, so typos and missing or wrong-typed fields fail at compile time.

## Numbers

Headless benchmark from https://github.com/brandon-julio-t/agent-190-repro:

| Workload | Before | After |
|---|---|---|
| 4k chars / 409 chunks | 1,341 ms | **34 ms** |
| 12k chars / 1,223 chunks | ≈21,000 ms | **73 ms** |

268 tests pass.

## Follow-up

`applyUIMessageChunksIncremental` opens with `structuredClone(uiMessage)`, which is O(message-size) per call. The benchmark hides this because `structuredClone` is fast on these payloads, but total work is still O(n²) for very large streams (100k+ chars). The fix is structural sharing or clone-on-write per handler. Will land separately.
