### PR TITLE
feat(vector): support 2560-dimensional embeddings

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -148,6 +148,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | 1408
               | 1536
               | 2048
+              | 2560
               | 3072
               | 4096;
             model: string;
@@ -4770,6 +4771,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | string
               | string
               | string
+              | string
             >;
           },
           null,
@@ -4792,6 +4794,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | 1408
               | 1536
               | 2048
+              | 2560
               | 3072
               | 4096;
           },
@@ -4811,6 +4814,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | 1408
               | 1536
               | 2048
+              | 2560
               | 3072
               | 4096;
             vectors: Array<{
@@ -4823,6 +4827,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             }>;
           },
           Array<
+            | string
             | string
             | string
             | string
@@ -4853,12 +4858,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | 1408
               | 1536
               | 2048
+              | 2560
               | 3072
               | 4096;
           },
           {
             continueCursor: string;
             ids: Array<
+              | string
               | string
               | string
               | string
@@ -4880,6 +4887,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           {
             vectors: Array<{
               id:
+                | string
                 | string
                 | string
                 | string

--- a/src/component/vector/tables.ts
+++ b/src/component/vector/tables.ts
@@ -68,7 +68,7 @@ export type VectorSchema = SchemaDefinition<
 >;
 
 export const VectorDimensions = [
-  128, 256, 512, 768, 1024, 1408, 1536, 2048, 3072, 4096,
+  128, 256, 512, 768, 1024, 1408, 1536, 2048, 2560, 3072, 4096,
 ] as const;
 export function validateVectorDimension(
   dimension: number,


### PR DESCRIPTION
## Summary

Add `2560` to the vector dimensions supported by the Agent component.

This enables embedding models that return 2560-dimensional vectors, including:

- `perplexity/pplx-embed-v1-4b`
- `perplexity/pplx-embed-context-v1-4b`

## Motivation

The Agent component currently restricts vector dimensions to a predefined
allowlist. Although Convex vector indexes support 2560 dimensions, it is
missing from that list.

As a result, applications cannot use these embedding models at their native
dimension without maintaining a local patch or reducing the embedding size.

## Changes

- Add `2560` to `VectorDimensions`
- Regenerate the Convex component types to include the new dimension

## Testing

- Ran `npm run build:clean`
- Ran `npm run test`
- Ran `npm run lint`
- Ran `npm run typecheck`

I have also been using this change successfully through a local package patch
with `perplexity/pplx-embed-v1-4b`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.