### PR TITLE
refactor `RunQueryCtx` to `QueryCtx` using `Pick`

### DIFF
--- a/src/client/definePlaygroundAPI.ts
+++ b/src/client/definePlaygroundAPI.ts
@@ -6,6 +6,7 @@ import {
   type ApiFromModules,
   type GenericActionCtx,
   type GenericDataModel,
+  type GenericMutationCtx,
   type GenericQueryCtx,
 } from "convex/server";
 import { v } from "convex/values";
@@ -64,7 +65,10 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
     }
   }
 
-  async function validateApiKey(ctx: QueryCtx, apiKey: string) {
+  async function validateApiKey(
+    ctx: QueryCtx | MutationCtx | ActionCtx,
+    apiKey: string,
+  ) {
     await ctx.runQuery(component.apiKeys.validate, { apiKey });
   }
 
@@ -368,3 +372,11 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
 }
 
 type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
+type MutationCtx = Pick<
+  GenericMutationCtx<GenericDataModel>,
+  "runQuery" | "runMutation"
+>;
+type ActionCtx = Pick<
+  GenericActionCtx<GenericDataModel>,
+  "runQuery" | "runMutation" | "runAction"
+>;

--- a/src/client/definePlaygroundAPI.ts
+++ b/src/client/definePlaygroundAPI.ts
@@ -64,7 +64,7 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
     }
   }
 
-  async function validateApiKey(ctx: RunQueryCtx, apiKey: string) {
+  async function validateApiKey(ctx: QueryCtx, apiKey: string) {
     await ctx.runQuery(component.apiKeys.validate, { apiKey });
   }
 
@@ -367,4 +367,4 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
   };
 }
 
-type RunQueryCtx = { runQuery: GenericQueryCtx<GenericDataModel>["runQuery"] };
+type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;


### PR DESCRIPTION
Renames the internal `RunQueryCtx` type to `QueryCtx` and updates its definition to use `Pick` instead of a manually declared interface, aligning it with idiomatic TypeScript patterns for extracting a subset of an existing type.