### PR TITLE
feat(streaming): add AI SDK 7 persisted-read compatibility

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -258,6 +258,32 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "reasoning";
                           }
                         | {
+                            data?: string | ArrayBuffer;
+                            mediaType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "reasoning-file";
+                            url?: string;
+                          }
+                        | {
+                            kind: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "custom";
+                          }
+                        | {
                             data: string;
                             providerMetadata?: Record<
                               string,
@@ -281,7 +307,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -297,7 +325,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -476,6 +506,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           }
                         | {
                             approvalId: string;
+                            isAutomatic?: boolean;
                             providerMetadata?: Record<
                               string,
                               Record<string, any>
@@ -484,6 +515,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            signature?: string;
                             toolCallId: string;
                             type: "tool-approval-request";
                           }
@@ -811,6 +843,32 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "reasoning";
                           }
                         | {
+                            data?: string | ArrayBuffer;
+                            mediaType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "reasoning-file";
+                            url?: string;
+                          }
+                        | {
+                            kind: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "custom";
+                          }
+                        | {
                             data: string;
                             providerMetadata?: Record<
                               string,
@@ -834,7 +892,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -850,7 +910,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -1029,6 +1091,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           }
                         | {
                             approvalId: string;
+                            isAutomatic?: boolean;
                             providerMetadata?: Record<
                               string,
                               Record<string, any>
@@ -1037,6 +1100,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            signature?: string;
                             toolCallId: string;
                             type: "tool-approval-request";
                           }
@@ -1400,6 +1464,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "reasoning";
                         }
                       | {
+                          data?: string | ArrayBuffer;
+                          mediaType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "reasoning-file";
+                          url?: string;
+                        }
+                      | {
+                          kind: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "custom";
+                        }
+                      | {
                           data: string;
                           providerMetadata?: Record<
                             string,
@@ -1417,7 +1501,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -1430,7 +1516,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -1596,11 +1684,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                         }
                       | {
                           approvalId: string;
+                          isAutomatic?: boolean;
                           providerMetadata?: Record<
                             string,
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          signature?: string;
                           toolCallId: string;
                           type: "tool-approval-request";
                         }
@@ -1954,6 +2044,32 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "reasoning";
                           }
                         | {
+                            data?: string | ArrayBuffer;
+                            mediaType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "reasoning-file";
+                            url?: string;
+                          }
+                        | {
+                            kind: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "custom";
+                          }
+                        | {
                             data: string;
                             providerMetadata?: Record<
                               string,
@@ -1977,7 +2093,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -1993,7 +2111,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -2172,6 +2292,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           }
                         | {
                             approvalId: string;
+                            isAutomatic?: boolean;
                             providerMetadata?: Record<
                               string,
                               Record<string, any>
@@ -2180,6 +2301,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            signature?: string;
                             toolCallId: string;
                             type: "tool-approval-request";
                           }
@@ -2510,6 +2632,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "reasoning";
                         }
                       | {
+                          data?: string | ArrayBuffer;
+                          mediaType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "reasoning-file";
+                          url?: string;
+                        }
+                      | {
+                          kind: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "custom";
+                        }
+                      | {
                           data: string;
                           providerMetadata?: Record<
                             string,
@@ -2527,7 +2669,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -2540,7 +2684,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -2706,11 +2852,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                         }
                       | {
                           approvalId: string;
+                          isAutomatic?: boolean;
                           providerMetadata?: Record<
                             string,
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          signature?: string;
                           toolCallId: string;
                           type: "tool-approval-request";
                         }
@@ -3028,6 +3176,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "reasoning";
                         }
                       | {
+                          data?: string | ArrayBuffer;
+                          mediaType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "reasoning-file";
+                          url?: string;
+                        }
+                      | {
+                          kind: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "custom";
+                        }
+                      | {
                           data: string;
                           providerMetadata?: Record<
                             string,
@@ -3045,7 +3213,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -3058,7 +3228,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -3224,11 +3396,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                         }
                       | {
                           approvalId: string;
+                          isAutomatic?: boolean;
                           providerMetadata?: Record<
                             string,
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          signature?: string;
                           toolCallId: string;
                           type: "tool-approval-request";
                         }
@@ -3554,6 +3728,32 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "reasoning";
                           }
                         | {
+                            data?: string | ArrayBuffer;
+                            mediaType: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "reasoning-file";
+                            url?: string;
+                          }
+                        | {
+                            kind: string;
+                            providerMetadata?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            providerOptions?: Record<
+                              string,
+                              Record<string, any>
+                            >;
+                            type: "custom";
+                          }
+                        | {
                             data: string;
                             providerMetadata?: Record<
                               string,
@@ -3577,7 +3777,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -3593,7 +3795,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            title?: string;
                             toolCallId: string;
+                            toolMetadata?: Record<string, any>;
                             toolName: string;
                             type: "tool-call";
                           }
@@ -3772,6 +3976,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           }
                         | {
                             approvalId: string;
+                            isAutomatic?: boolean;
                             providerMetadata?: Record<
                               string,
                               Record<string, any>
@@ -3780,6 +3985,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                               string,
                               Record<string, any>
                             >;
+                            signature?: string;
                             toolCallId: string;
                             type: "tool-approval-request";
                           }
@@ -4034,6 +4240,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "reasoning";
                         }
                       | {
+                          data?: string | ArrayBuffer;
+                          mediaType: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "reasoning-file";
+                          url?: string;
+                        }
+                      | {
+                          kind: string;
+                          providerMetadata?: Record<
+                            string,
+                            Record<string, any>
+                          >;
+                          providerOptions?: Record<string, Record<string, any>>;
+                          type: "custom";
+                        }
+                      | {
                           data: string;
                           providerMetadata?: Record<
                             string,
@@ -4051,7 +4277,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -4064,7 +4292,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          title?: string;
                           toolCallId: string;
+                          toolMetadata?: Record<string, any>;
                           toolName: string;
                           type: "tool-call";
                         }
@@ -4230,11 +4460,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                         }
                       | {
                           approvalId: string;
+                          isAutomatic?: boolean;
                           providerMetadata?: Record<
                             string,
                             Record<string, any>
                           >;
                           providerOptions?: Record<string, Record<string, any>>;
+                          signature?: string;
                           toolCallId: string;
                           type: "tool-approval-request";
                         }

--- a/src/streaming/materializePersistedUIMessageChunks.test.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.test.ts
@@ -222,6 +222,7 @@ describe("projectPersistedUIMessageChunks", () => {
               type: "file",
               data: "https://example.com/file.txt",
               mediaType: "text/plain",
+              providerOptions: { openai: { ignored: true } },
             },
           ],
         },
@@ -316,5 +317,167 @@ describe("projectPersistedUIMessageChunks", () => {
         reasoning: "",
       },
     ]);
+  });
+
+  it("round-trips extended UIMessageChunk parts through the same marker", () => {
+    const actual = projectPersistedUIMessageChunks(
+      stream,
+      [
+        {
+          type: "custom",
+          kind: "openai.annotation",
+          providerMetadata: { openai: { annotation: "kept" } },
+        },
+        {
+          type: "reasoning-file",
+          url: "https://example.com/reasoning.pdf",
+          mediaType: "application/pdf",
+        },
+        {
+          type: "tool-input-start",
+          toolCallId: "static-call",
+          toolName: "weather",
+          providerExecuted: true,
+          title: "Weather",
+          toolMetadata: { source: "forecast" },
+          providerMetadata: { openai: { call: "metadata" } },
+        },
+        {
+          type: "tool-input-delta",
+          toolCallId: "static-call",
+          inputTextDelta: '{"city":"Boston"}',
+        },
+        {
+          type: "tool-approval-request",
+          toolCallId: "static-call",
+          approvalId: "approval-1",
+          isAutomatic: true,
+          signature: "signed",
+        },
+        {
+          type: "tool-approval-response",
+          approvalId: "approval-1",
+          approved: false,
+          providerExecuted: true,
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "dynamic-call",
+          toolName: "unknown",
+          dynamic: true,
+          input: { value: 1 },
+        },
+        {
+          type: "tool-approval-request",
+          toolCallId: "dynamic-call",
+          approvalId: "approval-2",
+        },
+        {
+          type: "tool-approval-response",
+          approvalId: "approval-2",
+          approved: false,
+          reason: "denied",
+        },
+        { type: "tool-output-denied", toolCallId: "dynamic-call" },
+      ],
+      { status: "failed" },
+    );
+
+    expect(actual).toMatchObject([
+      {
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "custom",
+              kind: "openai.annotation",
+              providerOptions: { openai: { annotation: "kept" } },
+            },
+            {
+              type: "reasoning-file",
+              url: "https://example.com/reasoning.pdf",
+              mediaType: "application/pdf",
+            },
+            {
+              type: "tool-call",
+              toolCallId: "static-call",
+              toolName: "weather",
+              input: { city: "Boston" },
+              providerExecuted: true,
+              title: "Weather",
+              toolMetadata: { source: "forecast" },
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-1",
+              isAutomatic: true,
+              signature: "signed",
+            },
+            {
+              type: "tool-call",
+              toolCallId: "dynamic-call",
+              toolName: "unknown",
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-2",
+            },
+          ],
+        },
+      },
+      {
+        message: {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-1",
+              approved: false,
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              toolCallId: "static-call",
+              output: { type: "execution-denied" },
+            },
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-2",
+              approved: false,
+              reason: "denied",
+            },
+            {
+              type: "tool-result",
+              toolCallId: "dynamic-call",
+              output: {
+                type: "execution-denied",
+                reason: "denied",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    expect(
+      actual.flatMap((message) =>
+        Array.isArray(message.message.content)
+          ? message.message.content.filter((part) => part.type === "tool-result")
+          : [],
+      ),
+    ).toHaveLength(2);
+    expect(
+      actual.flatMap((message) =>
+        Array.isArray(message.message.content)
+          ? message.message.content.filter(
+              (part) =>
+                part.type === "tool-result" &&
+                part.toolCallId === "dynamic-call",
+            )
+          : [],
+      ),
+    ).toHaveLength(1);
+    for (const message of actual) {
+      expect(validate(vMessageWithMetadataInternal, message)).toBe(true);
+    }
   });
 });

--- a/src/streaming/materializePersistedUIMessageChunks.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.ts
@@ -103,6 +103,8 @@ export function projectPersistedUIMessageChunkParts(
       part.type === "text" ||
       part.type === "reasoning" ||
       part.type === "file" ||
+      part.type === "reasoning-file" ||
+      part.type === "custom" ||
       part.type === "source-url" ||
       part.type === "source-document" ||
       isToolPart(part) ||
@@ -144,6 +146,26 @@ export function projectPersistedUIMessageChunkParts(
           data: part.url,
           ...(part.filename ? { filename: part.filename } : {}),
           mediaType: part.mediaType,
+          ...(part.providerMetadata
+            ? { providerOptions: part.providerMetadata }
+            : {}),
+        });
+      } else if (part.type === "reasoning-file") {
+        assistantContent.push({
+          type: "reasoning-file",
+          url: part.url,
+          mediaType: part.mediaType,
+          ...(part.providerMetadata
+            ? { providerOptions: part.providerMetadata }
+            : {}),
+        });
+      } else if (part.type === "custom") {
+        assistantContent.push({
+          type: "custom",
+          kind: part.kind,
+          ...(part.providerMetadata
+            ? { providerOptions: part.providerMetadata }
+            : {}),
         });
       } else if (isToolPart(part) && part.state !== "input-streaming") {
         const input =
@@ -157,6 +179,8 @@ export function projectPersistedUIMessageChunkParts(
           input,
           args: input,
           providerExecuted: part.providerExecuted,
+          ...(part.title ? { title: part.title } : {}),
+          ...(part.toolMetadata ? { toolMetadata: part.toolMetadata } : {}),
           ...(part.callProviderMetadata
             ? { providerOptions: part.callProviderMetadata }
             : {}),
@@ -166,6 +190,12 @@ export function projectPersistedUIMessageChunkParts(
             type: "tool-approval-request",
             approvalId: part.approval.id,
             toolCallId: part.toolCallId,
+            ...(part.approval.isAutomatic !== undefined
+              ? { isAutomatic: part.approval.isAutomatic }
+              : {}),
+            ...(part.approval.signature
+              ? { signature: part.approval.signature }
+              : {}),
           });
         }
         if (
@@ -199,6 +229,14 @@ export function projectPersistedUIMessageChunkParts(
           reason: part.approval.reason,
           providerExecuted: part.providerExecuted,
         });
+      }
+      if (
+        part.state === "approval-responded" &&
+        part.approval?.approved === false
+      ) {
+        toolContent.push(
+          toolResult(part, "execution-denied", part.approval.reason),
+        );
       }
       if (part.providerExecuted === true) continue;
       if (part.state === "output-denied") {

--- a/src/streaming/persistedUIMessageChunks.test.ts
+++ b/src/streaming/persistedUIMessageChunks.test.ts
@@ -49,4 +49,157 @@ describe("reducePersistedUIMessageChunks", () => {
 
     expect(reduced.state.parts).toEqual([]);
   });
+
+  it("accepts the UIMessageChunk superset with replacement metadata", () => {
+    const reduced = reducePersistedUIMessageChunks(
+      createPersistedUIMessageChunkState(),
+      [
+        { type: "custom", kind: "openai.annotation" },
+        {
+          type: "reasoning-file",
+          url: "https://example.com/reasoning.pdf",
+          mediaType: "application/pdf",
+        },
+        {
+          type: "text-start",
+          id: "text-1",
+          providerMetadata: {
+            openai: { phase: "start", stale: true },
+            anthropic: { stale: true },
+          },
+        },
+        {
+          type: "text-delta",
+          id: "text-1",
+          delta: "answer",
+          providerMetadata: { anthropic: { phase: "delta" } },
+        },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "tool-input-start",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          title: "Old title",
+          providerMetadata: { openai: { phase: "call" } },
+        },
+        {
+          type: "tool-input-error",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          input: "bad",
+          errorText: "invalid",
+          title: "New title",
+          providerMetadata: { openai: { phase: "result" } },
+        },
+      ],
+    );
+
+    expect(reduced.state.parts).toStrictEqual([
+      {
+        type: "custom",
+        kind: "openai.annotation",
+        providerMetadata: undefined,
+      },
+      {
+        type: "reasoning-file",
+        url: "https://example.com/reasoning.pdf",
+        mediaType: "application/pdf",
+        providerMetadata: undefined,
+      },
+      {
+        type: "text",
+        text: "answer",
+        state: "done",
+        providerMetadata: { anthropic: { phase: "delta" } },
+      },
+      {
+        type: "tool-lookup",
+        toolName: undefined,
+        toolCallId: "call-1",
+        state: "output-error",
+        input: undefined,
+        rawInput: "bad",
+        errorText: "invalid",
+        providerExecuted: undefined,
+        callProviderMetadata: { openai: { phase: "call" } },
+        resultProviderMetadata: { openai: { phase: "result" } },
+        title: "New title",
+        toolMetadata: undefined,
+      },
+    ]);
+  });
+
+  it("clears a preliminary tool output when its final result is an error", () => {
+    const reduced = reducePersistedUIMessageChunks(
+      createPersistedUIMessageChunkState(),
+      [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          input: {},
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "call-1",
+          output: { partial: true },
+          preliminary: true,
+        },
+        {
+          type: "tool-output-error",
+          toolCallId: "call-1",
+          errorText: "final failure",
+        },
+      ],
+    );
+
+    expect(reduced.state.parts).toMatchObject([
+      {
+        type: "tool-lookup",
+        state: "output-error",
+        errorText: "final failure",
+      },
+    ]);
+    const part = reduced.state.parts[0] as {
+      output?: unknown;
+      preliminary?: boolean;
+    };
+    expect(part.output).toBeUndefined();
+    expect(part.preliminary).toBeUndefined();
+  });
+
+  it("requires boolean approval responses and stops at orphan continuations", () => {
+    const approvalPrefix = [
+      {
+        type: "tool-input-available",
+        toolCallId: "call-1",
+        toolName: "lookup",
+        input: {},
+      },
+      {
+        type: "tool-approval-request",
+        toolCallId: "call-1",
+        approvalId: "approval-1",
+      },
+    ];
+    expect(() =>
+      reducePersistedUIMessageChunks(createPersistedUIMessageChunkState(), [
+        ...approvalPrefix,
+        {
+          type: "tool-approval-response",
+          approvalId: "approval-1",
+          approved: "yes",
+        },
+      ]),
+    ).toThrow("field approved must be a boolean");
+
+    const orphaned = reducePersistedUIMessageChunks(
+      createPersistedUIMessageChunkState(),
+      [
+        { type: "tool-output-available", toolCallId: "orphan", output: 1 },
+        { type: "text-start", id: "unreachable" },
+      ],
+    );
+    expect(orphaned.state.parts).toEqual([]);
+  });
 });

--- a/src/streaming/persistedUIMessageChunks.ts
+++ b/src/streaming/persistedUIMessageChunks.ts
@@ -38,6 +38,19 @@ export type PersistedFilePart = {
   providerMetadata?: ProviderMetadata;
 };
 
+export type PersistedReasoningFilePart = {
+  type: "reasoning-file";
+  url: string;
+  mediaType: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type PersistedCustomPart = {
+  type: "custom";
+  kind: string;
+  providerMetadata?: ProviderMetadata;
+};
+
 export type PersistedSourcePart =
   | {
       type: "source-url";
@@ -81,6 +94,8 @@ export type PersistedToolPart = {
     id: string;
     approved?: boolean;
     reason?: string;
+    isAutomatic?: boolean;
+    signature?: string;
   };
 };
 
@@ -94,6 +109,8 @@ export type PersistedUIMessagePart =
   | PersistedTextPart
   | PersistedReasoningPart
   | PersistedFilePart
+  | PersistedReasoningFilePart
+  | PersistedCustomPart
   | PersistedSourcePart
   | PersistedToolPart
   | PersistedDataPart
@@ -338,6 +355,8 @@ export function reducePersistedUIMessageChunks(
         Object.assign(part, {
           state: "output-error" as const,
           errorText: stringField(chunk, "errorText"),
+          output: undefined,
+          preliminary: undefined,
           providerExecuted:
             optionalBoolean(chunk.providerExecuted) ?? part.providerExecuted,
           resultProviderMetadata:
@@ -373,9 +392,39 @@ export function reducePersistedUIMessageChunks(
         part.state = "approval-requested";
         part.approval = {
           id: stringField(chunk, "approvalId"),
+          isAutomatic: optionalBoolean(chunk.isAutomatic),
+          signature: optionalString(chunk.signature),
         };
         break;
       }
+      case "tool-approval-response": {
+        const approvalId = stringField(chunk, "approvalId");
+        const part = parts.find(
+          (candidate): candidate is PersistedToolPart =>
+            isToolPart(candidate) && candidate.approval?.id === approvalId,
+        );
+        if (!part) {
+          break chunkLoop;
+        }
+        part.state = "approval-responded";
+        part.approval = {
+          ...part.approval!,
+          approved: booleanField(chunk, "approved"),
+          reason: optionalString(chunk.reason),
+        };
+        part.providerExecuted =
+          optionalBoolean(chunk.providerExecuted) ?? part.providerExecuted;
+        part.callProviderMetadata =
+          providerMetadata(chunk.providerMetadata) ?? part.callProviderMetadata;
+        break;
+      }
+      case "custom":
+        parts.push({
+          type: "custom",
+          kind: stringField(chunk, "kind"),
+          providerMetadata: providerMetadata(chunk.providerMetadata),
+        });
+        break;
       case "source-url":
         parts.push({
           type: "source-url",
@@ -401,6 +450,14 @@ export function reducePersistedUIMessageChunks(
           mediaType: stringField(chunk, "mediaType"),
           url: stringField(chunk, "url"),
           filename: optionalString(chunk.filename),
+          providerMetadata: providerMetadata(chunk.providerMetadata),
+        });
+        break;
+      case "reasoning-file":
+        parts.push({
+          type: "reasoning-file",
+          mediaType: stringField(chunk, "mediaType"),
+          url: stringField(chunk, "url"),
           providerMetadata: providerMetadata(chunk.providerMetadata),
         });
         break;
@@ -528,18 +585,21 @@ const supportedChunkTypes = new Set([
   "reasoning-start",
   "reasoning-delta",
   "reasoning-end",
+  "custom",
   "error",
   "tool-input-start",
   "tool-input-delta",
   "tool-input-available",
   "tool-input-error",
   "tool-approval-request",
+  "tool-approval-response",
   "tool-output-available",
   "tool-output-error",
   "tool-output-denied",
   "source-url",
   "source-document",
   "file",
+  "reasoning-file",
   "start-step",
   "finish-step",
   "start",
@@ -563,6 +623,14 @@ function stringField(record: Record<string, unknown>, field: string): string {
   const value = record[field];
   if (typeof value !== "string") {
     throw new Error(`Persisted UIMessageChunk field ${field} must be a string`);
+  }
+  return value;
+}
+
+function booleanField(record: Record<string, unknown>, field: string): boolean {
+  const value = record[field];
+  if (typeof value !== "boolean") {
+    throw new Error(`Persisted UIMessageChunk field ${field} must be a boolean`);
   }
   return value;
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -73,6 +73,22 @@ export const vReasoningPart = v.object({
   providerMetadata,
 });
 
+export const vReasoningFilePart = v.object({
+  type: v.literal("reasoning-file"),
+  url: v.optional(v.string()),
+  data: v.optional(v.union(v.string(), v.bytes())),
+  mediaType: v.string(),
+  providerOptions,
+  providerMetadata,
+});
+
+export const vCustomContentPart = v.object({
+  type: v.literal("custom"),
+  kind: v.string(),
+  providerOptions,
+  providerMetadata,
+});
+
 export const vRedactedReasoningPart = v.object({
   type: v.literal("redacted-reasoning"),
   data: v.string(),
@@ -127,6 +143,8 @@ export const vToolCallPart = v.union(
     /** @deprecated Use `input` instead. */
     args: v.optional(v.any()),
     providerExecuted: v.optional(v.boolean()),
+    title: v.optional(v.string()),
+    toolMetadata: v.optional(v.record(v.string(), v.any())),
     providerOptions,
     providerMetadata,
   }),
@@ -139,6 +157,8 @@ export const vToolCallPart = v.union(
     args: v.any(),
     input: v.optional(v.any()),
     providerExecuted: v.optional(v.boolean()),
+    title: v.optional(v.string()),
+    toolMetadata: v.optional(v.record(v.string(), v.any())),
     providerOptions,
     providerMetadata,
   }),
@@ -271,6 +291,8 @@ export const vToolApprovalRequest = v.object({
    * ID of the tool call that the approval request is for.
    */
   toolCallId: v.string(),
+  isAutomatic: v.optional(v.boolean()),
+  signature: v.optional(v.string()),
   /** @todo Should we continue to include? */
   providerMetadata,
   /** @todo Should we continue to include? */
@@ -334,6 +356,8 @@ export const vAssistantContent = v.union(
       vTextPart,
       vFilePart,
       vReasoningPart,
+      vReasoningFilePart,
+      vCustomContentPart,
       vRedactedReasoningPart,
       vToolCallPart,
       vToolResultPart,
@@ -383,6 +407,8 @@ export type MessageContentParts =
   | Infer<typeof vImagePart>
   | Infer<typeof vFilePart>
   | Infer<typeof vReasoningPart>
+  | Infer<typeof vReasoningFilePart>
+  | Infer<typeof vCustomContentPart>
   | Infer<typeof vRedactedReasoningPart>
   | Infer<typeof vToolCallPart>
   | Infer<typeof vToolResultPart>

--- a/src/vercel/mapping.test.ts
+++ b/src/vercel/mapping.test.ts
@@ -264,6 +264,22 @@ describe("mapping", () => {
     expect((content as unknown[])[0]).toMatchObject(approvalResponse);
   });
 
+  test("stored reasoning-file URLs survive serialization", async () => {
+    const reasoningFile: SerializedContent = [
+      {
+        type: "reasoning-file",
+        url: "https://example.com/reasoning",
+        mediaType: "text/plain",
+      },
+    ];
+    const { content } = await serializeContent(
+      {} as ActionCtx,
+      {} as AgentComponent,
+      reasoningFile,
+    );
+    expect(content).toEqual(reasoningFile);
+  });
+
   describe("serializeNewMessagesInStep", () => {
     const ctx = {
       runAction: async () => undefined,

--- a/src/vercel/mapping.ts
+++ b/src/vercel/mapping.ts
@@ -26,7 +26,9 @@ import {
   type MessageWithMetadata,
   type Usage,
   type vFilePart,
+  type vCustomContentPart,
   type vImagePart,
+  type vReasoningFilePart,
   type vReasoningPart,
   type vRedactedReasoningPart,
   type vTextPart,
@@ -507,6 +509,9 @@ export async function serializeContent(
             toolCallId: part.toolCallId,
             toolName: part.toolName,
             providerExecuted: part.providerExecuted,
+            title: "title" in part ? part.title : undefined,
+            toolMetadata:
+              "toolMetadata" in part ? part.toolMetadata : undefined,
             ...metadata,
           } satisfies Infer<typeof vToolCallPart>;
         }
@@ -519,6 +524,32 @@ export async function serializeContent(
             text: part.text,
             ...metadata,
           } satisfies Infer<typeof vReasoningPart>;
+        }
+        case "reasoning-file": {
+          if ("url" in part && part.url !== undefined) {
+            return {
+              type: part.type,
+              url: part.url,
+              mediaType: part.mediaType,
+              ...metadata,
+            } satisfies Infer<typeof vReasoningFilePart>;
+          }
+          if (part.data === undefined) {
+            throw new Error("reasoning-file requires data or url");
+          }
+          return {
+            type: part.type,
+            data: serializeDataOrUrl(part.data),
+            mediaType: part.mediaType,
+            ...metadata,
+          } satisfies Infer<typeof vReasoningFilePart>;
+        }
+        case "custom": {
+          return {
+            type: part.type,
+            kind: part.kind,
+            ...metadata,
+          } satisfies Infer<typeof vCustomContentPart>;
         }
         // Not in current generation output, but could be in historical messages
         case "redacted-reasoning": {
@@ -536,6 +567,9 @@ export async function serializeContent(
             type: part.type,
             approvalId: part.approvalId,
             toolCallId: part.toolCallId,
+            isAutomatic:
+              "isAutomatic" in part ? part.isAutomatic : undefined,
+            signature: "signature" in part ? part.signature : undefined,
             ...metadata,
           } satisfies Infer<typeof vToolApprovalRequest>;
         }
@@ -699,6 +733,9 @@ export function toModelMessageContent(
             text: part.text,
             ...metadata,
           } satisfies ReasoningPart;
+        case "reasoning-file":
+        case "custom":
+          return null;
         case "redacted-reasoning":
           // Legacy v5 part: round-trip the redacted payload via providerOptions.
           return {


### PR DESCRIPTION
## Summary

- Extend the shared persisted stream reducer and projector for AI SDK 7 reasoning files, custom parts, approval responses, and metadata.
- Keep one `UIMessageChunk` format and one implementation: existing AI SDK 6 chunks are the readable subset, and AI SDK 7 adds the superset.
- Preserve replacement semantics for provider metadata and canonical denial projection.
- Keep the runtime and package dependencies on AI SDK 6 until #306.

## Review boundary

This PR adds persisted-read compatibility only. It extends the neutral files introduced in #304 and does not add a second codec, version policy, or runtime writer.

## Compatibility

- Existing AI SDK 6 persisted messages and completed stream rows remain readable.
- Schema changes are additive and require no data migration.
- No dependency or runtime upgrade occurs in this slice.

## Stack

1. #304 — isolate the provider adapter behind a neutral stream codec
2. **#305 — extend the codec for the AI SDK 7 chunk superset**
3. #306 — migrate the Vercel runtime to AI SDK 7
4. #307 — persist oversized streamed files

