### PR TITLE
feat(vercel)!: migrate runtime writer to AI SDK 7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install root dependencies & build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache-dependency-path: package.json
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install and build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.7.0
+
+- Breaking: requires AI SDK v7, provider packages v4, provider utilities v5,
+  and Node.js 22 or newer.
+- Migrates generation, streaming, tools, callbacks, usage, warnings, runtime
+  context, and provider types to AI SDK v7.
+- Uses one `UIMessageChunk` reducer for existing v0.6 stream data and new v0.7
+  streams. Existing persisted messages remain readable.
+- Adds AI SDK v7 message parts, tool-result forms, approval flows, and model
+  registry identifiers.
+- Deprecates top-level `system` in favor of `instructions`.
+- Does not yet offload every oversized inline file encoding. Reasoning files,
+  nested tool-result files, and tagged/base64/data-URL payloads will be
+  completed separately.
+
 ## 0.6.4
 
 - Fix streaming UI message dedupe (#281)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,91 @@
-# Migration Guide: v0.3.x to v0.6.0 (AI SDK v6)
+# Migration Guide: v0.6.x to v0.7.0 (AI SDK v7)
+
+`@convex-dev/agent` v0.7 uses AI SDK 7 at runtime. Existing messages saved by
+v0.6 remain readable; applications must update their AI SDK runtime and
+provider packages together.
+
+## 1. Update Node.js and dependencies
+
+Agent v0.7 requires Node.js 22 or newer.
+
+```bash
+pnpm add @convex-dev/agent@^0.7.0 ai@^7.0.0 \
+  @ai-sdk/provider@^4.0.0 @ai-sdk/provider-utils@^5.0.0
+```
+
+Update official provider packages to v4:
+
+```bash
+pnpm add @ai-sdk/openai@^4.0.0 @ai-sdk/anthropic@^4.0.0 \
+  @ai-sdk/google@^4.0.0 @ai-sdk/groq@^4.0.0
+```
+
+Update third-party providers to releases that support AI SDK 7. If your
+application uses `@convex-dev/rag` with Agent, use an AI SDK 7-compatible RAG
+release.
+
+Avoid installing with `--force`. Mixed AI SDK major versions can compile
+against incompatible model, tool, and message types.
+
+## 2. Rename top-level `system` to `instructions`
+
+Agent continues to accept `system` temporarily, but it is deprecated. Use
+`instructions` for top-level model guidance:
+
+```typescript
+const agent = new Agent(components.agent, {
+  languageModel: openai("gpt-5"),
+  instructions: "You are a helpful assistant.",
+});
+
+await agent.generateText(ctx, { threadId }, {
+  prompt: "Hello",
+  instructions: "Answer concisely.",
+});
+```
+
+Stored system messages remain supported. Passing system messages in assembled
+history requires `allowSystemInMessages: true`.
+
+## 3. Update AI SDK types and callbacks
+
+Agent's generation, streaming, tool, usage, warning, and provider types now
+come from AI SDK 7. Re-run TypeScript after updating dependencies and fix
+custom callbacks or wrappers that depend on AI SDK 6 types.
+
+In particular:
+
+- Use `mediaType` for AI SDK image and file parts.
+- Update custom tools and provider options to their AI SDK 7 forms.
+- Review code that consumes usage, warnings, response metadata, or step
+  results; these now use AI SDK 7 shapes.
+
+Agent still supports `maxSteps`; `stopWhen` remains the preferred AI SDK API.
+
+## 4. Existing data and streamed files
+
+No message-data migration is required. Agent reads messages saved by v0.6 and
+writes new streams in the AI SDK 7 `UIMessageChunk` format. The stream reader
+uses one reducer for the v0.6-compatible subset and the v0.7 superset.
+
+This release does not offload every oversized inline file encoding. Top-level
+`ArrayBuffer` image/file inputs and URL-backed files continue to work.
+Reasoning files, nested tool-result files, and tagged/base64/data-URL payloads
+will gain durable offloading separately.
+
+## 5. Verify
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test
+```
+
+See the [AI SDK migration guides](https://ai-sdk.dev/docs/migration-guides)
+for upstream breaking changes.
+
+---
+
+## Earlier migration: v0.3.x to v0.6.0 (AI SDK v6)
 
 This guide helps you upgrade from @convex-dev/agent v0.3.x to v0.6.0.
 

--- a/docs/files.mdx
+++ b/docs/files.mdx
@@ -118,7 +118,7 @@ await thread.generateText({
   message: {
     role: "user",
     content: [
-      { type: "image", image: imageBytes, mimeType: "image/png" },
+      { type: "image", image: imageBytes, mediaType: "image/png" },
       { type: "text", text: "What is this image?" },
     ],
   },
@@ -136,7 +136,7 @@ Saving to the files has 3 components:
    you can vacuum files that are no longer used (see
    [files/vacuum.ts](../example/convex/files/vacuum.ts)).
 3. Inserting a URL in place of the data in the message sent to the LLM, along
-   with the mimeType and other metadata provided. It will be inferred if not
+   with the media type and other metadata provided. It will be inferred if not
    provided in
    [`guessMimeType`](https://github.com/get-convex/agent/blob/main/src/mapping.ts#L556).
 
@@ -152,7 +152,7 @@ await thread.generateText({
   message: {
     role: "user",
     content: [
-      { type: "image", data: url, mimeType: blob.type },
+      { type: "image", image: url, mediaType: blob.type },
       { type: "text", text: "What is this image?" },
     ],
   },

--- a/docs/rag.mdx
+++ b/docs/rag.mdx
@@ -156,7 +156,7 @@ file around once you've retrieved it via searching.
 const description = await thread.generateText({
   message: {
     role: "user",
-    content: [{ type: "image", data: url, mimeType: blob.type }],
+    content: [{ type: "image", image: url, mediaType: blob.type }],
   },
 });
 ```

--- a/docs/tools.mdx
+++ b/docs/tools.mdx
@@ -147,7 +147,7 @@ const llmTool = createTool({
   }),
   handler: async (ctx, args): Promise<string> => {
     const result = await generateText({
-      system: "You are a helpful assistant.",
+      instructions: "You are a helpful assistant.",
       // Pass through all messages from the current generation
       prompt: [...options.messages, { role: "user", content: args.message }],
       model: myLanguageModel,

--- a/example/convex/modelsForDemo.ts
+++ b/example/convex/modelsForDemo.ts
@@ -1,11 +1,11 @@
 import { type EmbeddingModel } from "ai";
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV4 } from "@ai-sdk/provider";
 import { anthropic } from "@ai-sdk/anthropic";
 import { openai } from "@ai-sdk/openai";
 import { groq } from "@ai-sdk/groq";
 import { mockModel } from "@convex-dev/agent";
 
-let languageModel: LanguageModelV3;
+let languageModel: LanguageModelV4;
 // Note: This is only defined when OPENAI_API_KEY is set. Consumers should
 // handle the undefined case at runtime when using non-OpenAI providers.
 let embeddingModel: EmbeddingModel;

--- a/example/convex/usage_tracking/invoicing.ts
+++ b/example/convex/usage_tracking/invoicing.ts
@@ -52,8 +52,8 @@ export const generateInvoices = internalMutation({
       const cachedPromptTokens =
         doc.providerMetadata?.openai?.cachedPromptTokens ?? 0;
       const tokens = {
-        inputTokens: doc.usage.promptTokens - cachedPromptTokens,
-        outputTokens: doc.usage.completionTokens,
+        inputTokens: (doc.usage.promptTokens ?? 0) - cachedPromptTokens,
+        outputTokens: doc.usage.completionTokens ?? 0,
         cachedInputTokens: cachedPromptTokens,
       };
       if (!currentInvoice) {

--- a/example/convex/usage_tracking/usageHandler.ts
+++ b/example/convex/usage_tracking/usageHandler.ts
@@ -37,7 +37,7 @@ export const insertRawUsage = internalMutation({
       outputTokens: v.optional(v.number()),
       reasoningTokens: v.optional(v.number()),
       cachedInputTokens: v.optional(v.number()),
-      // AI SDK v6 additional fields
+      // AI SDK v7 additional fields
       inputTokenDetails: v.optional(v.any()),
       outputTokenDetails: v.optional(v.any()),
       raw: v.optional(v.any()),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.6.4",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@ai-sdk/anthropic": "3.0.13",
-        "@ai-sdk/google": "3.0.30",
-        "@ai-sdk/groq": "3.0.8",
-        "@ai-sdk/openai": "3.0.10",
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6",
+        "@ai-sdk/anthropic": "4.0.15",
+        "@ai-sdk/google": "4.0.16",
+        "@ai-sdk/groq": "4.0.11",
+        "@ai-sdk/openai": "4.0.14",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
         "@convex-dev/eslint-plugin": "^2.0.0",
-        "@convex-dev/rag": "0.7.5",
+        "@convex-dev/rag": "0.8.0-alpha.0",
         "@convex-dev/rate-limiter": "0.3.2",
         "@convex-dev/workflow": "0.4.3",
         "@edge-runtime/vm": "5.0.0",
@@ -34,11 +34,11 @@
         "@radix-ui/react-slot": "1.2.4",
         "@radix-ui/react-toast": "1.2.15",
         "@tailwindcss/typography": "0.5.19",
-        "@types/node": "20.19.37",
+        "@types/node": "22.20.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "4.7.0",
-        "ai": "6.0.35",
+        "ai": "7.0.28",
         "autoprefixer": "10.4.27",
         "chokidar-cli": "3.0.0",
         "class-variance-authority": "0.7.1",
@@ -55,7 +55,6 @@
         "eslint-plugin-react-refresh": "0.5.2",
         "globals": "16.5.0",
         "lucide-react": "0.577.0",
-        "ollama-ai-provider": "1.2.0",
         "openai": "5.23.2",
         "pkg-pr-new": "0.0.66",
         "postcss": "8.5.18",
@@ -75,12 +74,16 @@
         "vitest": "4.1.0",
         "zod": "3.25.76"
       },
+      "engines": {
+        "node": ">=22"
+      },
       "optionalDependencies": {
         "@ungap/structured-clone": "^1.3.0"
       },
       "peerDependencies": {
-        "@ai-sdk/provider-utils": "^4.0.6",
-        "ai": "^6.0.35",
+        "@ai-sdk/provider": "^4.0.0",
+        "@ai-sdk/provider-utils": "^5.0.0",
+        "ai": "^7.0.0",
         "convex": "^1.24.8",
         "convex-helpers": "^0.1.103",
         "react": "^18.3.1 || ^19.0.0"
@@ -131,158 +134,118 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.13.tgz",
-      "integrity": "sha512-62UqSpZWuR8pU2ZLc1IgPYiNdH01blAcaNEjrQtx4wCN7L2fUTXm/iG6Tq9qRCiRED+8eQ43olggbf0fbguqkA==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.15.tgz",
+      "integrity": "sha512-6iVlzqZjqqoHTmgO1WU9id/33pYykIRasWJFAMf1+d+nhju6d7566VRFsOGZ2W2GzgNtzKs8DGsYN7X5/wOGuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.14.tgz",
-      "integrity": "sha512-udVpkDaQ00jMcBvtGGvmkEBU31XidsHB4E8HIF9l7/H7lyjOS/EtXzN2adoupDg5j1/VjjSI3Ny5P1zHUvLyMA==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.20.tgz",
+      "integrity": "sha512-m3PdYs0yqSxswsrEhVj64wDLgFs35Zxl8liLNuWGzE7bwBLF6Mhu0E5rPpDNJbIjyQpA4aMKOOWBfjERw2zvPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/gateway/node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.30.tgz",
-      "integrity": "sha512-ZzG6dU0XUSSXbxQJJTQUFpWeKkfzdpR7IykEZwaiaW5d+3u3RZ/zkRiGwAOcUpLp6k0eMd+IJF4looJv21ecxw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.16.tgz",
+      "integrity": "sha512-6Iol15lTCUvLJ4jNGbtyT5b3xsF2mbcMkcaQTYFQiRijrFjTMrge0e6Xl5V9n+7g7KfrD377bk5yRFViHTvYUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/groq": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-3.0.8.tgz",
-      "integrity": "sha512-NUh5TWpX62Ar9zaJpMxkwO5V0+neKC5vNu6Pd28qmOV4YPwNR6YgOXRlYXnDXi5w3wULVJrRAg6OBSal9vz2iA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-4.0.11.tgz",
+      "integrity": "sha512-/TL59OiozAQutjm1gr8pdYo8BfnLQIMIxqhjGgvRvtOEy8SI+hJ/WO+0tt3RcmoPaD8GwaqMslXOglNUJdGUcg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.10.tgz",
-      "integrity": "sha512-G6HJORN0rKuCFrqIUiYchjl2b4UjzKvv3VcNuW7xwQIdI8EcdB9Pr8ZaR9nEImK9E639nM8gCfvFEUM1xwGaCA==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.14.tgz",
+      "integrity": "sha512-MnwhHrPOyFYvnOV5p0Iwxwuxnn0/hQbG3rXAyRAsYqfFTrzHJRU2p7BQtKX2PZWH+59iBYBFA2n4GFYC3KEK+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.3.tgz",
-      "integrity": "sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.6.tgz",
-      "integrity": "sha512-o/SP1GQOrpXAzHjMosPHI0Pu+YkwxIMndSjSLrEXtcVixdrjqrGaA9I7xJcWf+XpRFJ9byPHrKYnprwS+36gMg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.10.tgz",
+      "integrity": "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -829,16 +792,16 @@
       }
     },
     "node_modules/@convex-dev/rag": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@convex-dev/rag/-/rag-0.7.5.tgz",
-      "integrity": "sha512-u48NNcYdnBpGaAYq9GAbqEsCgFlKbaTj3Fc3cA+mNFis1flpy3Zz4eP2XdDavuyf/cNYE1dbxbnU20OcTvekOA==",
+      "version": "0.8.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@convex-dev/rag/-/rag-0.8.0-alpha.0.tgz",
+      "integrity": "sha512-tS3ErHuTAqvXbGOVXvthfbCGbJvFHGikFayf/gdZTFMFC+YFFMdBqygIzr44z5u9mp4KWyjQIWhA2MrJLyHHKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@convex-dev/workpool": "^0.4.3 || ^0.4.7-alpha",
-        "ai": "^6.0.0"
+        "@convex-dev/workpool": "^0.4.4"
       },
       "peerDependencies": {
+        "ai": "^7.0.0",
         "convex": "^1.24.8",
         "convex-helpers": "^0.1.94"
       }
@@ -1733,9 +1696,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
-      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-GIrJktdsFPx8gM0C3VyikkeYGZAV7iRIzUJuS5tFatiKLExybou0LI0MuxH9kksN38quyfWdQDl20lIEAEVkVA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3557,9 +3520,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3882,6 +3845,16 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -4016,6 +3989,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4040,32 +4020,21 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.35",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.35.tgz",
-      "integrity": "sha512-MxgtU6CjnegH1rhRfomM0gptKxP6r+9sxbLvYq36C1l85+o0LacqbXLdNVYzqab+lHN4q7ZP3QS8wZq4YkZahA==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.28.tgz",
+      "integrity": "sha512-RtynA4e6rWH2YiMX0OJz2h2i+sdJgiItuwqmstYZAiTZ0ZkZzQ8s4KVh7tQfZuDCfzIhRTg+q1h1xirT8AClkw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.14",
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.20",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -6393,9 +6362,9 @@
       "peer": true
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7711,9 +7680,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
-      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.9.tgz",
+      "integrity": "sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8776,60 +8745,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/ollama-ai-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider/-/ollama-ai-provider-1.2.0.tgz",
-      "integrity": "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "^1.0.0",
-        "@ai-sdk/provider-utils": "^2.0.0",
-        "partial-json": "0.1.7"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ollama-ai-provider/node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ollama-ai-provider/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9027,13 +8942,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9996,13 +9904,6 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
     }
   },
   "peerDependencies": {
-    "@ai-sdk/provider-utils": "^4.0.6",
-    "ai": "^6.0.35",
+    "@ai-sdk/provider": "^4.0.0",
+    "@ai-sdk/provider-utils": "^5.0.0",
+    "ai": "^7.0.0",
     "convex": "^1.24.8",
     "convex-helpers": "^0.1.103",
     "react": "^18.3.1 || ^19.0.0"
@@ -81,14 +82,14 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "3.0.13",
-    "@ai-sdk/google": "3.0.30",
-    "@ai-sdk/groq": "3.0.8",
-    "@ai-sdk/openai": "3.0.10",
-    "@ai-sdk/provider": "3.0.3",
-    "@ai-sdk/provider-utils": "4.0.6",
+    "@ai-sdk/anthropic": "4.0.15",
+    "@ai-sdk/google": "4.0.16",
+    "@ai-sdk/groq": "4.0.11",
+    "@ai-sdk/openai": "4.0.14",
+    "@ai-sdk/provider": "4.0.3",
+    "@ai-sdk/provider-utils": "5.0.10",
     "@convex-dev/eslint-plugin": "^2.0.0",
-    "@convex-dev/rag": "0.7.5",
+    "@convex-dev/rag": "0.8.0-alpha.0",
     "@convex-dev/rate-limiter": "0.3.2",
     "@convex-dev/workflow": "0.4.3",
     "@edge-runtime/vm": "5.0.0",
@@ -106,11 +107,11 @@
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-toast": "1.2.15",
     "@tailwindcss/typography": "0.5.19",
-    "@types/node": "20.19.37",
+    "@types/node": "22.20.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "4.7.0",
-    "ai": "6.0.35",
+    "ai": "7.0.28",
     "autoprefixer": "10.4.27",
     "chokidar-cli": "3.0.0",
     "class-variance-authority": "0.7.1",
@@ -127,7 +128,6 @@
     "eslint-plugin-react-refresh": "0.5.2",
     "globals": "16.5.0",
     "lucide-react": "0.577.0",
-    "ollama-ai-provider": "1.2.0",
     "openai": "5.23.2",
     "pkg-pr-new": "0.0.66",
     "postcss": "8.5.18",
@@ -151,5 +151,8 @@
   "module": "./dist/vercel/index.js",
   "optionalDependencies": {
     "@ungap/structured-clone": "^1.3.0"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -70,7 +70,7 @@
       "devDependencies": {
         "@convex-dev/agent": "file:..",
         "@eslint/js": "9.39.4",
-        "@types/node": "20.19.37",
+        "@types/node": "22.20.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "convex": "file:../node_modules/convex",
@@ -93,16 +93,17 @@
     "..": {
       "name": "@convex-dev/agent",
       "version": "0.6.4",
+      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@ai-sdk/anthropic": "3.0.13",
-        "@ai-sdk/google": "3.0.30",
-        "@ai-sdk/groq": "3.0.8",
-        "@ai-sdk/openai": "3.0.10",
-        "@ai-sdk/provider": "3.0.3",
-        "@ai-sdk/provider-utils": "4.0.6",
+        "@ai-sdk/anthropic": "4.0.15",
+        "@ai-sdk/google": "4.0.16",
+        "@ai-sdk/groq": "4.0.11",
+        "@ai-sdk/openai": "4.0.14",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
         "@convex-dev/eslint-plugin": "^2.0.0",
-        "@convex-dev/rag": "0.7.5",
+        "@convex-dev/rag": "0.8.0-alpha.0",
         "@convex-dev/rate-limiter": "0.3.2",
         "@convex-dev/workflow": "0.4.3",
         "@edge-runtime/vm": "5.0.0",
@@ -120,11 +121,11 @@
         "@radix-ui/react-slot": "1.2.4",
         "@radix-ui/react-toast": "1.2.15",
         "@tailwindcss/typography": "0.5.19",
-        "@types/node": "20.19.37",
+        "@types/node": "22.20.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "4.7.0",
-        "ai": "6.0.35",
+        "ai": "7.0.28",
         "autoprefixer": "10.4.27",
         "chokidar-cli": "3.0.0",
         "class-variance-authority": "0.7.1",
@@ -141,7 +142,6 @@
         "eslint-plugin-react-refresh": "0.5.2",
         "globals": "16.5.0",
         "lucide-react": "0.577.0",
-        "ollama-ai-provider": "1.2.0",
         "openai": "5.23.2",
         "pkg-pr-new": "0.0.66",
         "postcss": "8.5.18",
@@ -161,12 +161,16 @@
         "vitest": "4.1.0",
         "zod": "3.25.76"
       },
+      "engines": {
+        "node": ">=22"
+      },
       "optionalDependencies": {
         "@ungap/structured-clone": "^1.3.0"
       },
       "peerDependencies": {
-        "@ai-sdk/provider-utils": "^4.0.6",
-        "ai": "^6.0.35",
+        "@ai-sdk/provider": "^4.0.0",
+        "@ai-sdk/provider-utils": "^5.0.0",
+        "ai": "^7.0.0",
         "convex": "^1.24.8",
         "convex-helpers": "^0.1.103",
         "react": "^18.3.1 || ^19.0.0"
@@ -3264,9 +3268,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -106,7 +106,7 @@
   "devDependencies": {
     "@convex-dev/agent": "file:..",
     "@eslint/js": "9.39.4",
-    "@types/node": "20.19.37",
+    "@types/node": "22.20.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "convex": "file:../node_modules/convex",

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -185,7 +185,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            image: string | ArrayBuffer;
+                            image:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             mediaType?: string;
                             mimeType?: string;
                             providerOptions?: Record<
@@ -195,7 +201,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "image";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -230,7 +242,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -395,6 +413,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "text";
                                       }
                                     | {
+                                        data:
+                                          | { type: "url"; url: string }
+                                          | {
+                                              reference: Record<string, string>;
+                                              type: "reference";
+                                            }
+                                          | {
+                                              data: string | ArrayBuffer;
+                                              type: "data";
+                                            }
+                                          | { text: string; type: "text" };
+                                        filename?: string;
+                                        mediaType: string;
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        type: "file";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         type: "media";
@@ -410,6 +448,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-data";
                                       }
                                     | {
+                                        mediaType?: string;
                                         providerOptions?: Record<
                                           string,
                                           Record<string, any>
@@ -426,6 +465,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-id";
                                       }
                                     | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "file-reference";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         providerOptions?: Record<
@@ -433,6 +483,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                           Record<string, any>
                                         >;
                                         type: "image-data";
+                                      }
+                                    | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "image-file-reference";
                                       }
                                     | {
                                         providerOptions?: Record<
@@ -585,6 +646,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "text";
                                   }
                                 | {
+                                    data:
+                                      | { type: "url"; url: string }
+                                      | {
+                                          reference: Record<string, string>;
+                                          type: "reference";
+                                        }
+                                      | {
+                                          data: string | ArrayBuffer;
+                                          type: "data";
+                                        }
+                                      | { text: string; type: "text" };
+                                    filename?: string;
+                                    mediaType: string;
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    type: "file";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     type: "media";
@@ -600,6 +681,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-data";
                                   }
                                 | {
+                                    mediaType?: string;
                                     providerOptions?: Record<
                                       string,
                                       Record<string, any>
@@ -616,6 +698,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-id";
                                   }
                                 | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "file-reference";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     providerOptions?: Record<
@@ -623,6 +713,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       Record<string, any>
                                     >;
                                     type: "image-data";
+                                  }
+                                | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "image-file-reference";
                                   }
                                 | {
                                     providerOptions?: Record<
@@ -714,13 +812,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             status?: "pending" | "success" | "failed";
             text?: string;
             usage?: {
+              cacheWriteInputTokens?: number;
               cachedInputTokens?: number;
-              completionTokens: number;
-              promptTokens: number;
+              completionTokens?: number;
+              nonCachedInputTokens?: number;
+              promptTokens?: number;
+              raw?: Record<string, any>;
               reasoningTokens?: number;
-              totalTokens: number;
+              textOutputTokens?: number;
+              totalTokens?: number;
             };
             warnings?: Array<
+              | { details?: string; feature: string; type: "unsupported" }
+              | { details?: string; feature: string; type: "compatibility" }
+              | { message: string; setting: string; type: "deprecated" }
               | {
                   details?: string;
                   setting: string;
@@ -770,7 +875,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            image: string | ArrayBuffer;
+                            image:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             mediaType?: string;
                             mimeType?: string;
                             providerOptions?: Record<
@@ -780,7 +891,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "image";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -815,7 +932,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -980,6 +1103,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "text";
                                       }
                                     | {
+                                        data:
+                                          | { type: "url"; url: string }
+                                          | {
+                                              reference: Record<string, string>;
+                                              type: "reference";
+                                            }
+                                          | {
+                                              data: string | ArrayBuffer;
+                                              type: "data";
+                                            }
+                                          | { text: string; type: "text" };
+                                        filename?: string;
+                                        mediaType: string;
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        type: "file";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         type: "media";
@@ -995,6 +1138,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-data";
                                       }
                                     | {
+                                        mediaType?: string;
                                         providerOptions?: Record<
                                           string,
                                           Record<string, any>
@@ -1011,6 +1155,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-id";
                                       }
                                     | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "file-reference";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         providerOptions?: Record<
@@ -1018,6 +1173,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                           Record<string, any>
                                         >;
                                         type: "image-data";
+                                      }
+                                    | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "image-file-reference";
                                       }
                                     | {
                                         providerOptions?: Record<
@@ -1170,6 +1336,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "text";
                                   }
                                 | {
+                                    data:
+                                      | { type: "url"; url: string }
+                                      | {
+                                          reference: Record<string, string>;
+                                          type: "reference";
+                                        }
+                                      | {
+                                          data: string | ArrayBuffer;
+                                          type: "data";
+                                        }
+                                      | { text: string; type: "text" };
+                                    filename?: string;
+                                    mediaType: string;
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    type: "file";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     type: "media";
@@ -1185,6 +1371,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-data";
                                   }
                                 | {
+                                    mediaType?: string;
                                     providerOptions?: Record<
                                       string,
                                       Record<string, any>
@@ -1201,6 +1388,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-id";
                                   }
                                 | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "file-reference";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     providerOptions?: Record<
@@ -1208,6 +1403,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       Record<string, any>
                                     >;
                                     type: "image-data";
+                                  }
+                                | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "image-file-reference";
                                   }
                                 | {
                                     providerOptions?: Record<
@@ -1304,14 +1507,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             threadId: string;
             tool: boolean;
             usage?: {
+              cacheWriteInputTokens?: number;
               cachedInputTokens?: number;
-              completionTokens: number;
-              promptTokens: number;
+              completionTokens?: number;
+              nonCachedInputTokens?: number;
+              promptTokens?: number;
+              raw?: Record<string, any>;
               reasoningTokens?: number;
-              totalTokens: number;
+              textOutputTokens?: number;
+              totalTokens?: number;
             };
             userId?: string;
             warnings?: Array<
+              | { details?: string; feature: string; type: "unsupported" }
+              | { details?: string; feature: string; type: "compatibility" }
+              | { message: string; setting: string; type: "deprecated" }
               | {
                   details?: string;
                   setting: string;
@@ -1406,14 +1616,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          image: string | ArrayBuffer;
+                          image:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           mediaType?: string;
                           mimeType?: string;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "image";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -1442,7 +1664,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -1582,6 +1810,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "text";
                                     }
                                   | {
+                                      data:
+                                        | { type: "url"; url: string }
+                                        | {
+                                            reference: Record<string, string>;
+                                            type: "reference";
+                                          }
+                                        | {
+                                            data: string | ArrayBuffer;
+                                            type: "data";
+                                          }
+                                        | { text: string; type: "text" };
+                                      filename?: string;
+                                      mediaType: string;
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      type: "file";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       type: "media";
@@ -1597,6 +1845,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-data";
                                     }
                                   | {
+                                      mediaType?: string;
                                       providerOptions?: Record<
                                         string,
                                         Record<string, any>
@@ -1613,6 +1862,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-id";
                                     }
                                   | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "file-reference";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       providerOptions?: Record<
@@ -1620,6 +1877,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         Record<string, any>
                                       >;
                                       type: "image-data";
+                                    }
+                                  | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "image-file-reference";
                                     }
                                   | {
                                       providerOptions?: Record<
@@ -1760,6 +2025,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "text";
                                 }
                               | {
+                                  data:
+                                    | { type: "url"; url: string }
+                                    | {
+                                        reference: Record<string, string>;
+                                        type: "reference";
+                                      }
+                                    | {
+                                        data: string | ArrayBuffer;
+                                        type: "data";
+                                      }
+                                    | { text: string; type: "text" };
+                                  filename?: string;
+                                  mediaType: string;
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  type: "file";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   type: "media";
@@ -1775,6 +2060,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-data";
                                 }
                               | {
+                                  mediaType?: string;
                                   providerOptions?: Record<
                                     string,
                                     Record<string, any>
@@ -1791,6 +2077,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-id";
                                 }
                               | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "file-reference";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   providerOptions?: Record<
@@ -1798,6 +2092,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     Record<string, any>
                                   >;
                                   type: "image-data";
+                                }
+                              | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "image-file-reference";
                                 }
                               | {
                                   providerOptions?: Record<
@@ -1894,14 +2196,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           threadId: string;
           tool: boolean;
           usage?: {
+            cacheWriteInputTokens?: number;
             cachedInputTokens?: number;
-            completionTokens: number;
-            promptTokens: number;
+            completionTokens?: number;
+            nonCachedInputTokens?: number;
+            promptTokens?: number;
+            raw?: Record<string, any>;
             reasoningTokens?: number;
-            totalTokens: number;
+            textOutputTokens?: number;
+            totalTokens?: number;
           };
           userId?: string;
           warnings?: Array<
+            | { details?: string; feature: string; type: "unsupported" }
+            | { details?: string; feature: string; type: "compatibility" }
+            | { message: string; setting: string; type: "deprecated" }
             | { details?: string; setting: string; type: "unsupported-setting" }
             | { details?: string; tool: any; type: "unsupported-tool" }
             | { message: string; type: "other" }
@@ -1971,7 +2280,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            image: string | ArrayBuffer;
+                            image:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             mediaType?: string;
                             mimeType?: string;
                             providerOptions?: Record<
@@ -1981,7 +2296,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "image";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -2016,7 +2337,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -2181,6 +2508,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "text";
                                       }
                                     | {
+                                        data:
+                                          | { type: "url"; url: string }
+                                          | {
+                                              reference: Record<string, string>;
+                                              type: "reference";
+                                            }
+                                          | {
+                                              data: string | ArrayBuffer;
+                                              type: "data";
+                                            }
+                                          | { text: string; type: "text" };
+                                        filename?: string;
+                                        mediaType: string;
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        type: "file";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         type: "media";
@@ -2196,6 +2543,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-data";
                                       }
                                     | {
+                                        mediaType?: string;
                                         providerOptions?: Record<
                                           string,
                                           Record<string, any>
@@ -2212,6 +2560,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-id";
                                       }
                                     | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "file-reference";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         providerOptions?: Record<
@@ -2219,6 +2578,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                           Record<string, any>
                                         >;
                                         type: "image-data";
+                                      }
+                                    | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "image-file-reference";
                                       }
                                     | {
                                         providerOptions?: Record<
@@ -2371,6 +2741,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "text";
                                   }
                                 | {
+                                    data:
+                                      | { type: "url"; url: string }
+                                      | {
+                                          reference: Record<string, string>;
+                                          type: "reference";
+                                        }
+                                      | {
+                                          data: string | ArrayBuffer;
+                                          type: "data";
+                                        }
+                                      | { text: string; type: "text" };
+                                    filename?: string;
+                                    mediaType: string;
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    type: "file";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     type: "media";
@@ -2386,6 +2776,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-data";
                                   }
                                 | {
+                                    mediaType?: string;
                                     providerOptions?: Record<
                                       string,
                                       Record<string, any>
@@ -2402,6 +2793,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-id";
                                   }
                                 | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "file-reference";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     providerOptions?: Record<
@@ -2409,6 +2808,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       Record<string, any>
                                     >;
                                     type: "image-data";
+                                  }
+                                | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "image-file-reference";
                                   }
                                 | {
                                     providerOptions?: Record<
@@ -2505,14 +2912,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             threadId: string;
             tool: boolean;
             usage?: {
+              cacheWriteInputTokens?: number;
               cachedInputTokens?: number;
-              completionTokens: number;
-              promptTokens: number;
+              completionTokens?: number;
+              nonCachedInputTokens?: number;
+              promptTokens?: number;
+              raw?: Record<string, any>;
               reasoningTokens?: number;
-              totalTokens: number;
+              textOutputTokens?: number;
+              totalTokens?: number;
             };
             userId?: string;
             warnings?: Array<
+              | { details?: string; feature: string; type: "unsupported" }
+              | { details?: string; feature: string; type: "compatibility" }
+              | { message: string; setting: string; type: "deprecated" }
               | {
                   details?: string;
                   setting: string;
@@ -2574,14 +2988,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          image: string | ArrayBuffer;
+                          image:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           mediaType?: string;
                           mimeType?: string;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "image";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -2610,7 +3036,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -2750,6 +3182,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "text";
                                     }
                                   | {
+                                      data:
+                                        | { type: "url"; url: string }
+                                        | {
+                                            reference: Record<string, string>;
+                                            type: "reference";
+                                          }
+                                        | {
+                                            data: string | ArrayBuffer;
+                                            type: "data";
+                                          }
+                                        | { text: string; type: "text" };
+                                      filename?: string;
+                                      mediaType: string;
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      type: "file";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       type: "media";
@@ -2765,6 +3217,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-data";
                                     }
                                   | {
+                                      mediaType?: string;
                                       providerOptions?: Record<
                                         string,
                                         Record<string, any>
@@ -2781,6 +3234,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-id";
                                     }
                                   | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "file-reference";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       providerOptions?: Record<
@@ -2788,6 +3249,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         Record<string, any>
                                       >;
                                       type: "image-data";
+                                    }
+                                  | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "image-file-reference";
                                     }
                                   | {
                                       providerOptions?: Record<
@@ -2928,6 +3397,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "text";
                                 }
                               | {
+                                  data:
+                                    | { type: "url"; url: string }
+                                    | {
+                                        reference: Record<string, string>;
+                                        type: "reference";
+                                      }
+                                    | {
+                                        data: string | ArrayBuffer;
+                                        type: "data";
+                                      }
+                                    | { text: string; type: "text" };
+                                  filename?: string;
+                                  mediaType: string;
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  type: "file";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   type: "media";
@@ -2943,6 +3432,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-data";
                                 }
                               | {
+                                  mediaType?: string;
                                   providerOptions?: Record<
                                     string,
                                     Record<string, any>
@@ -2959,6 +3449,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-id";
                                 }
                               | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "file-reference";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   providerOptions?: Record<
@@ -2966,6 +3464,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     Record<string, any>
                                   >;
                                   type: "image-data";
+                                }
+                              | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "image-file-reference";
                                 }
                               | {
                                   providerOptions?: Record<
@@ -3062,14 +3568,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           threadId: string;
           tool: boolean;
           usage?: {
+            cacheWriteInputTokens?: number;
             cachedInputTokens?: number;
-            completionTokens: number;
-            promptTokens: number;
+            completionTokens?: number;
+            nonCachedInputTokens?: number;
+            promptTokens?: number;
+            raw?: Record<string, any>;
             reasoningTokens?: number;
-            totalTokens: number;
+            textOutputTokens?: number;
+            totalTokens?: number;
           };
           userId?: string;
           warnings?: Array<
+            | { details?: string; feature: string; type: "unsupported" }
+            | { details?: string; feature: string; type: "compatibility" }
+            | { message: string; setting: string; type: "deprecated" }
             | { details?: string; setting: string; type: "unsupported-setting" }
             | { details?: string; tool: any; type: "unsupported-tool" }
             | { message: string; type: "other" }
@@ -3118,14 +3631,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          image: string | ArrayBuffer;
+                          image:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           mediaType?: string;
                           mimeType?: string;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "image";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -3154,7 +3679,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -3294,6 +3825,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "text";
                                     }
                                   | {
+                                      data:
+                                        | { type: "url"; url: string }
+                                        | {
+                                            reference: Record<string, string>;
+                                            type: "reference";
+                                          }
+                                        | {
+                                            data: string | ArrayBuffer;
+                                            type: "data";
+                                          }
+                                        | { text: string; type: "text" };
+                                      filename?: string;
+                                      mediaType: string;
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      type: "file";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       type: "media";
@@ -3309,6 +3860,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-data";
                                     }
                                   | {
+                                      mediaType?: string;
                                       providerOptions?: Record<
                                         string,
                                         Record<string, any>
@@ -3325,6 +3877,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-id";
                                     }
                                   | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "file-reference";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       providerOptions?: Record<
@@ -3332,6 +3892,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         Record<string, any>
                                       >;
                                       type: "image-data";
+                                    }
+                                  | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "image-file-reference";
                                     }
                                   | {
                                       providerOptions?: Record<
@@ -3472,6 +4040,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "text";
                                 }
                               | {
+                                  data:
+                                    | { type: "url"; url: string }
+                                    | {
+                                        reference: Record<string, string>;
+                                        type: "reference";
+                                      }
+                                    | {
+                                        data: string | ArrayBuffer;
+                                        type: "data";
+                                      }
+                                    | { text: string; type: "text" };
+                                  filename?: string;
+                                  mediaType: string;
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  type: "file";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   type: "media";
@@ -3487,6 +4075,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-data";
                                 }
                               | {
+                                  mediaType?: string;
                                   providerOptions?: Record<
                                     string,
                                     Record<string, any>
@@ -3503,6 +4092,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-id";
                                 }
                               | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "file-reference";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   providerOptions?: Record<
@@ -3510,6 +4107,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     Record<string, any>
                                   >;
                                   type: "image-data";
+                                }
+                              | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "image-file-reference";
                                 }
                               | {
                                   providerOptions?: Record<
@@ -3606,14 +4211,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           threadId: string;
           tool: boolean;
           usage?: {
+            cacheWriteInputTokens?: number;
             cachedInputTokens?: number;
-            completionTokens: number;
-            promptTokens: number;
+            completionTokens?: number;
+            nonCachedInputTokens?: number;
+            promptTokens?: number;
+            raw?: Record<string, any>;
             reasoningTokens?: number;
-            totalTokens: number;
+            textOutputTokens?: number;
+            totalTokens?: number;
           };
           userId?: string;
           warnings?: Array<
+            | { details?: string; feature: string; type: "unsupported" }
+            | { details?: string; feature: string; type: "compatibility" }
+            | { message: string; setting: string; type: "deprecated" }
             | { details?: string; setting: string; type: "unsupported-setting" }
             | { details?: string; tool: any; type: "unsupported-tool" }
             | { message: string; type: "other" }
@@ -3655,7 +4267,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            image: string | ArrayBuffer;
+                            image:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             mediaType?: string;
                             mimeType?: string;
                             providerOptions?: Record<
@@ -3665,7 +4283,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "image";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -3700,7 +4324,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                             type: "text";
                           }
                         | {
-                            data: string | ArrayBuffer;
+                            data:
+                              | string
+                              | ArrayBuffer
+                              | {
+                                  reference: Record<string, string>;
+                                  type: "reference";
+                                };
                             filename?: string;
                             mediaType?: string;
                             mimeType?: string;
@@ -3865,6 +4495,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "text";
                                       }
                                     | {
+                                        data:
+                                          | { type: "url"; url: string }
+                                          | {
+                                              reference: Record<string, string>;
+                                              type: "reference";
+                                            }
+                                          | {
+                                              data: string | ArrayBuffer;
+                                              type: "data";
+                                            }
+                                          | { text: string; type: "text" };
+                                        filename?: string;
+                                        mediaType: string;
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        type: "file";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         type: "media";
@@ -3880,6 +4530,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-data";
                                       }
                                     | {
+                                        mediaType?: string;
                                         providerOptions?: Record<
                                           string,
                                           Record<string, any>
@@ -3896,6 +4547,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         type: "file-id";
                                       }
                                     | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "file-reference";
+                                      }
+                                    | {
                                         data: string;
                                         mediaType: string;
                                         providerOptions?: Record<
@@ -3903,6 +4565,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                           Record<string, any>
                                         >;
                                         type: "image-data";
+                                      }
+                                    | {
+                                        providerOptions?: Record<
+                                          string,
+                                          Record<string, any>
+                                        >;
+                                        providerReference: Record<
+                                          string,
+                                          string
+                                        >;
+                                        type: "image-file-reference";
                                       }
                                     | {
                                         providerOptions?: Record<
@@ -4055,6 +4728,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "text";
                                   }
                                 | {
+                                    data:
+                                      | { type: "url"; url: string }
+                                      | {
+                                          reference: Record<string, string>;
+                                          type: "reference";
+                                        }
+                                      | {
+                                          data: string | ArrayBuffer;
+                                          type: "data";
+                                        }
+                                      | { text: string; type: "text" };
+                                    filename?: string;
+                                    mediaType: string;
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    type: "file";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     type: "media";
@@ -4070,6 +4763,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-data";
                                   }
                                 | {
+                                    mediaType?: string;
                                     providerOptions?: Record<
                                       string,
                                       Record<string, any>
@@ -4086,6 +4780,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     type: "file-id";
                                   }
                                 | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "file-reference";
+                                  }
+                                | {
                                     data: string;
                                     mediaType: string;
                                     providerOptions?: Record<
@@ -4093,6 +4795,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       Record<string, any>
                                     >;
                                     type: "image-data";
+                                  }
+                                | {
+                                    providerOptions?: Record<
+                                      string,
+                                      Record<string, any>
+                                    >;
+                                    providerReference: Record<string, string>;
+                                    type: "image-file-reference";
                                   }
                                 | {
                                     providerOptions?: Record<
@@ -4182,14 +4892,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          image: string | ArrayBuffer;
+                          image:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           mediaType?: string;
                           mimeType?: string;
                           providerOptions?: Record<string, Record<string, any>>;
                           type: "image";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -4218,7 +4940,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                           type: "text";
                         }
                       | {
-                          data: string | ArrayBuffer;
+                          data:
+                            | string
+                            | ArrayBuffer
+                            | {
+                                reference: Record<string, string>;
+                                type: "reference";
+                              };
                           filename?: string;
                           mediaType?: string;
                           mimeType?: string;
@@ -4358,6 +5086,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "text";
                                     }
                                   | {
+                                      data:
+                                        | { type: "url"; url: string }
+                                        | {
+                                            reference: Record<string, string>;
+                                            type: "reference";
+                                          }
+                                        | {
+                                            data: string | ArrayBuffer;
+                                            type: "data";
+                                          }
+                                        | { text: string; type: "text" };
+                                      filename?: string;
+                                      mediaType: string;
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      type: "file";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       type: "media";
@@ -4373,6 +5121,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-data";
                                     }
                                   | {
+                                      mediaType?: string;
                                       providerOptions?: Record<
                                         string,
                                         Record<string, any>
@@ -4389,6 +5138,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                       type: "file-id";
                                     }
                                   | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "file-reference";
+                                    }
+                                  | {
                                       data: string;
                                       mediaType: string;
                                       providerOptions?: Record<
@@ -4396,6 +5153,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                         Record<string, any>
                                       >;
                                       type: "image-data";
+                                    }
+                                  | {
+                                      providerOptions?: Record<
+                                        string,
+                                        Record<string, any>
+                                      >;
+                                      providerReference: Record<string, string>;
+                                      type: "image-file-reference";
                                     }
                                   | {
                                       providerOptions?: Record<
@@ -4536,6 +5301,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "text";
                                 }
                               | {
+                                  data:
+                                    | { type: "url"; url: string }
+                                    | {
+                                        reference: Record<string, string>;
+                                        type: "reference";
+                                      }
+                                    | {
+                                        data: string | ArrayBuffer;
+                                        type: "data";
+                                      }
+                                    | { text: string; type: "text" };
+                                  filename?: string;
+                                  mediaType: string;
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  type: "file";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   type: "media";
@@ -4551,6 +5336,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-data";
                                 }
                               | {
+                                  mediaType?: string;
                                   providerOptions?: Record<
                                     string,
                                     Record<string, any>
@@ -4567,6 +5353,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                   type: "file-id";
                                 }
                               | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "file-reference";
+                                }
+                              | {
                                   data: string;
                                   mediaType: string;
                                   providerOptions?: Record<
@@ -4574,6 +5368,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                                     Record<string, any>
                                   >;
                                   type: "image-data";
+                                }
+                              | {
+                                  providerOptions?: Record<
+                                    string,
+                                    Record<string, any>
+                                  >;
+                                  providerReference: Record<string, string>;
+                                  type: "image-file-reference";
                                 }
                               | {
                                   providerOptions?: Record<
@@ -4670,14 +5472,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           threadId: string;
           tool: boolean;
           usage?: {
+            cacheWriteInputTokens?: number;
             cachedInputTokens?: number;
-            completionTokens: number;
-            promptTokens: number;
+            completionTokens?: number;
+            nonCachedInputTokens?: number;
+            promptTokens?: number;
+            raw?: Record<string, any>;
             reasoningTokens?: number;
-            totalTokens: number;
+            textOutputTokens?: number;
+            totalTokens?: number;
           };
           userId?: string;
           warnings?: Array<
+            | { details?: string; feature: string; type: "unsupported" }
+            | { details?: string; feature: string; type: "compatibility" }
+            | { message: string; setting: string; type: "deprecated" }
             | { details?: string; setting: string; type: "unsupported-setting" }
             | { details?: string; tool: any; type: "unsupported-tool" }
             | { message: string; type: "other" }

--- a/src/streaming/materializePersistedUIMessageChunks.test.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.test.ts
@@ -21,6 +21,36 @@ const stream: StreamMessage = {
 };
 
 describe("projectPersistedUIMessageChunks", () => {
+  it("preserves canonical content tool outputs", () => {
+    const canonicalOutput = {
+      type: "content",
+      value: [{ type: "text", text: "already canonical" }],
+    };
+    const actual = projectPersistedUIMessageChunks(
+      stream,
+      [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          input: { query: "hello" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "call-1",
+          output: canonicalOutput,
+        },
+      ],
+      { status: "success" },
+    );
+
+    expect(actual[1].message).toMatchObject({
+      role: "tool",
+      content: [{ output: canonicalOutput }],
+    });
+    expect(validate(vMessageWithMetadataInternal, actual[1])).toBe(true);
+  });
+
   it("keeps persisted sources on the step that produced them", () => {
     const chunks = [
       { type: "start-step" },

--- a/src/streaming/materializePersistedUIMessageChunks.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.ts
@@ -1,10 +1,12 @@
-import type {
-  Message,
-  MessageContentParts,
-  MessageWithMetadataInternal,
-  StreamDelta,
-  StreamMessage,
+import {
+  vToolResultOutput,
+  type Message,
+  type MessageContentParts,
+  type MessageWithMetadataInternal,
+  type StreamDelta,
+  type StreamMessage,
 } from "../validators.js";
+import { validate } from "convex-helpers/validators";
 import {
   collectContiguousStreamParts,
   createPersistedUIMessageChunkState,
@@ -333,11 +335,16 @@ function toolResult(
         }
       : mode === "error-text"
         ? { type: "error-text" as const, value: String(raw) }
-      : mode === "error-json"
-        ? { type: "error-json" as const, value: raw ?? null }
-        : typeof raw === "string"
-          ? { type: "text" as const, value: raw }
-          : { type: "json" as const, value: raw ?? null };
+        : mode === "error-json"
+          ? { type: "error-json" as const, value: raw ?? null }
+          : validate(vToolResultOutput, raw)
+            ? (raw as Extract<
+                MessageContentParts,
+                { type: "tool-result" }
+              >["output"])
+            : typeof raw === "string"
+              ? { type: "text" as const, value: raw }
+              : { type: "json" as const, value: raw ?? null };
   const providerOptions =
     part.resultProviderMetadata ?? part.callProviderMetadata;
   return {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -15,6 +15,11 @@ export const vProviderMetadata = vProviderOptions;
 const providerMetadata = providerOptions;
 export type ProviderMetadata = Infer<typeof providerMetadata>;
 
+export const vProviderReference = v.object({
+  type: v.literal("reference"),
+  reference: v.record(v.string(), v.string()),
+});
+
 export const vThreadStatus = v.union(
   v.literal("active"),
   v.literal("archived"), // unused
@@ -42,7 +47,7 @@ export const vTextPart = v.object({
 
 export const vImagePart = v.object({
   type: v.literal("image"),
-  image: v.union(v.string(), v.bytes()),
+  image: v.union(v.string(), v.bytes(), vProviderReference),
   mediaType: v.optional(v.string()),
   /** @deprecated Use `mediaType` instead. */
   mimeType: v.optional(v.string()),
@@ -51,7 +56,7 @@ export const vImagePart = v.object({
 
 export const vFilePart = v.object({
   type: v.literal("file"),
-  data: v.union(v.string(), v.bytes()),
+  data: v.union(v.string(), v.bytes(), vProviderReference),
   filename: v.optional(v.string()),
   mediaType: v.optional(v.string()),
   /** @deprecated Use `mediaType` instead. */
@@ -88,7 +93,6 @@ export const vCustomContentPart = v.object({
   providerOptions,
   providerMetadata,
 });
-
 export const vRedactedReasoningPart = v.object({
   type: v.literal("redacted-reasoning"),
   data: v.string(),
@@ -198,6 +202,21 @@ export const vToolResultOutput = v.union(
           text: v.string(),
           providerOptions,
         }),
+        v.object({
+          type: v.literal("file"),
+          data: v.union(
+            v.object({ type: v.literal("url"), url: v.string() }),
+            vProviderReference,
+            v.object({
+              type: v.literal("data"),
+              data: v.union(v.string(), v.bytes()),
+            }),
+            v.object({ type: v.literal("text"), text: v.string() }),
+          ),
+          mediaType: v.string(),
+          filename: v.optional(v.string()),
+          providerOptions,
+        }),
         /** @deprecated Use `image-data` or `file-data` instead. */
         v.object({
           type: v.literal("media"),
@@ -219,6 +238,7 @@ export const vToolResultOutput = v.union(
         v.object({
           type: v.literal("file-url"),
           url: v.string(),
+          mediaType: v.optional(v.string()),
           providerOptions,
         }),
         v.object({
@@ -235,6 +255,11 @@ export const vToolResultOutput = v.union(
           providerOptions,
         }),
         v.object({
+          type: v.literal("file-reference"),
+          providerReference: v.record(v.string(), v.string()),
+          providerOptions,
+        }),
+        v.object({
           type: v.literal("image-data"),
           data: v.string(),
           /**
@@ -242,6 +267,11 @@ export const vToolResultOutput = v.union(
            * @see https://www.iana.org/assignments/media-types/media-types.xhtml
            */
           mediaType: v.string(),
+          providerOptions,
+        }),
+        v.object({
+          type: v.literal("image-file-reference"),
+          providerReference: v.record(v.string(), v.string()),
           providerOptions,
         }),
         v.object({
@@ -457,15 +487,34 @@ export const vFinishReason = v.union(
 );
 
 export const vUsage = v.object({
-  promptTokens: v.number(),
-  completionTokens: v.number(),
-  totalTokens: v.number(),
+  promptTokens: v.optional(v.number()),
+  completionTokens: v.optional(v.number()),
+  totalTokens: v.optional(v.number()),
   reasoningTokens: v.optional(v.number()),
   cachedInputTokens: v.optional(v.number()),
+  nonCachedInputTokens: v.optional(v.number()),
+  cacheWriteInputTokens: v.optional(v.number()),
+  textOutputTokens: v.optional(v.number()),
+  raw: v.optional(v.record(v.string(), v.any())),
 });
 export type Usage = Infer<typeof vUsage>;
 
 export const vLanguageModelCallWarning = v.union(
+  v.object({
+    type: v.literal("unsupported"),
+    feature: v.string(),
+    details: v.optional(v.string()),
+  }),
+  v.object({
+    type: v.literal("compatibility"),
+    feature: v.string(),
+    details: v.optional(v.string()),
+  }),
+  v.object({
+    type: v.literal("deprecated"),
+    setting: v.string(),
+    message: v.string(),
+  }),
   v.object({
     type: v.literal("unsupported-setting"),
     setting: v.string(),
@@ -541,8 +590,13 @@ export const vStorageOptions = v.object({
   ),
 });
 
-const vPromptFields = {
-  system: v.optional(v.string()),
+// Generated Convex actions keep the established `system` wire field. The
+// Vercel adapter translates it to AI SDK 7's `instructions` before invoking
+// the model, so action payloads never carry both spellings.
+const vActionPromptFields = {
+  system: v.optional(
+    v.union(v.string(), vSystemMessage, v.array(vSystemMessage)),
+  ),
   prompt: v.optional(v.string()),
   messages: v.optional(v.array(vMessage)),
   promptMessageId: v.optional(v.string()),
@@ -569,7 +623,8 @@ const vCommonArgs = {
   storageOptions: v.optional(vStorageOptions),
   providerOptions,
   callSettings: v.optional(vCallSettings),
-  ...vPromptFields,
+  allowSystemInMessages: v.optional(v.boolean()),
+  ...vActionPromptFields,
 };
 
 export const vTextArgs = v.object({

--- a/src/vercel/UIMessages.ts
+++ b/src/vercel/UIMessages.ts
@@ -1,8 +1,10 @@
 import {
   convertToModelMessages,
   type UIMessage as AIUIMessage,
+  type CustomContentUIPart,
   type DeepPartial,
   type DynamicToolUIPart,
+  type ReasoningFileUIPart,
   type ReasoningUIPart,
   type SourceDocumentUIPart,
   type SourceUrlUIPart,
@@ -13,6 +15,10 @@ import {
   type UIDataTypes,
   type UITools,
 } from "ai";
+import {
+  convertUint8ArrayToBase64,
+  type ReasoningFilePart,
+} from "@ai-sdk/provider-utils";
 import type { Infer } from "convex/values";
 import { toModelMessage, fromModelMessage, toUIFilePart } from "./mapping.js";
 import {
@@ -399,7 +405,13 @@ function createAssistantUIMessage<
 
   // Extract approval parts from raw message content for UI rendering
   type ApprovalPart =
-    | { type: "tool-approval-request"; approvalId: string; toolCallId: string }
+    | {
+        type: "tool-approval-request";
+        approvalId: string;
+        toolCallId: string;
+        isAutomatic?: boolean;
+        signature?: string;
+      }
     | {
         type: "tool-approval-response";
         approvalId: string;
@@ -496,6 +508,16 @@ function createAssistantUIMessage<
             ...partCommon,
             ...contentPart,
           } satisfies ReasoningUIPart);
+          break;
+        case "reasoning-file":
+          allParts.push(toUIReasoningFilePart(contentPart));
+          break;
+        case "custom":
+          allParts.push({
+            type: "custom",
+            kind: contentPart.kind,
+            providerMetadata: contentPart.providerOptions,
+          } satisfies CustomContentUIPart);
           break;
         case "file":
         case "image":
@@ -614,6 +636,8 @@ function createAssistantUIMessage<
           const typedPart = contentPart as {
             toolCallId: string;
             approvalId: string;
+            isAutomatic?: boolean;
+            signature?: string;
           };
           const toolCallPart = allParts.find(
             (part) =>
@@ -624,6 +648,12 @@ function createAssistantUIMessage<
             toolCallPart.state = "approval-requested";
             (toolCallPart as ToolUIPart & { approval?: object }).approval = {
               id: typedPart.approvalId,
+              ...(typedPart.isAutomatic !== undefined
+                ? { isAutomatic: typedPart.isAutomatic }
+                : {}),
+              ...(typedPart.signature !== undefined
+                ? { signature: typedPart.signature }
+                : {}),
             };
           } else {
             console.warn(
@@ -648,9 +678,15 @@ function createAssistantUIMessage<
           ) as ToolUIPart | undefined;
 
           if (toolCallPart) {
+            const approval = (
+              toolCallPart as ToolUIPart & {
+                approval?: { isAutomatic?: boolean; signature?: string };
+              }
+            ).approval;
             if (typedPart.approved) {
               toolCallPart.state = "approval-responded";
               (toolCallPart as ToolUIPart & { approval?: object }).approval = {
+                ...approval,
                 id: typedPart.approvalId,
                 approved: true,
                 reason: typedPart.reason,
@@ -658,6 +694,7 @@ function createAssistantUIMessage<
             } else {
               toolCallPart.state = "output-denied";
               (toolCallPart as ToolUIPart & { approval?: object }).approval = {
+                ...approval,
                 id: typedPart.approvalId,
                 approved: false,
                 reason: typedPart.reason,
@@ -711,6 +748,12 @@ function createAssistantUIMessage<
         // update state if not in a final state
         (toolCallPart as ToolUIPart & { approval?: object }).approval = {
           id: approvalPart.approvalId,
+          ...(approvalPart.isAutomatic !== undefined
+            ? { isAutomatic: approvalPart.isAutomatic }
+            : {}),
+          ...(approvalPart.signature !== undefined
+            ? { signature: approvalPart.signature }
+            : {}),
         };
         if (!finalStates.has(toolCallPart.state)) {
           toolCallPart.state = "approval-requested";
@@ -726,7 +769,13 @@ function createAssistantUIMessage<
 
       if (toolCallPart) {
         // Always update approval info, but only update state if not in a final state
+        const approval = (
+          toolCallPart as ToolUIPart & {
+            approval?: { isAutomatic?: boolean; signature?: string };
+          }
+        ).approval;
         (toolCallPart as ToolUIPart & { approval?: object }).approval = {
+          ...approval,
           id: approvalPart.approvalId,
           approved: approvalPart.approved,
           reason: approvalPart.reason,
@@ -776,6 +825,48 @@ function createAssistantUIMessage<
     parts: allParts,
     metadata: group.find((m) => m.metadata)?.metadata,
   };
+}
+
+function toUIReasoningFilePart(part: ReasoningFilePart): ReasoningFileUIPart {
+  const data = part.data;
+  return {
+    type: "reasoning-file",
+    mediaType: part.mediaType,
+    url: toUIReasoningFileUrl(data, part.mediaType),
+    providerMetadata: part.providerOptions,
+  };
+}
+
+function toUIReasoningFileUrl(
+  data: ReasoningFilePart["data"],
+  mediaType: string,
+): string {
+  if (isTaggedReasoningFileData(data)) {
+    if (data.type === "url") return data.url.toString();
+    data = data.data;
+  }
+  if (data instanceof URL) return data.toString();
+  if (typeof data === "string") {
+    return data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+  }
+  const bytes =
+    data instanceof ArrayBuffer
+      ? new Uint8Array(data)
+      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return `data:${mediaType};base64,${convertUint8ArrayToBase64(bytes)}`;
+}
+
+function isTaggedReasoningFileData(
+  data: ReasoningFilePart["data"],
+): data is Extract<ReasoningFilePart["data"], { type: string }> {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    !(data instanceof URL) &&
+    !(data instanceof ArrayBuffer) &&
+    !(data instanceof Uint8Array) &&
+    "type" in data
+  );
 }
 
 function toSourcePart(

--- a/src/vercel/client/approval.test.ts
+++ b/src/vercel/client/approval.test.ts
@@ -145,6 +145,14 @@ export const testApproveFlow = action({
       threadId: thread.threadId,
       paginationOpts: { cursor: null, numItems: 20 },
     });
+    const toolResults = allMessages.page.flatMap((message) =>
+      Array.isArray(message.message?.content)
+        ? message.message.content.filter(
+            (part) =>
+              part.type === "tool-result" && part.toolCallId === "tc-approve",
+          )
+        : [],
+    );
 
     return {
       approvalId,
@@ -154,8 +162,9 @@ export const testApproveFlow = action({
       secondSavedCount: result2.savedMessages?.length ?? 0,
       totalThreadMessages: allMessages.page.length,
       threadMessageRoles: allMessages.page.map((m) => m.message?.role),
+      toolResults,
       usageCallCount: usageCalls.length,
-      // Verify usage data includes detail fields (AI SDK v6)
+      // Verify usage data includes detail fields.
       lastUsage: usageCalls.at(-1),
     };
   },
@@ -431,8 +440,6 @@ describe("Tool Approval Workflow", () => {
     expect(result.firstSavedCount).toBeGreaterThanOrEqual(2);
     // Second call: tool-result + assistant text
     expect(result.secondSavedCount).toBeGreaterThanOrEqual(1);
-    // Thread should have (ascending): user, assistant(tool-call+approval),
-    // tool(approval-response), tool(tool-result), assistant(text)
     // listMessages returns descending order:
     expect(result.threadMessageRoles).toEqual([
       "assistant", // final text
@@ -441,9 +448,17 @@ describe("Tool Approval Workflow", () => {
       "assistant", // tool-call + approval-request
       "user", // prompt
     ]);
+    expect(result.toolResults).toEqual([
+      {
+        type: "tool-result",
+        toolCallId: "tc-approve",
+        toolName: "deleteFile",
+        output: { type: "text", value: "Deleted: test.txt" },
+      },
+    ]);
     // Usage handler should be called for each generateText call
     expect(result.usageCallCount).toBeGreaterThanOrEqual(2);
-    // Usage data should include AI SDK v6 detail fields
+    // Usage data should include detail fields.
     expect(result.lastUsage).toBeDefined();
     expect(result.lastUsage!.inputTokenDetails).toBeDefined();
     expect(result.lastUsage!.outputTokenDetails).toBeDefined();
@@ -457,9 +472,7 @@ describe("Tool Approval Workflow", () => {
     expect(result.approvalId).toBeDefined();
     expect(result.firstText).toBe("");
     expect(result.secondText).toBe("OK, I won't delete that file.");
-    // Same message ordering as approve flow:
-    // user, assistant(tool-call+approval), tool(denial-response),
-    // tool(execution-denied result), assistant(text)
+    // Same message ordering as approve flow.
     expect(result.threadMessageRoles).toEqual([
       "assistant",
       "tool",
@@ -483,14 +496,11 @@ describe("Tool Approval Workflow", () => {
     expect(result.secondText).toBe(
       "Done! Deleted old.txt and renamed a.txt to b.txt.",
     );
-    // Both approval responses should be merged into one tool message
-    // (write-time merge in respondToToolCallApproval via findApprovalContext)
-    // Thread: user, assistant(2 tool-calls + 2 approvals),
-    //         tool(2 approval-responses merged), tool(2 tool-results), assistant(text)
+    // Executed results are persisted separately from approval responses.
     expect(result.threadMessageRoles).toEqual([
       "assistant", // final text
       "tool", // tool-results
-      "tool", // approval-responses (merged)
+      "tool", // approval-responses
       "assistant", // tool-calls + approval-requests
       "user", // prompt
     ]);

--- a/src/vercel/client/createTool.ts
+++ b/src/vercel/client/createTool.ts
@@ -1,4 +1,9 @@
-import type { ToolResultOutput } from "@ai-sdk/provider-utils";
+import type { JSONObject } from "@ai-sdk/provider";
+import type {
+  Context,
+  Experimental_SandboxSession,
+  ToolResultOutput,
+} from "@ai-sdk/provider-utils";
 import type {
   FlexibleSchema,
   ModelMessage,
@@ -28,12 +33,16 @@ export type ToolCtx<DataModel extends GenericDataModel = GenericDataModel> =
     messageId?: string;
   };
 
+export type AgentToolExecutionOptions<TOOL_CONTEXT extends Context = Context> =
+  ToolExecutionOptions<TOOL_CONTEXT>;
+
 /**
  * Function that is called to determine if the tool needs approval before it can be executed.
  */
 export type ToolNeedsApprovalFunctionCtx<
   INPUT,
   Ctx extends ToolCtx = ToolCtx,
+  TOOL_CONTEXT extends Context = Context,
 > = (
   ctx: Ctx,
   input: INPUT,
@@ -52,7 +61,7 @@ export type ToolNeedsApprovalFunctionCtx<
      *
      * Experimental (can break in patch releases).
      */
-    experimental_context?: unknown;
+    context: TOOL_CONTEXT;
   },
 ) => boolean | PromiseLike<boolean>;
 
@@ -60,10 +69,11 @@ export type ToolExecuteFunctionCtx<
   INPUT,
   OUTPUT,
   Ctx extends ToolCtx = ToolCtx,
+  TOOL_CONTEXT extends Context = Context,
 > = (
   ctx: Ctx,
   input: INPUT,
-  options: ToolExecutionOptions,
+  options: AgentToolExecutionOptions<TOOL_CONTEXT>,
 ) => AsyncIterable<OUTPUT> | PromiseLike<OUTPUT>;
 
 type NeverOptional<N, T> = 0 extends 1 & N
@@ -83,6 +93,7 @@ export type ToolOutputPropertiesCtx<
   INPUT,
   OUTPUT,
   Ctx extends ToolCtx = ToolCtx,
+  TOOL_CONTEXT extends Context = Context,
 > = NeverOptional<
   OUTPUT,
   {
@@ -93,7 +104,7 @@ export type ToolOutputPropertiesCtx<
      * @param input - The input of the tool call.
      * @param options.abortSignal - A signal that can be used to abort the tool call.
      */
-    execute?: ToolExecuteFunctionCtx<INPUT, OUTPUT, Ctx>;
+    execute?: ToolExecuteFunctionCtx<INPUT, OUTPUT, Ctx, TOOL_CONTEXT>;
     outputSchema?: FlexibleSchema<OUTPUT>;
     /**
      * @deprecated Removed in v0.6.0. Use `execute` instead.
@@ -133,14 +144,24 @@ export type ToolInputProperties<INPUT> = {
  *
  * @returns A tool to be used with the AI SDK.
  */
-export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
+export function createTool<
+  INPUT,
+  OUTPUT,
+  Ctx extends ToolCtx = ToolCtx,
+  TOOL_CONTEXT extends Context = Context,
+>(
   def: {
     /**
      * An optional description of what the tool does.
      * Will be used by the language model to decide whether to use the tool.
      * Not used for provider-defined tools.
      */
-    description?: string;
+    description?:
+      | string
+      | ((options: {
+          context: NoInfer<TOOL_CONTEXT>;
+          experimental_sandbox?: Experimental_SandboxSession;
+        }) => string);
     /**
      * An optional title of the tool.
      */
@@ -151,6 +172,8 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
      * functionality that can be fully encapsulated in the provider.
      */
     providerOptions?: ProviderOptions;
+    metadata?: JSONObject;
+    contextSchema?: FlexibleSchema<TOOL_CONTEXT>;
   } & ToolInputProperties<INPUT> & {
       /**
        * An optional list of input examples that show the language
@@ -166,7 +189,8 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
         | boolean
         | ToolNeedsApprovalFunctionCtx<
             [INPUT] extends [never] ? unknown : INPUT,
-            Ctx
+            Ctx,
+            TOOL_CONTEXT
           >;
       /**
        * Strict mode setting for the tool.
@@ -186,7 +210,7 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
        */
       onInputStart?: (
         ctx: Ctx,
-        options: ToolExecutionOptions,
+        options: AgentToolExecutionOptions<TOOL_CONTEXT>,
       ) => void | PromiseLike<void>;
       /**
        * Optional function that is called when an argument streaming delta is available.
@@ -194,7 +218,9 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
        */
       onInputDelta?: (
         ctx: Ctx,
-        options: { inputTextDelta: string } & ToolExecutionOptions,
+        options: {
+          inputTextDelta: string;
+        } & AgentToolExecutionOptions<TOOL_CONTEXT>,
       ) => void | PromiseLike<void>;
       /**
        * Optional function that is called when a tool call can be started,
@@ -204,9 +230,9 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
         ctx: Ctx,
         options: {
           input: [INPUT] extends [never] ? unknown : INPUT;
-        } & ToolExecutionOptions,
+        } & AgentToolExecutionOptions<TOOL_CONTEXT>,
       ) => void | PromiseLike<void>;
-    } & ToolOutputPropertiesCtx<INPUT, OUTPUT, Ctx> & {
+    } & ToolOutputPropertiesCtx<INPUT, OUTPUT, Ctx, TOOL_CONTEXT> & {
       /**
        * Optional conversion function that maps the tool result to an output that can be used by the language model.
        *
@@ -234,7 +260,7 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
         },
       ) => ToolResultOutput | PromiseLike<ToolResultOutput>;
     },
-): Tool<INPUT, OUTPUT> {
+): Tool<INPUT, OUTPUT, TOOL_CONTEXT> {
   // Runtime backwards compat - types will show errors but runtime still works
   const inputSchema = def.inputSchema ?? (def as any).args;
   if (!inputSchema)
@@ -260,16 +286,18 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
         " handler function, define an outputSchema, or both",
     );
 
-  const t = tool<INPUT, OUTPUT>({
+  const t = tool<INPUT, OUTPUT, TOOL_CONTEXT>({
     type: "function",
     __acceptsCtx: true,
     ctx: def.ctx,
     description: def.description,
     title: def.title,
     providerOptions: def.providerOptions,
+    metadata: def.metadata,
     inputSchema,
+    contextSchema: def.contextSchema,
     inputExamples: def.inputExamples,
-    needsApproval(this: Tool<INPUT, OUTPUT>, input, options) {
+    needsApproval(this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>, input, options) {
       const needsApproval = def.needsApproval;
       if (!needsApproval || typeof needsApproval === "boolean")
         return Boolean(needsApproval);
@@ -287,9 +315,9 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
     ...(executeHandler
       ? {
           execute(
-            this: Tool<INPUT, OUTPUT>,
+            this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>,
             input: INPUT,
-            options: ToolExecutionOptions,
+            options: ToolExecutionOptions<TOOL_CONTEXT>,
           ) {
             if (!getCtx(this)) {
               throw new Error(
@@ -306,25 +334,37 @@ export function createTool<INPUT, OUTPUT, Ctx extends ToolCtx = ToolCtx>(
   });
   if (def.onInputStart) {
     const origOnInputStart = def.onInputStart;
-    t.onInputStart = function (this: Tool<INPUT, OUTPUT>, options) {
+    t.onInputStart = function (
+      this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>,
+      options,
+    ) {
       return origOnInputStart.call(this, getCtx(this), options);
     };
   }
   if (def.onInputDelta) {
     const origOnInputDelta = def.onInputDelta;
-    t.onInputDelta = function (this: Tool<INPUT, OUTPUT>, options) {
+    t.onInputDelta = function (
+      this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>,
+      options,
+    ) {
       return origOnInputDelta.call(this, getCtx(this), options);
     };
   }
   if (def.onInputAvailable) {
     const origOnInputAvailable = def.onInputAvailable;
-    t.onInputAvailable = function (this: Tool<INPUT, OUTPUT>, options) {
+    t.onInputAvailable = function (
+      this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>,
+      options,
+    ) {
       return origOnInputAvailable.call(this, getCtx(this), options);
     };
   }
   if (def.toModelOutput) {
     const origToModelOutput = def.toModelOutput;
-    t.toModelOutput = function (this: Tool<INPUT, OUTPUT>, options) {
+    t.toModelOutput = function (
+      this: Tool<INPUT, OUTPUT, TOOL_CONTEXT>,
+      options,
+    ) {
       return origToModelOutput.call(this, getCtx(this), options);
     };
   }

--- a/src/vercel/client/definePlaygroundAPI.ts
+++ b/src/vercel/client/definePlaygroundAPI.ts
@@ -27,7 +27,7 @@ import {
   getProviderName,
   isTool,
 } from "../../shared.js";
-import { serializeNewMessagesInStep, toModelMessage } from "../mapping.js";
+import { serializeResponseMessages, toModelMessage } from "../mapping.js";
 import type { Agent } from "../index.js";
 import { listMessages as listMessages_ } from "./messages.js";
 import { syncStreams, vStreamMessagesReturnValue } from "./streaming.js";
@@ -282,9 +282,8 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
         { contextOptions, storageOptions, saveStreamDeltas: true },
       );
       const outputMessages: MessageDoc[][] = [];
-      let previousResponseMessageCount = 0;
       for (const step of await steps) {
-        const { messages } = await serializeNewMessagesInStep(
+        const { messages } = await serializeResponseMessages(
           ctx,
           component,
           step,
@@ -292,9 +291,8 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
             model: getModelName(agent.options.languageModel),
             provider: getProviderName(agent.options.languageModel),
           },
-          previousResponseMessageCount,
+          step.response.messages,
         );
-        previousResponseMessageCount = step.response.messages.length;
         outputMessages.push(
           messages.map((messageWithMetadata, i) => {
             return {

--- a/src/vercel/client/index.test.ts
+++ b/src/vercel/client/index.test.ts
@@ -24,7 +24,7 @@ import { defineSchema } from "convex/server";
 import { stepCountIs } from "ai";
 import { components, initConvexTest } from "./setup.test.js";
 import { z } from "zod/v4";
-import { mockModel } from "./mockModel.js";
+import { MockLanguageModel, mockModel } from "./mockModel.js";
 
 const schema = defineSchema({});
 type DataModel = DataModelFromSchemaDefinition<typeof schema>;
@@ -35,12 +35,50 @@ const action = actionGeneric as ActionBuilder<DataModel, "public">;
 
 const TEST_TEXT = JSON.stringify({ hello: "world" });
 
+const agentModel = new MockLanguageModel({
+  content: [{ type: "text", text: TEST_TEXT }],
+});
 const agent = new Agent(components.agent, {
   name: "test",
   instructions: "You are a test agent",
+  languageModel: agentModel,
+});
+
+let capturedRawBodies: { request?: unknown; response?: unknown } | undefined;
+const rawBodyAgent = new Agent(components.agent, {
+  name: "raw-body-test",
   languageModel: mockModel({
-    content: [{ type: "text", text: TEST_TEXT }],
+    doGenerate: async () => ({
+      content: [{ type: "text", text: "raw" }],
+      finishReason: { unified: "stop", raw: undefined },
+      usage: {
+        inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 1, text: 1, reasoning: 0 },
+      },
+      request: { body: { prompt: "request-body" } },
+      response: { body: { text: "response-body" }, headers: {} },
+      warnings: [],
+    }),
   }),
+  rawRequestResponseHandler: async (_ctx, event) => {
+    capturedRawBodies = {
+      request: event.request.body,
+      response: event.response.body,
+    };
+  },
+});
+
+export const captureRawBodies = action({
+  args: {},
+  handler: async (ctx) => {
+    capturedRawBodies = undefined;
+    await rawBodyAgent.generateText(
+      ctx,
+      { userId: "raw-body-user" },
+      { prompt: "raw" },
+    );
+    return capturedRawBodies;
+  },
 });
 
 export const testQuery = query({
@@ -90,7 +128,7 @@ const saveStepAgent = new Agent(components.agent, {
 });
 
 export const replayStepsViaSaveStep = action({
-  args: { withWatermark: v.boolean() },
+  args: { withPreviousStep: v.boolean() },
   handler: async (ctx, args) => {
     const { thread } = await saveStepAgent.createThread(ctx, {
       userId: "ss-gen",
@@ -101,18 +139,21 @@ export const replayStepsViaSaveStep = action({
     const { threadId } = await saveStepAgent.createThread(ctx, {
       userId: "ss-replay",
     });
-    const { messageId: promptMessageId } = await saveStepAgent.saveMessage(ctx, {
-      threadId,
-      message: { role: "user", content: "echo hi" },
-      skipEmbeddings: true,
-    });
+    const { messageId: promptMessageId } = await saveStepAgent.saveMessage(
+      ctx,
+      {
+        threadId,
+        message: { role: "user", content: "echo hi" },
+        skipEmbeddings: true,
+      },
+    );
     let previousStep: (typeof steps)[number] | undefined;
     for (const step of steps) {
       await saveStepAgent.saveStep(ctx, {
         threadId,
         promptMessageId,
         step,
-        previousStep: args.withWatermark ? previousStep : undefined,
+        previousStep: args.withPreviousStep ? previousStep : undefined,
       });
       previousStep = step;
     }
@@ -231,6 +272,7 @@ const testApi: ApiFromModules<{
     generateTextAction: typeof generateTextAction;
     generateObjectAction: typeof generateObjectAction;
     saveMessageMutation: typeof saveMessageMutation;
+    captureRawBodies: typeof captureRawBodies;
     replayStepsViaSaveStep: typeof replayStepsViaSaveStep;
   };
 }>["fns"] = anyApi["index.test"] as any;
@@ -247,27 +289,26 @@ describe("Agent thick client", () => {
     expect(result).toBeDefined();
     expect(result).toMatch(TEST_TEXT);
   });
-  test("saveStep with previousStep saves each step's new messages exactly once", async () => {
-    const t = initConvexTest(schema);
-    const res = await t.action(testApi.replayStepsViaSaveStep, {
-      withWatermark: true,
-    });
-    expect(res.stepCount).toBe(2);
-    const toolCalls = res.contentTypes.filter((t) => t === "tool-call").length;
-    const toolResults = res.contentTypes.filter(
-      (t) => t === "tool-result",
-    ).length;
-    expect(toolCalls).toBe(1);
-    expect(toolResults).toBe(1);
-  });
-  test("saveStep without previousStep duplicates prior messages", async () => {
-    const t = initConvexTest(schema);
-    const res = await t.action(testApi.replayStepsViaSaveStep, {
-      withWatermark: false,
-    });
-    const toolCalls = res.contentTypes.filter((t) => t === "tool-call").length;
-    expect(toolCalls).toBeGreaterThan(1);
-  });
+  test.each([true, false])(
+    "saveStep persists each SDK 7 step once (previousStep: %s)",
+    async (withPreviousStep) => {
+      const t = initConvexTest(schema);
+      const res = await t.action(testApi.replayStepsViaSaveStep, {
+        withPreviousStep,
+      });
+      expect(res.stepCount).toBe(2);
+      const toolCalls = res.contentTypes.filter(
+        (t) => t === "tool-call",
+      ).length;
+      const toolResults = res.contentTypes.filter(
+        (t) => t === "tool-result",
+      ).length;
+      expect({ toolCalls, toolResults }).toEqual({
+        toolCalls: 1,
+        toolResults: 1,
+      });
+    },
+  );
 });
 
 describe("filterOutOrphanedToolMessages", () => {
@@ -335,6 +376,14 @@ describe("filterOutOrphanedToolMessages", () => {
 });
 
 describe("Agent option variations and normal behavior", () => {
+  test("raw handler opts into retained SDK 7 request and response bodies", async () => {
+    const t = initConvexTest(schema);
+    await expect(t.action(testApi.captureRawBodies, {})).resolves.toEqual({
+      request: { prompt: "request-body" },
+      response: { text: "response-body" },
+    });
+  });
+
   test("Agent can be constructed with minimal options", () => {
     const a = new Agent(components.agent, {
       name: "minimal",
@@ -467,6 +516,25 @@ describe("Agent-generated mutations/actions/queries", () => {
       messages: [{ role: "user", content: "Give object" }],
     });
     expect(objResult.object).toBeDefined();
+  });
+
+  test("asTextAction maps its system wire field to AI SDK instructions", async () => {
+    const t = initConvexTest(schema);
+    const before = agentModel.doGenerateCalls.length;
+
+    await t.action(testApi.generateTextAction, {
+      userId: "8",
+      system: "Action-scoped instructions",
+      prompt: "Say hi",
+    });
+
+    const call = agentModel.doGenerateCalls.at(-1);
+    expect(agentModel.doGenerateCalls).toHaveLength(before + 1);
+    expect(call?.prompt[0]).toEqual({
+      role: "system",
+      content: "Action-scoped instructions",
+    });
+    expect(call).not.toHaveProperty("system");
   });
 
   test("asSaveMessagesMutation works via t.mutation", async () => {

--- a/src/vercel/client/mockModel.ts
+++ b/src/vercel/client/mockModel.ts
@@ -1,7 +1,7 @@
 import type {
-  LanguageModelV3,
-  LanguageModelV3Content,
-  LanguageModelV3StreamPart,
+  LanguageModelV4,
+  LanguageModelV4Content,
+  LanguageModelV4StreamPart,
 } from "@ai-sdk/provider";
 import { simulateReadableStream, type ProviderMetadata } from "ai";
 import { assert, pick } from "convex-helpers";
@@ -13,26 +13,25 @@ C C C C C C C C C C C C C C C
 D D D D D D D D D D D D D D D
 `;
 const DEFAULT_USAGE = {
-  outputTokens: 10,
-  inputTokens: 3,
-  totalTokens: 13,
-  inputTokenDetails: {
-    noCacheTokens: 3,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: 0,
+    cacheWrite: 0,
   },
-  outputTokenDetails: {
-    textTokens: 10,
-    reasoningTokens: 0,
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: 0,
   },
 };
 
 export type MockModelArgs = {
-  provider?: LanguageModelV3["provider"];
-  modelId?: LanguageModelV3["modelId"];
+  provider?: LanguageModelV4["provider"];
+  modelId?: LanguageModelV4["modelId"];
   supportedUrls?:
-    | LanguageModelV3["supportedUrls"]
-    | (() => LanguageModelV3["supportedUrls"]);
+    | LanguageModelV4["supportedUrls"]
+    | (() => LanguageModelV4["supportedUrls"]);
   chunkDelayInMs?: number;
   initialDelayInMs?: number;
   /** A list of the responses for multiple steps.
@@ -40,15 +39,15 @@ export type MockModelArgs = {
    * then the next list would be after the tool response or another tool call.
    * Tool responses come from actual tool calls!
    */
-  contentSteps?: LanguageModelV3Content[][];
+  contentSteps?: LanguageModelV4Content[][];
   /** A single list of content responded from each step.
    * Provide contentSteps instead if you want to do multi-step responses with
    * tool calls.
    */
-  content?: LanguageModelV3Content[];
+  content?: LanguageModelV4Content[];
   // provide either content, contentResponses or doGenerate & doStream
-  doGenerate?: LanguageModelV3["doGenerate"];
-  doStream?: LanguageModelV3["doStream"];
+  doGenerate?: LanguageModelV4["doGenerate"];
+  doStream?: LanguageModelV4["doStream"];
   providerMetadata?: ProviderMetadata;
   fail?:
     | boolean
@@ -62,23 +61,23 @@ function atMostOneOf(...args: unknown[]) {
   return args.filter(Boolean).length <= 1;
 }
 
-export function mockModel(args?: MockModelArgs): LanguageModelV3 {
+export function mockModel(args?: MockModelArgs): LanguageModelV4 {
   return new MockLanguageModel(args ?? {});
 }
 
-export class MockLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3";
+export class MockLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4";
 
-  private _supportedUrls: () => LanguageModelV3["supportedUrls"];
+  private _supportedUrls: () => LanguageModelV4["supportedUrls"];
 
-  readonly provider: LanguageModelV3["provider"];
-  readonly modelId: LanguageModelV3["modelId"];
+  readonly provider: LanguageModelV4["provider"];
+  readonly modelId: LanguageModelV4["modelId"];
 
-  doGenerate: LanguageModelV3["doGenerate"];
-  doStream: LanguageModelV3["doStream"];
+  doGenerate: LanguageModelV4["doGenerate"];
+  doStream: LanguageModelV4["doStream"];
 
-  doGenerateCalls: Parameters<LanguageModelV3["doGenerate"]>[0][] = [];
-  doStreamCalls: Parameters<LanguageModelV3["doStream"]>[0][] = [];
+  doGenerateCalls: Parameters<LanguageModelV4["doGenerate"]>[0][] = [];
+  doStreamCalls: Parameters<LanguageModelV4["doStream"]>[0][] = [];
 
   constructor(args: MockModelArgs) {
     assert(
@@ -108,19 +107,19 @@ export class MockLanguageModel implements LanguageModelV3 {
       "Mock error message";
     const metadata = pick(args, ["providerMetadata"]);
 
-    const chunkResponses: LanguageModelV3StreamPart[][] = contentSteps.map(
+    const chunkResponses: LanguageModelV4StreamPart[][] = contentSteps.map(
       (content) => {
-        const chunks: LanguageModelV3StreamPart[] = [
+        const chunks: LanguageModelV4StreamPart[] = [
           { type: "stream-start", warnings: [] },
         ];
         chunks.push(
-          ...content.flatMap((c, ci): LanguageModelV3StreamPart[] => {
+          ...content.flatMap((c, ci): LanguageModelV4StreamPart[] => {
             if (c.type !== "text" && c.type !== "reasoning") {
               return [c];
             }
             const metadata = pick(c, ["providerMetadata"]);
             const deltas = c.text.split(" ");
-            const parts: LanguageModelV3StreamPart[] = [];
+            const parts: LanguageModelV4StreamPart[] = [];
             if (c.type === "reasoning") {
               parts.push({
                 type: "reasoning-start",
@@ -135,7 +134,7 @@ export class MockLanguageModel implements LanguageModelV3 {
                       delta: (di ? " " : "") + delta,
                       id: `reasoning-${ci}`,
                       ...metadata,
-                    }) satisfies LanguageModelV3StreamPart,
+                    }) satisfies LanguageModelV4StreamPart,
                 ),
               );
               parts.push({
@@ -157,7 +156,7 @@ export class MockLanguageModel implements LanguageModelV3 {
                       delta: (di ? " " : "") + delta,
                       id: `txt-${ci}`,
                       ...metadata,
-                    }) satisfies LanguageModelV3StreamPart,
+                    }) satisfies LanguageModelV4StreamPart,
                 ),
               );
               parts.push({
@@ -177,7 +176,7 @@ export class MockLanguageModel implements LanguageModelV3 {
         }
         chunks.push({
           type: "finish",
-          finishReason: fail ? "error" : "stop",
+          finishReason: { unified: fail ? "error" : "stop", raw: undefined },
           usage: DEFAULT_USAGE,
           ...(metadata as any),
         });
@@ -198,7 +197,7 @@ export class MockLanguageModel implements LanguageModelV3 {
       } else if (contentSteps.length) {
         const result = {
           content: contentSteps[callIndex % contentSteps.length],
-          finishReason: "stop" as const,
+          finishReason: { unified: "stop" as const, raw: undefined },
           usage: DEFAULT_USAGE,
           ...(metadata as any),
           warnings: [],

--- a/src/vercel/client/start.test.ts
+++ b/src/vercel/client/start.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { resolveUsageModel } from "./start.js";
+
+describe("resolveUsageModel", () => {
+  it("prefers a step model while object results retain the active model", () => {
+    const activeModel = { provider: "fallback", model: "fallback-model" };
+    const stepModel = { provider: "router", model: "routed-model" };
+
+    expect(resolveUsageModel({ step: { model: stepModel } }, activeModel)).toBe(
+      stepModel,
+    );
+    expect(resolveUsageModel({ object: {} }, activeModel)).toBe(activeModel);
+  });
+});

--- a/src/vercel/client/start.ts
+++ b/src/vercel/client/start.ts
@@ -1,20 +1,27 @@
 import {
-  stepCountIs,
-  type CallSettings,
+  isStepCount,
   type GenerateObjectResult,
   type IdGenerator,
   type LanguageModel,
+  type Instructions,
   type ModelMessage,
   type StepResult,
   type StopCondition,
   type ToolSet,
 } from "ai";
+import type { Context } from "@ai-sdk/provider-utils";
 import {
   serializeResponseMessages,
   serializeObjectResult,
 } from "../mapping.js";
 import { embedMessages, fetchContextWithPrompt } from "./search.js";
-import type { ActionCtx, AgentComponent, Config, Options } from "./types.js";
+import type {
+  ActionCtx,
+  AgentCallSettings,
+  AgentComponent,
+  Config,
+  Options,
+} from "./types.js";
 import type { Message, MessageDoc } from "../../validators.js";
 import {
   getModelName,
@@ -27,10 +34,54 @@ import { assert, omit } from "convex-helpers";
 import { saveInputMessages } from "./saveInputMessages.js";
 import type { GenericActionCtx, GenericDataModel } from "convex/server";
 
+export function resolveUsageModel(
+  toSave:
+    | { step: { model?: ModelOrMetadata } }
+    | { object: unknown },
+  activeModel: ModelOrMetadata,
+): ModelOrMetadata {
+  return "step" in toSave ? (toSave.step.model ?? activeModel) : activeModel;
+}
+
+type RawRequestResponseInclude = Record<string, boolean>;
+
+/**
+ * The raw handler promises request and, for non-streaming calls, response
+ * bodies. Preserve explicit caller choices while opting in to those bodies.
+ */
+function rawRequestResponseInclude(
+  args: {
+    experimental_include?: RawRequestResponseInclude;
+    include?: RawRequestResponseInclude;
+  },
+  enabled: boolean,
+  operation:
+    | "generateText"
+    | "streamText"
+    | "generateObject"
+    | "streamObject"
+    | undefined,
+): RawRequestResponseInclude | undefined {
+  if (!enabled) return undefined;
+
+  const requested = {
+    ...args.experimental_include,
+    ...args.include,
+  };
+  return {
+    ...requested,
+    requestBody: requested.requestBody ?? true,
+    ...((operation === "generateText" || operation === "generateObject")
+      ? { responseBody: requested.responseBody ?? true }
+      : {}),
+  };
+}
+
 export async function startGeneration<
   T,
   Tools extends ToolSet = ToolSet,
   CustomCtx extends object = object,
+  RUNTIME_CONTEXT extends Context = Context,
 >(
   ctx: ActionCtx & CustomCtx,
   component: AgentComponent,
@@ -74,13 +125,20 @@ export async function startGeneration<
      *   the promptMessageId message, if provided.
      */
     messages?: (ModelMessage | Message)[];
+    instructions?: Instructions;
+    /** @deprecated Use instructions. */
+    system?: Instructions;
+    allowSystemInMessages?: boolean;
     /**
      * The abort signal to be passed to the LLM call. If triggered, it will
      * mark the pending message as failed. If the generation is asynchronously
      * aborted, it will trigger this signal when detected.
      */
     abortSignal?: AbortSignal;
-    stopWhen?: StopCondition<Tools> | Array<StopCondition<Tools>>;
+    runtimeContext?: RUNTIME_CONTEXT;
+    stopWhen?:
+      | StopCondition<Tools, RUNTIME_CONTEXT>
+      | Array<StopCondition<Tools, RUNTIME_CONTEXT>>;
     _internal?: { generateId?: IdGenerator };
   },
   {
@@ -94,14 +152,20 @@ export async function startGeneration<
       agentName: string;
       agentForToolCtx?: Agent;
     },
+  _operation?:
+    | "generateText"
+    | "streamText"
+    | "generateObject"
+    | "streamObject",
 ): Promise<{
   args: T & {
-    system?: string;
+    instructions?: Instructions;
     model: LanguageModel;
     messages: ModelMessage[];
     prompt?: never;
     tools?: Tools;
-  } & CallSettings;
+    runtimeContext?: RUNTIME_CONTEXT;
+  } & AgentCallSettings;
   order: number;
   stepOrder: number;
   userId: string | undefined;
@@ -109,7 +173,10 @@ export async function startGeneration<
   updateModel: (model: ModelOrMetadata | undefined) => void;
   save: <TOOLS extends ToolSet>(
     toSave:
-      | { step: StepResult<TOOLS> }
+      | {
+          step: StepResult<TOOLS, RUNTIME_CONTEXT>;
+          responseMessages?: ModelMessage[];
+        }
       | { object: GenerateObjectResult<unknown> },
     createPendingMessage?: boolean,
     finishStreamId?: string,
@@ -132,6 +199,15 @@ export async function startGeneration<
     prompt: args.prompt,
     promptMessageId: args.promptMessageId,
   });
+  const allowSystemInMessages = args.allowSystemInMessages ?? true;
+  if (
+    !allowSystemInMessages &&
+    context.messages.some((message) => message.role === "system")
+  ) {
+    throw new Error(
+      "System messages in assembled message history require allowSystemInMessages: true. Use instructions for top-level system guidance.",
+    );
+  }
 
   const saveMessages = opts.storageOptions?.saveMessages ?? "promptAndOutput";
   const { promptMessageId, pendingMessage, savedMessages } =
@@ -159,13 +235,22 @@ export async function startGeneration<
   assert(model, "model is required");
   let activeModel: ModelOrMetadata = model;
 
-  const fail = async (reason: string) => {
-    if (pendingMessageId) {
-      await ctx.runMutation(component.messages.finalizeMessage, {
-        messageId: pendingMessageId,
-        result: { status: "failed", error: reason },
-      });
+  // Both the caller's AbortSignal listener and AI SDK's onAbort can report
+  // the same cancellation. Share the one finalization instead of racing two
+  // mutations for the pending message.
+  let pendingMessageFailure: Promise<void> | undefined;
+  const fail = (reason: string): Promise<void> => {
+    if (!pendingMessageId) return Promise.resolve();
+    if (!pendingMessageFailure) {
+      const messageId = pendingMessageId;
+      pendingMessageFailure = ctx
+        .runMutation(component.messages.finalizeMessage, {
+          messageId,
+          result: { status: "failed", error: reason },
+        })
+        .then(() => undefined);
     }
+    return pendingMessageFailure;
   };
   if (args.abortSignal) {
     const abortSignal = args.abortSignal;
@@ -185,34 +270,52 @@ export async function startGeneration<
     agent: opts.agentForToolCtx,
   } satisfies ToolCtx;
   const tools = wrapTools(toolCtx, args.tools) as Tools;
+  const argsWithoutSystem = omit(
+    args as typeof args & { system?: Instructions },
+    ["system"],
+  );
+  const {
+    promptMessageId: _promptMessageId,
+    messages: _messages,
+    prompt: _prompt,
+    instructions: _instructions,
+    onStepFinish: _onStepFinish,
+    ...aiCallArgs
+  } = argsWithoutSystem as typeof argsWithoutSystem & {
+    onStepFinish?: unknown;
+  };
+  const include = rawRequestResponseInclude(
+    aiCallArgs as {
+      experimental_include?: RawRequestResponseInclude;
+      include?: RawRequestResponseInclude;
+    },
+    Boolean(opts.rawRequestResponseHandler),
+    _operation,
+  );
   const aiArgs = {
     ...opts.callSettings,
     providerOptions: opts.providerOptions,
-    ...omit(args, ["promptMessageId", "messages", "prompt"]),
+    ...aiCallArgs,
     model,
     messages: context.messages,
+    instructions: args.instructions ?? args.system,
+    allowSystemInMessages,
     stopWhen:
-      args.stopWhen ?? (opts.maxSteps ? stepCountIs(opts.maxSteps) : undefined),
+      args.stopWhen ?? (opts.maxSteps ? isStepCount(opts.maxSteps) : undefined),
     tools,
-  } as T & {
+    ...(include ? { include } : {}),
+  } as unknown as T & {
     model: LanguageModel;
     messages: ModelMessage[];
     prompt?: never;
     tools?: Tools;
     _internal?: { generateId?: IdGenerator };
-  } & CallSettings;
+  } & AgentCallSettings;
   // NOTE: We intentionally do NOT override _internal.generateId here.
   // The AI SDK uses generateId() for many internal IDs (approval IDs,
   // tool execution IDs, message IDs, etc.) and they must be unique.
   // The pending message is linked via the explicit `pendingMessageId`
   // parameter passed to addMessages in the save closure.
-  // Track how many response messages we've already saved across steps.
-  // step.response.messages is cumulative — each step appends to it.
-  // We need to know which messages are new in each step to serialize
-  // only the new ones (important for tool approval flows where the SDK
-  // may add extra messages like approval tool-results).
-  let previousResponseMessageCount = 0;
-
   return {
     args: aiArgs,
     order: order ?? 0,
@@ -228,7 +331,10 @@ export async function startGeneration<
     fail,
     save: async <TOOLS extends ToolSet>(
       toSave:
-        | { step: StepResult<TOOLS> }
+        | {
+            step: StepResult<TOOLS, RUNTIME_CONTEXT>;
+            responseMessages?: ModelMessage[];
+          }
         | { object: GenerateObjectResult<unknown> },
       createPendingMessage?: boolean,
       /**
@@ -247,11 +353,8 @@ export async function startGeneration<
             activeModel,
           );
         } else {
-          const allResponseMessages = toSave.step.response.messages;
-          const newResponseMessages = allResponseMessages.slice(
-            previousResponseMessageCount,
-          );
-          previousResponseMessageCount = allResponseMessages.length;
+          const newResponseMessages =
+            toSave.responseMessages ?? toSave.step.response.messages;
           // Even an empty completed step needs a durable assistant result so
           // the pending message can be finalized at the storage boundary.
           const responseMessagesToSave: ModelMessage[] =
@@ -300,6 +403,7 @@ export async function startGeneration<
             );
           } else {
             pendingMessageId = lastMessage._id;
+            pendingMessageFailure = undefined;
             savedMessages.push(...saved.messages.slice(0, -1));
           }
         } else {
@@ -318,12 +422,13 @@ export async function startGeneration<
         });
       }
       if (opts.usageHandler && output.usage) {
+        const usageModel = resolveUsageModel(toSave, activeModel);
         await opts.usageHandler(ctx, {
           userId,
           threadId,
           agentName: opts.agentName,
-          model: getModelName(activeModel),
-          provider: getProviderName(activeModel),
+          model: getModelName(usageModel),
+          provider: getProviderName(usageModel),
           usage: output.usage,
           providerMetadata: output.providerMetadata,
         });

--- a/src/vercel/client/streamText.test.ts
+++ b/src/vercel/client/streamText.test.ts
@@ -11,6 +11,7 @@ import {
 import { v } from "convex/values";
 import { components, initConvexTest } from "./setup.test.js";
 import { mockModel } from "./mockModel.js";
+import { runAbortCleanup } from "./streamText.js";
 
 const schema = defineSchema({});
 type DataModel = DataModelFromSchemaDefinition<typeof schema>;
@@ -145,6 +146,31 @@ describe("streamText with saveStreamDeltas.returnImmediately (issue #265)", () =
   });
 });
 
+describe("streamText abort cleanup", () => {
+  test("attempts every cleanup and rethrows the first internal failure", async () => {
+    const calls: string[] = [];
+    const firstFailure = new Error("failed pending message cleanup");
+
+    await expect(
+      runAbortCleanup({
+        failCall: async () => {
+          calls.push("call.fail");
+          throw firstFailure;
+        },
+        failStreamer: async () => {
+          calls.push("streamer.fail");
+          throw new Error("failed stream cleanup");
+        },
+        onAbort: () => {
+          calls.push("user.onAbort");
+        },
+      }),
+    ).rejects.toBe(firstFailure);
+
+    expect(calls).toEqual(["call.fail", "streamer.fail", "user.onAbort"]);
+  });
+});
+
 describe("streamText with an empty final step (issue #274)", () => {
   test.each([
     ["awaited", testApi.streamTextEmptyAwaited],
@@ -178,9 +204,9 @@ describe("streamText with an empty final step (issue #274)", () => {
           provider: "mock-provider",
           providerMetadata: { mock: { emptyResponse: true } },
           usage: expect.objectContaining({
-            promptTokens: 0,
-            completionTokens: 0,
-            totalTokens: 0,
+            promptTokens: 3,
+            completionTokens: 10,
+            totalTokens: 13,
           }),
         }),
       );

--- a/src/vercel/client/streamText.ts
+++ b/src/vercel/client/streamText.ts
@@ -1,9 +1,11 @@
 import type {
+  ModelMessage,
   StepResult,
   StreamTextResult,
   ToolSet,
   UIMessage as AIUIMessage,
 } from "ai";
+import type { Context } from "@ai-sdk/provider-utils";
 import { streamText as streamTextAi } from "ai";
 import {
   compressUIMessageChunks,
@@ -14,15 +16,30 @@ import {
 import type {
   ActionCtx,
   AgentComponent,
-  AgentPrompt,
   GenerationOutputMetadata,
   Options,
-  Output,
+  StreamingTextArgs,
 } from "./types.js";
+import type { Output as AISDKOutput } from "ai";
 import { startGeneration } from "./start.js";
 import type { Agent } from "../index.js";
 import { getModelName, getProviderName } from "../../shared.js";
 import { errorToString, willContinue } from "./utils.js";
+
+/** Finish every abort cleanup path before surfacing an internal failure. */
+export async function runAbortCleanup(cleanup: {
+  failCall: () => Promise<void>;
+  failStreamer: () => Promise<void>;
+  onAbort?: () => PromiseLike<void> | void;
+}): Promise<void> {
+  const results = await Promise.allSettled([
+    cleanup.failCall(),
+    cleanup.failStreamer(),
+  ]);
+  await cleanup.onAbort?.();
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure) throw failure.reason;
+}
 
 /**
  * This behaves like {@link streamText} from the "ai" package except that
@@ -32,8 +49,14 @@ import { errorToString, willContinue } from "./utils.js";
  * to a thread (and optionally userId).
  */
 export async function streamText<
-  TOOLS extends ToolSet,
-  OUTPUT extends Output<any, any, any> = never,
+  AgentTools extends ToolSet,
+  TOOLS extends ToolSet | undefined = undefined,
+  OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+    string,
+    string,
+    never
+  >,
+  RUNTIME_CONTEXT extends Context = Context,
 >(
   ctx: ActionCtx,
   component: AgentComponent,
@@ -41,17 +64,7 @@ export async function streamText<
    * The arguments to the streamText function, similar to the ai sdk's
    * {@link streamText} function, along with Agent prompt options.
    */
-  streamTextArgs: AgentPrompt &
-    Omit<
-      Parameters<typeof streamTextAi<TOOLS, OUTPUT>>[0],
-      "model" | "prompt" | "messages"
-    > & {
-      /**
-       * The tools to use for the tool calls. This will override tools specified
-       * in the Agent constructor or createThread / continueThread.
-       */
-      tools?: TOOLS;
-    },
+  streamTextArgs: StreamingTextArgs<AgentTools, TOOLS, OUTPUT, RUNTIME_CONTEXT>,
   /**
    * The {@link ContextOptions} and {@link StorageOptions}
    * options to use for fetching contextual messages and saving input/output messages.
@@ -73,17 +86,49 @@ export async function streamText<
     saveStreamDeltas?: boolean | StreamingOptions;
     agentForToolCtx?: Agent;
   },
-): Promise<StreamTextResult<TOOLS, OUTPUT> & GenerationOutputMetadata> {
+): Promise<
+  StreamTextResult<
+    TOOLS extends undefined ? AgentTools : TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  > &
+    GenerationOutputMetadata
+> {
+  type Tools = TOOLS extends undefined ? AgentTools : TOOLS;
   const { threadId } = options ?? {};
   const { args, userId, order, stepOrder, promptMessageId, ...call } =
-    await startGeneration(ctx, component, streamTextArgs, options);
+    await startGeneration<
+      StreamingTextArgs<AgentTools, TOOLS, OUTPUT, RUNTIME_CONTEXT>,
+      Tools,
+      object,
+      RUNTIME_CONTEXT
+    >(
+      ctx,
+      component,
+      streamTextArgs,
+      options,
+      "streamText",
+    );
 
-  const steps: StepResult<TOOLS>[] = [];
+  const steps: StepResult<Tools, RUNTIME_CONTEXT>[] = [];
+  let initialResponseMessages: ModelMessage[] = [];
+  let initialResponseMessagesSaved = false;
+  const responseMessagesForStep = (
+    step: StepResult<Tools, RUNTIME_CONTEXT>,
+  ) => [
+    ...(initialResponseMessagesSaved ? [] : initialResponseMessages),
+    ...step.response.messages,
+  ];
 
   // Track the final step for atomic save with stream finish (issue #181).
   // Only used when streamText awaits stream consumption itself; the
   // `returnImmediately` path saves inline instead (see onStepFinish below).
-  let pendingFinalStep: StepResult<TOOLS> | undefined;
+  let pendingFinalStep:
+    | {
+        step: StepResult<Tools, RUNTIME_CONTEXT>;
+        responseMessages: ModelMessage[];
+      }
+    | undefined;
 
   // Whether streamText will await stream consumption before returning.
   // When false (saveStreamDeltas.returnImmediately === true), we cannot
@@ -123,7 +168,7 @@ export async function streamText<
         )
       : undefined;
 
-  const result = streamTextAi({
+  const result = streamTextAi<Tools, RUNTIME_CONTEXT, OUTPUT>({
     ...args,
     abortSignal: streamer?.abortController.signal ?? args.abortSignal,
     experimental_transform: mergeTransforms(
@@ -136,7 +181,19 @@ export async function streamText<
       await streamer?.fail(errorToString(error.error));
       return streamTextArgs.onError?.(error);
     },
+    onAbort: async (event) => {
+      const reason = args.abortSignal?.reason
+        ? errorToString(args.abortSignal.reason)
+        : "streamText aborted";
+      await runAbortCleanup({
+        failCall: () => call.fail(reason),
+        failStreamer: async () => streamer?.fail(reason),
+        onAbort: () => streamTextArgs.onAbort?.(event),
+      });
+    },
     prepareStep: async (options) => {
+      if (options.stepNumber === 0)
+        initialResponseMessages = [...options.responseMessages];
       const result = await streamTextArgs.prepareStep?.(options);
       if (result) {
         const model = result.model ?? options.model;
@@ -150,7 +207,7 @@ export async function streamText<
       }
       return undefined;
     },
-    onStepFinish: async (step) => {
+    onStepEnd: async (step) => {
       steps.push(step);
       const createPendingMessage = await willContinue(steps, args.stopWhen);
       if (!createPendingMessage && streamer) {
@@ -159,22 +216,36 @@ export async function streamText<
         if (willAwaitStream) {
           // We're about to `await stream` below — defer the save so it
           // happens atomically with stream finish (issue #181).
-          pendingFinalStep = step;
+          pendingFinalStep = {
+            step,
+            responseMessages: responseMessagesForStep(step),
+          };
         } else {
           // returnImmediately path: streamText is about to return without
           // awaiting consumption, so the deferred-save block below won't
           // see this step. Save inline now (issue #265).
           const finishStreamId = await streamer.getOrCreateStreamId();
-          await call.save({ step }, false, finishStreamId);
+          await call.save(
+            { step, responseMessages: responseMessagesForStep(step) },
+            false,
+            finishStreamId,
+          );
+          initialResponseMessagesSaved = true;
         }
       } else {
-        await call.save({ step }, createPendingMessage);
+        await call.save(
+          { step, responseMessages: responseMessagesForStep(step) },
+          createPendingMessage,
+        );
+        initialResponseMessagesSaved = true;
       }
-      return args.onStepFinish?.(step);
+      return (streamTextArgs.onStepEnd ?? streamTextArgs.onStepFinish)?.(step);
     },
-  }) as StreamTextResult<TOOLS, OUTPUT>;
+  } as Parameters<
+    typeof streamTextAi<Tools, RUNTIME_CONTEXT, OUTPUT>
+  >[0]) as StreamTextResult<Tools, RUNTIME_CONTEXT, OUTPUT>;
   const stream = streamer?.consumeStream(
-    result.toUIMessageStream<AIUIMessage<TOOLS>>(),
+    result.toUIMessageStream<AIUIMessage<Tools>>(),
   );
   if (willAwaitStream) {
     try {
@@ -188,7 +259,7 @@ export async function streamText<
       // Save the deferred final step if it was already generated but not yet persisted
       if (pendingFinalStep) {
         try {
-          await call.save({ step: pendingFinalStep }, false);
+          await call.save(pendingFinalStep, false);
         } catch (saveError) {
           console.error("Failed to save deferred final step:", saveError);
         }
@@ -201,7 +272,7 @@ export async function streamText<
   // If we deferred the final step save, do it now with atomic stream finish.
   if (pendingFinalStep && streamer) {
     const finishStreamId = await streamer.getOrCreateStreamId();
-    await call.save({ step: pendingFinalStep }, false, finishStreamId);
+    await call.save(pendingFinalStep, false, finishStreamId);
   }
   const metadata: GenerationOutputMetadata = {
     promptMessageId,

--- a/src/vercel/client/streaming.test.ts
+++ b/src/vercel/client/streaming.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createThread } from "../../client/threads.js";
+import type { MutationCtx } from "../../client/types.js";
 import type { GenericSchema, SchemaDefinition } from "convex/server";
 import { streamText } from "ai";
 import { components, initConvexTest } from "./setup.test.js";
@@ -184,6 +185,176 @@ describe("DeltaStreamer", () => {
       }
     });
   });
-  // TODO: test errors & aborted states
+  test("honors a signal that was aborted before construction", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await t.run(async (ctx) => {
+      const streamer = new DeltaStreamer<string>(
+        components.agent,
+        ctx,
+        { ...defaultTestOptions, abortSignal: abortController.signal },
+        { ...testMetadata, threadId },
+      );
+
+      expect(streamer.abortController.signal.aborted).toBe(true);
+      await streamer.addParts(["ignored"]);
+      expect(streamer.streamId).toBeUndefined();
+      await expect(streamer.getOrCreateStreamId()).rejects.toThrow(
+        "Cannot create a stream after it has been aborted",
+      );
+    });
+  });
+
+  test("shares signal and fail cleanup while stream creation is in flight", async () => {
+    let resolveCreate!: (streamId: string) => void;
+    const creatingStream = new Promise<string>((resolve) => {
+      resolveCreate = resolve;
+    });
+    let resolveAbort!: () => void;
+    const abortingStream = new Promise<void>((resolve) => {
+      resolveAbort = resolve;
+    });
+    const runMutation = vi
+      .fn()
+      .mockImplementationOnce(() => creatingStream)
+      .mockImplementationOnce(() => abortingStream);
+    const abortController = new AbortController();
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      { ...defaultTestOptions, abortSignal: abortController.signal },
+      { ...testMetadata, threadId },
+    );
+
+    const streamId = streamer.getStreamId();
+    abortController.abort();
+    const failing = streamer.fail("creation failed");
+    let failSettled = false;
+    void failing.then(() => {
+      failSettled = true;
+    });
+    resolveCreate("stream-1");
+    await expect(streamId).resolves.toBe("stream-1");
+    await vi.waitFor(() => expect(runMutation).toHaveBeenCalledTimes(2));
+
+    expect(failSettled).toBe(false);
+    resolveAbort();
+    await failing;
+
+    expect(runMutation).toHaveBeenNthCalledWith(
+      2,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "abortSignal" },
+    );
+  });
+
+  test("aborts the component stream when a delta write fails", async () => {
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce("stream-1")
+      .mockRejectedValueOnce(new Error("delta failed"))
+      .mockResolvedValueOnce(undefined);
+    let abortReason: string | undefined;
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      {
+        ...defaultTestOptions,
+        onAsyncAbort: async (reason) => {
+          abortReason = reason;
+        },
+      },
+      { ...testMetadata, threadId },
+    );
+
+    await streamer.addParts(["A"]);
+    await streamer.finish();
+
+    expect(abortReason).toBe("delta failed");
+    expect(runMutation).toHaveBeenNthCalledWith(
+      3,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "delta failed" },
+    );
+  });
+
+  test("surfaces pending-message cleanup failure after aborting the stream", async () => {
+    const pendingMessageFailure = new Error("pending message cleanup failed");
+    let resolveComponentAbort!: () => void;
+    const componentAborted = new Promise<void>((resolve) => {
+      resolveComponentAbort = resolve;
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce("stream-1")
+      .mockRejectedValueOnce(new Error("delta failed"))
+      .mockImplementationOnce(() => {
+        resolveComponentAbort();
+        return Promise.resolve();
+      });
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      {
+        ...defaultTestOptions,
+        onAsyncAbort: async () => {
+          throw pendingMessageFailure;
+        },
+      },
+      { ...testMetadata, threadId },
+    );
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        yield "A";
+        await componentAborted;
+      },
+    } as unknown as Parameters<typeof streamer.consumeStream>[0];
+
+    await expect(streamer.consumeStream(stream)).rejects.toBe(
+      pendingMessageFailure,
+    );
+
+    expect(runMutation).toHaveBeenNthCalledWith(
+      3,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "delta failed" },
+    );
+  });
+
+  test("finishes external abort cleanup when the active delta write fails", async () => {
+    const pendingMessageFailure = new Error("pending message cleanup failed");
+    let rejectDelta!: (error: Error) => void;
+    const deltaWrite = new Promise<never>((_, reject) => {
+      rejectDelta = reject;
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce("stream-1")
+      .mockImplementationOnce(() => deltaWrite)
+      .mockResolvedValueOnce(undefined);
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      {
+        ...defaultTestOptions,
+        onAsyncAbort: async () => {
+          throw pendingMessageFailure;
+        },
+      },
+      { ...testMetadata, threadId },
+    );
+
+    await streamer.addParts(["A"]);
+    const failing = streamer.fail("external abort");
+    rejectDelta(new Error("delta failed"));
+
+    await expect(failing).rejects.toBe(pendingMessageFailure);
+    expect(runMutation).toHaveBeenNthCalledWith(
+      3,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "external abort" },
+    );
+  });
   // TODO: test fetching partial stream data - syncStreams w/ cursors
 });

--- a/src/vercel/client/streaming.ts
+++ b/src/vercel/client/streaming.ts
@@ -208,6 +208,7 @@ export class DeltaStreamer<T> {
   #nextParts: T[] = [];
   #latestWrite: number = 0;
   #ongoingWrite: Promise<void> | undefined;
+  #abortPromise: Promise<void> | undefined;
   #cursor: number = 0;
   public abortController: AbortController;
   // When true, the stream will be finished externally (e.g., atomically via addMessages)
@@ -243,34 +244,28 @@ export class DeltaStreamer<T> {
     this.#nextParts = [];
     this.abortController = new AbortController();
     if (config.abortSignal) {
-      config.abortSignal.addEventListener("abort", async () => {
-        try {
-          if (this.abortController.signal.aborted) {
-            return;
-          }
-          this.abortController.abort();
-          // Wait for in-flight stream creation before trying to abort it
-          if (this.#creatingStreamIdPromise) {
-            await this.#creatingStreamIdPromise;
-          }
-          if (this.streamId) {
-            await this.#ongoingWrite;
-            await this.ctx.runMutation(this.component.streams.abort, {
-              streamId: this.streamId,
-              reason: "abortSignal",
-            });
-          }
-        } catch {
-          // Best-effort cleanup — the stream will be garbage-collected
-          // by the 10-minute timeout if this fails.
-        }
-      });
+      const abortFromSignal = () => {
+        void this.#abort("abortSignal").catch(() => {
+          // Best-effort cleanup — the stream timeout is the fallback.
+        });
+      };
+      if (config.abortSignal.aborted) {
+        abortFromSignal();
+      } else {
+        config.abortSignal.addEventListener("abort", abortFromSignal, {
+          once: true,
+        });
+      }
     }
   }
 
   // Avoid race conditions by only creating once
   #creatingStreamIdPromise: Promise<string> | undefined;
   public async getStreamId() {
+    if (this.abortController.signal.aborted) {
+      await this.#abortPromise;
+      throw new Error("Cannot create a stream after it has been aborted");
+    }
     if (!this.streamId) {
       if (!this.#creatingStreamIdPromise) {
         this.#creatingStreamIdPromise = this.ctx.runMutation(
@@ -310,9 +305,11 @@ export class DeltaStreamer<T> {
     }
     // Skip finish if it will be handled externally (atomically with message save)
     // or if the stream was aborted (e.g., due to a failed delta write).
-    // Aborted streams are cleaned up via streams.abort (called by the abort
-    // signal handler), so we don't need to call finish() for them.
-    if (!this.#finishedExternally && !this.abortController.signal.aborted) {
+    // Abort cleanup owns the terminal component transition, so consumeStream
+    // must wait for it instead of also trying to finish the stream.
+    if (this.abortController.signal.aborted) {
+      await this.#waitForAbortCleanup();
+    } else if (!this.#finishedExternally) {
       await this.finish();
     }
   }
@@ -343,28 +340,27 @@ export class DeltaStreamer<T> {
       return;
     }
     this.#latestWrite = Date.now();
+    let success: boolean;
     try {
-      const success = await this.ctx.runMutation(
+      success = await this.ctx.runMutation(
         this.component.streams.addDelta,
         delta,
       );
-      if (!success) {
-        // An in-flight #sendDelta started before markFinishedExternally()
-        // will get `success === false` because the stream row is already
-        // "finished". That's a benign late-write miss, not a failure —
-        // don't convert it into an abort.
-        if (this.#finishedExternally) {
-          return;
-        }
-        await this.config.onAsyncAbort("async abort");
-        this.abortController.abort();
-        return;
-      }
     } catch (e) {
-      await this.config.onAsyncAbort(
+      await this.#abortDelta(
         e instanceof Error ? e.message : "unknown error",
       );
-      this.abortController.abort();
+      return;
+    }
+    if (!success) {
+      // An in-flight #sendDelta started before markFinishedExternally()
+      // will get `success === false` because the stream row is already
+      // "finished". That's a benign late-write miss, not a failure —
+      // don't convert it into an abort.
+      if (this.#finishedExternally) {
+        return;
+      }
+      await this.#abortDelta("async abort");
       return;
     }
     // Now that we've sent the delta, check if we need to send another one.
@@ -400,9 +396,17 @@ export class DeltaStreamer<T> {
     if (!this.streamId) {
       return;
     }
-    await this.#ongoingWrite;
+    try {
+      await this.#ongoingWrite;
+    } catch (error) {
+      if (this.abortController.signal.aborted) {
+        await this.#waitForAbortCleanup();
+      }
+      throw error;
+    }
     await this.#sendDelta(); // #sendDelta checks aborted internally
     if (this.abortController.signal.aborted) {
+      await this.#waitForAbortCleanup();
       return;
     }
     await this.ctx.runMutation(this.component.streams.finish, {
@@ -411,18 +415,76 @@ export class DeltaStreamer<T> {
   }
 
   public async fail(reason: string) {
-    if (this.abortController.signal.aborted) {
-      return;
+    await this.#abort(reason);
+  }
+
+  async #abortDelta(reason: string) {
+    let callbackFailure: { error: unknown } | undefined;
+    try {
+      await this.config.onAsyncAbort(reason);
+    } catch (error) {
+      callbackFailure = { error };
     }
-    this.abortController.abort();
-    if (!this.streamId) {
-      return;
+    if (!this.#abortPromise) {
+      try {
+        await this.#abort(reason, false);
+      } catch {
+        // The stream timeout is the bounded cleanup fallback.
+      }
     }
-    await this.#ongoingWrite;
-    await this.ctx.runMutation(this.component.streams.abort, {
-      streamId: this.streamId,
-      reason,
-    });
+    if (callbackFailure) throw callbackFailure.error;
+  }
+
+  #abort(reason: string, waitForOngoingWrite = true): Promise<void> {
+    if (!this.#abortPromise) {
+      this.abortController.abort();
+      this.#abortPromise = this.#abortCreatedStream(
+        reason,
+        waitForOngoingWrite,
+      );
+    }
+    return this.#abortPromise;
+  }
+
+  async #waitForAbortCleanup() {
+    let writeFailure: { error: unknown } | undefined;
+    try {
+      await this.#ongoingWrite;
+    } catch (error) {
+      writeFailure = { error };
+    }
+    try {
+      await this.#abortPromise;
+    } catch (error) {
+      writeFailure ??= { error };
+    }
+    if (writeFailure) throw writeFailure.error;
+  }
+
+  async #abortCreatedStream(reason: string, waitForOngoingWrite: boolean) {
+    if (this.#creatingStreamIdPromise) {
+      this.streamId ??= await this.#creatingStreamIdPromise;
+    }
+    if (!this.streamId) return;
+    let writeFailure: { error: unknown } | undefined;
+    if (waitForOngoingWrite) {
+      try {
+        await this.#ongoingWrite;
+      } catch (error) {
+        writeFailure = { error };
+      }
+    }
+    let abortFailure: { error: unknown } | undefined;
+    try {
+      await this.ctx.runMutation(this.component.streams.abort, {
+        streamId: this.streamId,
+        reason,
+      });
+    } catch (error) {
+      abortFailure = { error };
+    }
+    if (writeFailure) throw writeFailure.error;
+    if (abortFailure) throw abortFailure.error;
   }
 }
 

--- a/src/vercel/client/types.test.ts
+++ b/src/vercel/client/types.test.ts
@@ -1,13 +1,13 @@
-import type { LanguageModelV2, LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV3, LanguageModelV4 } from "@ai-sdk/provider";
 import { expectTypeOf, test } from "vitest";
 import type { AgentPrompt, Config } from "./types.js";
 
 expectTypeOf<{ languageModel: string }>().toExtend<Config>();
-expectTypeOf<{ languageModel: LanguageModelV3 }>().toExtend<Config>();
-expectTypeOf<{ languageModel: LanguageModelV2 }>().not.toExtend<Config>();
+expectTypeOf<{ languageModel: LanguageModelV4 }>().toExtend<Config>();
+expectTypeOf<{ languageModel: LanguageModelV3 }>().not.toExtend<Config>();
 
 expectTypeOf<{ model: string }>().toExtend<AgentPrompt>();
-expectTypeOf<{ model: LanguageModelV3 }>().toExtend<AgentPrompt>();
-expectTypeOf<{ model: LanguageModelV2 }>().not.toExtend<AgentPrompt>();
+expectTypeOf<{ model: LanguageModelV4 }>().toExtend<AgentPrompt>();
+expectTypeOf<{ model: LanguageModelV3 }>().not.toExtend<AgentPrompt>();
 
 test("noop", () => {});

--- a/src/vercel/client/types.ts
+++ b/src/vercel/client/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Context,
   FlexibleSchema,
   InferSchema,
   ModelMessage,
@@ -10,25 +11,21 @@ import type {
   GenerateObjectResult,
   generateText,
   GenerateTextResult,
+  Instructions,
+  LanguageModelCallOptions,
   LanguageModelRequestMetadata,
   LanguageModelResponseMetadata,
   LanguageModelUsage,
   LanguageModel,
+  Output as AISDKOutput,
   streamObject,
   streamText,
   StreamTextResult,
   ToolSet,
-  CallSettings,
+  RequestOptions,
   generateObject,
 } from "ai";
 
-export interface Output<_T = any, _P = any, _E = any> {
-  name: string;
-  responseFormat: any;
-  parseCompleteOutput: any;
-  parsePartialOutput: any;
-  createElementStreamTransform: any;
-}
 import type {
   GenericActionCtx,
   GenericDataModel,
@@ -52,20 +49,21 @@ export type {
 } from "../../client/types.js";
 
 /**
- * Type-level check that ensures models are from AI SDK v6.
+ * Type-level check that ensures models are from AI SDK v7.
  * If a v5 model (LanguageModelV2) is passed, TypeScript will show the error message string.
  */
-type AssertAISDKv6<T> = T extends string
+type AssertAISDKv7<T> = T extends string
   ? T
-  : T extends { specificationVersion: "v3" }
+  : T extends { specificationVersion: "v4" }
     ? T
-    : "⚠️ @convex-dev/agent v0.6.0 requires AI SDK v6. Update your dependencies: npm install ai@^6.0.35 @ai-sdk/openai@^3.0.10 (or other provider). See: node_modules/@convex-dev/agent/MIGRATION.md";
+    : "⚠️ @convex-dev/agent requires AI SDK v7. Update your dependencies: npm install ai@^7.0.0 @ai-sdk/openai@^4.0.0 (or other provider).";
 
 export type AgentPrompt = {
   /**
    * System message to include in the prompt. Overwrites Agent instructions.
    */
-  system?: string;
+  system?: Instructions;
+  instructions?: Instructions;
   /**
    * A prompt. It can be either a text prompt or a list of messages.
    * If used with `promptMessageId`, it will be used in place of that
@@ -100,13 +98,13 @@ export type AgentPrompt = {
    * The model to use for the LLM calls. This will override the languageModel
    * specified in the Agent config.
    */
-  model?: AssertAISDKv6<LanguageModel>;
+  model?: AssertAISDKv7<LanguageModel>;
 };
 
 export type Config = {
   /**
    * The LLM model to use for generating / streaming text and objects.
-   * Requires AI SDK v6 (@ai-sdk/* packages v3.x).
+   * Requires AI SDK v7 (@ai-sdk/* packages v4.x).
    *
    * @example
    * import { openai } from "@ai-sdk/openai"
@@ -114,7 +112,7 @@ export type Config = {
    *   languageModel: openai.chat("gpt-4o-mini"),
    * })
    */
-  languageModel?: AssertAISDKv6<LanguageModel>;
+  languageModel?: AssertAISDKv7<LanguageModel>;
   /**
    * @deprecated Use `embeddingModel` instead.
    */
@@ -170,7 +168,7 @@ export type Config = {
    * This can be overridden at each generate/stream callsite on a per-field
    * basis. To clear a default setting, you'll need to pass `undefined`.
    */
-  callSettings?: CallSettings;
+  callSettings?: AgentCallSettings;
   /**
    * The maximum number of steps to allow for a single generation.
    *
@@ -188,6 +186,9 @@ export type Config = {
    */
   maxSteps?: number;
 };
+
+export type AgentCallSettings = LanguageModelCallOptions &
+  Omit<RequestOptions, "timeout">;
 
 /**
  * Options to configure what messages are fetched as context,
@@ -351,42 +352,77 @@ export type RawRequestResponseHandler = (
     threadId: string | undefined;
     agentName: string | undefined;
     request: LanguageModelRequestMetadata;
-    response: LanguageModelResponseMetadata;
+    response:
+      | LanguageModelResponseMetadata
+      | Omit<LanguageModelResponseMetadata, "messages">;
   },
 ) => void | Promise<void>;
 
 export type TextArgs<
   AgentTools extends ToolSet,
   TOOLS extends ToolSet | undefined = undefined,
-  OUTPUT extends Output<any, any, any> = never,
+  OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+    string,
+    string
+  >,
+  RUNTIME_CONTEXT extends Context = Context,
 > = Omit<
   Parameters<
-    typeof generateText<TOOLS extends undefined ? AgentTools : TOOLS, OUTPUT>
+    typeof generateText<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >
   >[0],
-  "model" | "prompt" | "messages"
+  "model" | "prompt" | "messages" | "system" | "onStepFinish"
 > & {
   /**
    * The tools to use for the tool calls. This will override tools specified
    * in the Agent constructor or createThread / continueThread.
    */
   tools?: TOOLS;
+  /** @deprecated Use onStepEnd. */
+  onStepFinish?: Parameters<
+    typeof generateText<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >
+  >[0]["onStepEnd"];
 } & AgentPrompt;
 
 export type StreamingTextArgs<
   AgentTools extends ToolSet,
   TOOLS extends ToolSet | undefined = undefined,
-  OUTPUT extends Output<any, any, any> = never,
+  OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+    string,
+    string,
+    never
+  >,
+  RUNTIME_CONTEXT extends Context = Context,
 > = Omit<
   Parameters<
-    typeof streamText<TOOLS extends undefined ? AgentTools : TOOLS, OUTPUT>
+    typeof streamText<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >
   >[0],
-  "model" | "prompt" | "messages"
+  "model" | "prompt" | "messages" | "system" | "onStepFinish"
 > & {
   /**
    * The tools to use for the tool calls. This will override tools specified
    * in the Agent constructor or createThread / continueThread.
    */
   tools?: TOOLS;
+  /** @deprecated Use onStepEnd. */
+  onStepFinish?: Parameters<
+    typeof streamText<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >
+  >[0]["onStepEnd"];
 } & AgentPrompt;
 
 export type ObjectMode = "object" | "array" | "enum" | "no-schema";
@@ -402,7 +438,7 @@ export type GenerateObjectArgs<
 > = AgentPrompt &
   Omit<
     Parameters<typeof generateObject<SCHEMA, OUTPUT, RESULT>>[0],
-    "model" | "prompt" | "messages"
+    "model" | "prompt" | "messages" | "system"
   > & {
     schema?: SCHEMA;
     enum?: Array<RESULT>;
@@ -419,7 +455,7 @@ export type StreamObjectArgs<
 > = AgentPrompt &
   Omit<
     Parameters<typeof streamObject<SCHEMA, OUTPUT, RESULT>>[0],
-    "model" | "prompt" | "messages"
+    "model" | "prompt" | "messages" | "system"
   > & {
     schema?: SCHEMA;
     enum?: Array<RESULT>;
@@ -454,7 +490,7 @@ export type MaybeCustomCtx<
             userId?: string | undefined;
             threadId?: string | undefined;
           },
-          llmArgs: TextArgs<AgentTools>,
+          llmArgs: TextArgs<AgentTools, AgentTools>,
         ) => CustomCtx;
       }
     : { customCtx?: never };
@@ -492,13 +528,25 @@ export interface Thread<DefaultTools extends ToolSet> {
    */
   generateText<
     TOOLS extends ToolSet | undefined = undefined,
-    OUTPUT extends Output<any, any, any> = never,
+    OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+      string,
+      string
+    >,
+    RUNTIME_CONTEXT extends Context = Context,
   >(
-    generateTextArgs: AgentPrompt &
-      TextArgs<TOOLS extends undefined ? DefaultTools : TOOLS, TOOLS, OUTPUT>,
+    generateTextArgs: TextArgs<
+        TOOLS extends undefined ? DefaultTools : TOOLS,
+        TOOLS,
+        OUTPUT,
+        RUNTIME_CONTEXT
+      >,
     options?: Options,
   ): Promise<
-    GenerateTextResult<TOOLS extends undefined ? DefaultTools : TOOLS, OUTPUT> &
+    GenerateTextResult<
+      TOOLS extends undefined ? DefaultTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    > &
       ThreadOutputMetadata
   >;
 
@@ -514,13 +562,18 @@ export interface Thread<DefaultTools extends ToolSet> {
    */
   streamText<
     TOOLS extends ToolSet | undefined = undefined,
-    OUTPUT extends Output<any, any, any> = never,
+    OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+      string,
+      string,
+      never
+    >,
+    RUNTIME_CONTEXT extends Context = Context,
   >(
-    streamTextArgs: AgentPrompt &
-      StreamingTextArgs<
+    streamTextArgs: StreamingTextArgs<
         TOOLS extends undefined ? DefaultTools : TOOLS,
         TOOLS,
-        OUTPUT
+        OUTPUT,
+        RUNTIME_CONTEXT
       >,
     options?: Options & {
       /**
@@ -536,7 +589,11 @@ export interface Thread<DefaultTools extends ToolSet> {
       saveStreamDeltas?: boolean | StreamingOptions;
     },
   ): Promise<
-    StreamTextResult<TOOLS extends undefined ? DefaultTools : TOOLS, OUTPUT> &
+    StreamTextResult<
+      TOOLS extends undefined ? DefaultTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    > &
       ThreadOutputMetadata
   >;
   /**
@@ -558,8 +615,7 @@ export interface Thread<DefaultTools extends ToolSet> {
       ? Array<InferSchema<SCHEMA>>
       : InferSchema<SCHEMA>,
   >(
-    generateObjectArgs: AgentPrompt &
-      GenerateObjectArgs<SCHEMA, OUTPUT, RESULT>,
+    generateObjectArgs: GenerateObjectArgs<SCHEMA, OUTPUT, RESULT>,
     options?: Options,
   ): Promise<GenerateObjectResult<RESULT> & ThreadOutputMetadata>;
   /**
@@ -584,7 +640,7 @@ export interface Thread<DefaultTools extends ToolSet> {
     /**
      * The same arguments you'd pass to "ai" sdk {@link streamObject}.
      */
-    streamObjectArgs: AgentPrompt & StreamObjectArgs<SCHEMA, OUTPUT, RESULT>,
+    streamObjectArgs: StreamObjectArgs<SCHEMA, OUTPUT, RESULT>,
     options?: Options,
   ): Promise<
     ReturnType<typeof streamObject<SCHEMA, OUTPUT, RESULT>> &

--- a/src/vercel/client/utils.ts
+++ b/src/vercel/client/utils.ts
@@ -1,4 +1,5 @@
-import type { StepResult, StopCondition } from "ai";
+import type { Context } from "@ai-sdk/provider-utils";
+import type { StepResult, StopCondition, ToolSet } from "ai";
 
 /**
  * A stop condition that only matches tool calls which completed
@@ -14,18 +15,23 @@ export function hasSuccessfulToolCall(toolName: string): StopCondition<any> {
     ) ?? false;
 }
 
-export async function willContinue(
-  steps: StepResult<any>[],
-
-  stopWhen: StopCondition<any> | Array<StopCondition<any>> | undefined,
+export async function willContinue<
+  TOOLS extends ToolSet,
+  RUNTIME_CONTEXT extends Context,
+>(
+  steps: StepResult<TOOLS, RUNTIME_CONTEXT>[],
+  stopWhen:
+    | StopCondition<TOOLS, RUNTIME_CONTEXT>
+    | Array<StopCondition<TOOLS, RUNTIME_CONTEXT>>
+    | undefined,
 ): Promise<boolean> {
   const step = steps.at(-1)!;
   // we aren't doing another round after a tool result
   // TODO: whether to handle continuing after too much context used..
   if (step.finishReason !== "tool-calls") return false;
   // Count both successful results and errors as completed outputs.
-  // In AI SDK v6, failed tool calls produce tool-error content parts
-  // instead of tool-result, so only checking toolResults misses them.
+  // Failed tool calls are represented as tool-error content parts, so only
+  // checking toolResults misses them.
   const completedOutputs =
     step.content?.filter(
       (p) => p.type === "tool-result" || p.type === "tool-error",

--- a/src/vercel/deltas.test.ts
+++ b/src/vercel/deltas.test.ts
@@ -4,7 +4,6 @@ import {
   blankUIMessage,
   emptyIncrementalStreamState,
   getParts,
-  updateFromUIMessageChunks,
 } from "./deltas.js";
 import type { StreamDelta } from "../validators.js";
 import type { ToolUIPart, UIMessageChunk } from "ai";
@@ -24,80 +23,84 @@ describe("UIMessageChunks", () => {
     );
     expect(uiMessage.text).toBe("");
     expect(uiMessage.parts).toEqual([]);
-    const updatedMessage = await updateFromUIMessageChunks(uiMessage, [
-      { type: "start" },
-      { type: "start-step" },
-      { type: "reasoning-start", id: "reasoning-0" },
-      { type: "reasoning-delta", id: "reasoning-0", delta: "Okay" },
-      {
-        type: "reasoning-delta",
-        id: "reasoning-0",
-        delta: ", the user is asking...",
-      },
-      { type: "text-start", id: "txt-1" },
-      {
-        type: "text-delta",
-        id: "txt-1",
-        delta: "Hey ho.",
-      },
-      { type: "reasoning-end", id: "reasoning-0" },
-      { type: "text-end", id: "txt-1" },
-      { type: "tool-input-start", toolCallId: "0ychh9k6f", toolName: "say" },
-      {
-        type: "tool-input-delta",
-        toolCallId: "0ychh9k6f",
-        inputTextDelta:
-          '{"question":"What is your favorite flavor of ice cream?"}',
-      },
-      {
-        type: "tool-input-available",
-        toolCallId: "0ychh9k6f",
-        toolName: "say",
-        input: { question: "What is your favorite flavor of ice cream?" },
-        providerMetadata: { openai: { itemId: "123" } },
-      },
-      {
-        type: "tool-output-available",
-        toolCallId: "0ychh9k6f",
-        output: "I'm sorry I can't help you. Stop asking me questions.",
-      },
-      { type: "finish-step" },
-      { type: "start-step" },
-      { type: "tool-input-start", toolCallId: "1ychh9k6f", toolName: "say" },
-      {
-        type: "tool-input-delta",
-        toolCallId: "1ychh9k6f",
-        inputTextDelta:
-          '{"question":"What is your favorite flavor of ice cream?"}',
-      },
-      {
-        type: "tool-input-available",
-        toolCallId: "1ychh9k6f",
-        toolName: "say",
-        input: { question: "What is your favorite flavor of ice cream?" },
-      },
-      {
-        type: "tool-output-available",
-        toolCallId: "1ychh9k6f",
-        output: "I'm serious.",
-      },
-      { type: "finish-step" },
-      { type: "start-step" },
-      { type: "text-start", id: "msg_0" },
-      {
-        type: "text-delta",
-        id: "msg_0",
-        delta: "The best ice cream flavor is vanilla",
-      },
-      {
-        type: "text-delta",
-        id: "msg_0",
-        delta: ".",
-      },
-      { type: "text-end", id: "msg_0" },
-      { type: "finish-step" },
-      { type: "finish" },
-    ]);
+    const updatedMessage = applyUIMessageChunksIncremental(
+      uiMessage,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-delta", id: "reasoning-0", delta: "Okay" },
+        {
+          type: "reasoning-delta",
+          id: "reasoning-0",
+          delta: ", the user is asking...",
+        },
+        { type: "text-start", id: "txt-1" },
+        {
+          type: "text-delta",
+          id: "txt-1",
+          delta: "Hey ho.",
+        },
+        { type: "reasoning-end", id: "reasoning-0" },
+        { type: "text-end", id: "txt-1" },
+        { type: "tool-input-start", toolCallId: "0ychh9k6f", toolName: "say" },
+        {
+          type: "tool-input-delta",
+          toolCallId: "0ychh9k6f",
+          inputTextDelta:
+            '{"question":"What is your favorite flavor of ice cream?"}',
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "0ychh9k6f",
+          toolName: "say",
+          input: { question: "What is your favorite flavor of ice cream?" },
+          providerMetadata: { openai: { itemId: "123" } },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "0ychh9k6f",
+          output: "I'm sorry I can't help you. Stop asking me questions.",
+        },
+        { type: "finish-step" },
+        { type: "start-step" },
+        { type: "tool-input-start", toolCallId: "1ychh9k6f", toolName: "say" },
+        {
+          type: "tool-input-delta",
+          toolCallId: "1ychh9k6f",
+          inputTextDelta:
+            '{"question":"What is your favorite flavor of ice cream?"}',
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "1ychh9k6f",
+          toolName: "say",
+          input: { question: "What is your favorite flavor of ice cream?" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "1ychh9k6f",
+          output: "I'm serious.",
+        },
+        { type: "finish-step" },
+        { type: "start-step" },
+        { type: "text-start", id: "msg_0" },
+        {
+          type: "text-delta",
+          id: "msg_0",
+          delta: "The best ice cream flavor is vanilla",
+        },
+        {
+          type: "text-delta",
+          id: "msg_0",
+          delta: ".",
+        },
+        { type: "text-end", id: "msg_0" },
+        { type: "finish-step" },
+        { type: "finish" },
+      ],
+      emptyIncrementalStreamState(),
+    ).message;
     expect(updatedMessage.text).toBe(
       "Hey ho. The best ice cream flavor is vanilla.",
     );
@@ -163,9 +166,8 @@ describe("UIMessageChunks - continuation stream", () => {
     // User approves
     // Stream B: tool-result (referencing tool-call from Stream A) -> this test
     //
-    // The AI SDK's readUIMessageStream expects tool-call before tool-result,
-    // but they're in different streams. The onError handler should gracefully
-    // ignore this error since stored messages provide the fallback.
+    // The continuation stream does not repeat the prior tool call. The reducer
+    // tolerates the orphan result because stored messages provide that context.
     const uiMessage = blankUIMessage(
       {
         streamId: "continuation-stream",
@@ -180,17 +182,21 @@ describe("UIMessageChunks - continuation stream", () => {
 
     // Send a tool-result without the corresponding tool-call in this stream
     // This would normally throw "No tool invocation found" error
-    const updatedMessage = await updateFromUIMessageChunks(uiMessage, [
-      { type: "start" },
-      { type: "start-step" },
-      {
-        type: "tool-output-available",
-        toolCallId: "call_from_previous_stream",
-        output: "Tool execution result",
-      },
-      { type: "finish-step" },
-      { type: "finish" },
-    ]);
+    const updatedMessage = applyUIMessageChunksIncremental(
+      uiMessage,
+      [
+        { type: "start" },
+        { type: "start-step" },
+        {
+          type: "tool-output-available",
+          toolCallId: "call_from_previous_stream",
+          output: "Tool execution result",
+        },
+        { type: "finish-step" },
+        { type: "finish" },
+      ],
+      emptyIncrementalStreamState(),
+    ).message;
 
     // The message should NOT be marked as failed - the error should be suppressed
     expect(updatedMessage.status).not.toBe("failed");
@@ -370,6 +376,276 @@ describe("mergeDeltas", () => {
     expect((toolPart as { providerExecuted?: boolean }).providerExecuted).toBe(
       true,
     );
+
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
+      msg,
+      [
+        {
+          type: "tool-output-available",
+          toolCallId: "c1",
+          output: { result: "final" },
+        },
+      ] as UIMessageChunk[],
+      state,
+    ));
+    const completedToolPart = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
+    );
+    expect(
+      (completedToolPart as { preliminary?: boolean }).preliminary,
+    ).toBeUndefined();
+
+    ({ message: msg, streamState: state } = applyUIMessageChunksIncremental(
+      msg,
+      [
+        {
+          type: "tool-output-error",
+          toolCallId: "c1",
+          errorText: "final failure",
+        },
+      ] as UIMessageChunk[],
+      state,
+    ));
+
+    const failedToolPart = msg.parts.find(
+      (p): p is ToolUIPart => "toolCallId" in p && p.toolCallId === "c1",
+    );
+    expect(failedToolPart).toMatchObject({ state: "output-error" });
+    expect((failedToolPart as { output?: unknown }).output).toBeUndefined();
+    expect(
+      (failedToolPart as { preliminary?: boolean }).preliminary,
+    ).toBeUndefined();
+  });
+
+  it("keeps a denied approval distinct from its later denied output", () => {
+    const streamMessage = {
+      streamId: "s-tool-approval",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    let message = blankUIMessage(streamMessage, "thread-tool-approval");
+    let streamState = emptyIncrementalStreamState();
+    ({ message, streamState } = applyUIMessageChunksIncremental(
+      message,
+      [
+        {
+          type: "tool-input-start",
+          toolCallId: "call-1",
+          toolName: "deleteFile",
+          providerExecuted: true,
+          providerMetadata: { openai: { request: "call-1" } },
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "deleteFile",
+          input: { path: "/tmp/file" },
+        },
+        {
+          type: "tool-approval-request",
+          toolCallId: "call-1",
+          approvalId: "approval-1",
+        },
+        {
+          type: "tool-approval-response",
+          approvalId: "approval-1",
+          approved: false,
+          reason: "User declined",
+        },
+      ] as UIMessageChunk[],
+      streamState,
+    ));
+
+    expect(message.parts).toContainEqual(
+      expect.objectContaining({
+        toolCallId: "call-1",
+        state: "approval-responded",
+        approval: {
+          id: "approval-1",
+          approved: false,
+          reason: "User declined",
+        },
+        providerExecuted: true,
+        callProviderMetadata: { openai: { request: "call-1" } },
+      }),
+    );
+
+    ({ message, streamState } = applyUIMessageChunksIncremental(
+      message,
+      [{ type: "tool-output-denied", toolCallId: "call-1" }],
+      streamState,
+    ));
+
+    expect(message.parts).toContainEqual(
+      expect.objectContaining({
+        toolCallId: "call-1",
+        state: "output-denied",
+      }),
+    );
+  });
+
+  it("matches SDK 7 provider metadata replacement and dynamic tool initialization", () => {
+    const streamMessage = {
+      streamId: "s-metadata",
+      status: "streaming" as const,
+      order: 0,
+      stepOrder: 0,
+      format: "UIMessageChunk" as const,
+      agentName: "a",
+    };
+    const { message } = applyUIMessageChunksIncremental(
+      blankUIMessage(streamMessage, "thread-metadata"),
+      [
+        {
+          type: "text-start",
+          id: "t",
+          providerMetadata: { openai: { first: true } },
+        },
+        {
+          type: "text-delta",
+          id: "t",
+          delta: "x",
+          providerMetadata: { openai: { second: true } },
+        },
+        {
+          type: "tool-input-start",
+          toolCallId: "dynamic-1",
+          toolName: "runtimeTool",
+          dynamic: true,
+          providerExecuted: true,
+          title: "Runtime tool",
+          toolMetadata: { source: "provider" },
+          providerMetadata: { openai: { itemId: "item-1" } },
+        },
+      ] as UIMessageChunk[],
+      emptyIncrementalStreamState(),
+    );
+
+    expect(message.parts.find((part) => part.type === "text")).toMatchObject({
+      providerMetadata: { openai: { second: true } },
+    });
+    expect(
+      message.parts.find(
+        (part) => "toolCallId" in part && part.toolCallId === "dynamic-1",
+      ),
+    ).toMatchObject({
+      type: "dynamic-tool",
+      providerExecuted: true,
+      title: "Runtime tool",
+      toolMetadata: { source: "provider" },
+      callProviderMetadata: { openai: { itemId: "item-1" } },
+    });
+  });
+
+  it("creates tool parts from standalone tool-input-available chunks", () => {
+    const { message } = applyUIMessageChunksIncremental(
+      blankUIMessage(
+        {
+          streamId: "s-available",
+          status: "streaming",
+          order: 0,
+          stepOrder: 0,
+          format: "UIMessageChunk",
+          agentName: "a",
+        },
+        "thread-available",
+      ),
+      [
+        {
+          type: "tool-input-available",
+          toolCallId: "static-call",
+          toolName: "weather",
+          input: { city: "Boston" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "dynamic-call",
+          toolName: "runtimeTool",
+          dynamic: true,
+          input: { id: 1 },
+        },
+      ] as UIMessageChunk[],
+      emptyIncrementalStreamState(),
+    );
+
+    expect(message.parts).toMatchObject([
+      {
+        type: "tool-weather",
+        toolCallId: "static-call",
+        state: "input-available",
+        input: { city: "Boston" },
+        providerExecuted: true,
+      },
+      {
+        type: "dynamic-tool",
+        toolCallId: "dynamic-call",
+        toolName: "runtimeTool",
+        state: "input-available",
+        input: { id: 1 },
+      },
+    ]);
+  });
+
+  it("creates output-error parts from standalone tool-input-error chunks", () => {
+    const { message } = applyUIMessageChunksIncremental(
+      blankUIMessage(
+        {
+          streamId: "s-error",
+          status: "streaming",
+          order: 0,
+          stepOrder: 0,
+          format: "UIMessageChunk",
+          agentName: "a",
+        },
+        "thread-error",
+      ),
+      [
+        {
+          type: "tool-input-error",
+          toolCallId: "static-error",
+          toolName: "weather",
+          input: { city: "Boston" },
+          errorText: "Invalid weather request",
+          providerExecuted: true,
+          providerMetadata: { openai: { result: "static" } },
+        },
+        {
+          type: "tool-input-error",
+          toolCallId: "dynamic-error",
+          toolName: "runtimeTool",
+          dynamic: true,
+          input: { id: 1 },
+          errorText: "Invalid runtime request",
+          providerMetadata: { anthropic: { result: "dynamic" } },
+        },
+      ] as UIMessageChunk[],
+      emptyIncrementalStreamState(),
+    );
+
+    expect(message.parts).toMatchObject([
+      {
+        type: "tool-weather",
+        toolCallId: "static-error",
+        state: "output-error",
+        rawInput: { city: "Boston" },
+        errorText: "Invalid weather request",
+        providerExecuted: true,
+        resultProviderMetadata: { openai: { result: "static" } },
+      },
+      {
+        type: "dynamic-tool",
+        toolCallId: "dynamic-error",
+        toolName: "runtimeTool",
+        state: "output-error",
+        input: { id: 1 },
+        errorText: "Invalid runtime request",
+        resultProviderMetadata: { anthropic: { result: "dynamic" } },
+      },
+    ]);
   });
 
   it("applyUIMessageChunksIncremental: tool-input-error sets rawInput and clears input for static tools", async () => {
@@ -388,7 +664,15 @@ describe("mergeDeltas", () => {
       [
         { type: "start" },
         { type: "start-step" },
-        { type: "tool-input-start", toolCallId: "c2", toolName: "myTool" },
+        {
+          type: "tool-input-start",
+          toolCallId: "c2",
+          toolName: "myTool",
+          providerExecuted: true,
+          title: "My tool",
+          toolMetadata: { source: "test" },
+          providerMetadata: { openai: { itemId: "call-1" } },
+        },
       ] as UIMessageChunk[],
       state,
     ));
@@ -416,6 +700,12 @@ describe("mergeDeltas", () => {
     expect(toolPart?.input).toBeUndefined();
     expect((toolPart as { rawInput?: unknown }).rawInput).toEqual({
       bad: "args",
+    });
+    expect(toolPart).toMatchObject({
+      providerExecuted: true,
+      title: "My tool",
+      toolMetadata: { source: "test" },
+      callProviderMetadata: { openai: { itemId: "call-1" } },
     });
   });
 
@@ -588,10 +878,11 @@ describe("mergeDeltas", () => {
     ];
 
     // SDK: process the entire stream at once.
-    const sdkMsg = await updateFromUIMessageChunks(
+    const sdkMsg = applyUIMessageChunksIncremental(
       blankUIMessage(streamMessage, "thread-equiv"),
       batches.flat(),
-    );
+      emptyIncrementalStreamState(),
+    ).message;
 
     // Incremental: process batch by batch, threading state.
     let incMsg = blankUIMessage(streamMessage, "thread-equiv");

--- a/src/vercel/deltas.ts
+++ b/src/vercel/deltas.ts
@@ -1,13 +1,13 @@
 import {
-  readUIMessageStream,
+  type CustomContentUIPart,
   type DynamicToolUIPart,
   type ProviderMetadata,
+  type ReasoningFileUIPart,
   type ReasoningUIPart,
   type TextUIPart,
   type ToolUIPart,
   type UIMessageChunk,
 } from "ai";
-import { assert } from "convex-helpers";
 import { type UIMessage } from "./UIMessages.js";
 import { joinText, sorted } from "../shared.js";
 import {
@@ -50,58 +50,6 @@ export function statusFromStreamStatus(
   }
 }
 
-export async function updateFromUIMessageChunks(
-  uiMessage: UIMessage,
-  parts: UIMessageChunk[],
-) {
-  if (parts.length === 0) {
-    return uiMessage;
-  }
-  const partsStream = new ReadableStream<UIMessageChunk>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
-  let failed = false;
-  let suppressError = false;
-  const messageStream = readUIMessageStream({
-    message: uiMessage,
-    stream: partsStream,
-    onError: (e) => {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      if (errorMessage.toLowerCase().includes("no tool invocation found")) {
-        suppressError = true;
-        return;
-      }
-      failed = true;
-      console.error("Error in stream", e);
-    },
-    terminateOnError: true,
-  });
-  let message = uiMessage;
-  try {
-    for await (const messagePart of messageStream) {
-      assert(
-        messagePart.id === message.id,
-        `Expecting to only make one UIMessage in a stream`,
-      );
-      message = messagePart;
-    }
-  } catch (e) {
-    if (!suppressError) {
-      throw e;
-    }
-  }
-  if (failed) {
-    message.status = "failed";
-  }
-  message.text = joinText(message.parts);
-  return message;
-}
-
 type ToolPart = ToolUIPart | DynamicToolUIPart;
 
 function transitionToolPart<S extends ToolPart["state"]>(
@@ -133,11 +81,18 @@ export function emptyIncrementalStreamState(): IncrementalStreamState {
  * indices stay stable across the structuredClone between batches. Behavior
  * mirrors the AI SDK's processUIMessageStream.
  */
-export function applyUIMessageChunksIncremental(
-  uiMessage: UIMessage,
+export function applyUIMessageChunksIncremental<
+  METADATA = unknown,
+  DATA_PARTS extends import("ai").UIDataTypes = import("ai").UIDataTypes,
+  TOOLS extends import("ai").UITools = import("ai").UITools,
+>(
+  uiMessage: UIMessage<METADATA, DATA_PARTS, TOOLS>,
   newParts: UIMessageChunk[],
   prev: IncrementalStreamState,
-): { message: UIMessage; streamState: IncrementalStreamState } {
+): {
+  message: UIMessage<METADATA, DATA_PARTS, TOOLS>;
+  streamState: IncrementalStreamState;
+} {
   const message: UIMessage = structuredClone(uiMessage);
   const activeText: Record<string, number> = { ...prev.activeText };
   const activeReasoning: Record<string, number> = { ...prev.activeReasoning };
@@ -174,7 +129,9 @@ export function applyUIMessageChunksIncremental(
           type: "text",
           text: "",
           state: "streaming",
-          providerMetadata: part.providerMetadata,
+          ...(part.providerMetadata
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
         };
         message.parts.push(newPart);
         activeText[part.id] = message.parts.length - 1;
@@ -185,10 +142,11 @@ export function applyUIMessageChunksIncremental(
         if (idx !== undefined) {
           const textPart = message.parts[idx] as TextUIPart;
           textPart.text += part.delta;
-          textPart.providerMetadata = mergeProviderMetadata(
+          const providerMetadata = mergeProviderMetadata(
             textPart.providerMetadata,
             part.providerMetadata,
           );
+          if (providerMetadata) textPart.providerMetadata = providerMetadata;
         }
         break;
       }
@@ -197,10 +155,11 @@ export function applyUIMessageChunksIncremental(
         if (idx !== undefined) {
           const textPart = message.parts[idx] as TextUIPart;
           textPart.state = "done";
-          textPart.providerMetadata = mergeProviderMetadata(
+          const providerMetadata = mergeProviderMetadata(
             textPart.providerMetadata,
             part.providerMetadata,
           );
+          if (providerMetadata) textPart.providerMetadata = providerMetadata;
           delete activeText[part.id];
         }
         break;
@@ -210,7 +169,9 @@ export function applyUIMessageChunksIncremental(
           type: "reasoning",
           text: "",
           state: "streaming",
-          providerMetadata: part.providerMetadata,
+          ...(part.providerMetadata
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
         };
         message.parts.push(newPart);
         activeReasoning[part.id] = message.parts.length - 1;
@@ -221,10 +182,12 @@ export function applyUIMessageChunksIncremental(
         if (idx !== undefined) {
           const reasoningPart = message.parts[idx] as ReasoningUIPart;
           reasoningPart.text += part.delta;
-          reasoningPart.providerMetadata = mergeProviderMetadata(
+          const providerMetadata = mergeProviderMetadata(
             reasoningPart.providerMetadata,
             part.providerMetadata,
           );
+          if (providerMetadata)
+            reasoningPart.providerMetadata = providerMetadata;
         }
         break;
       }
@@ -233,14 +196,35 @@ export function applyUIMessageChunksIncremental(
         if (idx !== undefined) {
           const reasoningPart = message.parts[idx] as ReasoningUIPart;
           reasoningPart.state = "done";
-          reasoningPart.providerMetadata = mergeProviderMetadata(
+          const providerMetadata = mergeProviderMetadata(
             reasoningPart.providerMetadata,
             part.providerMetadata,
           );
+          if (providerMetadata)
+            reasoningPart.providerMetadata = providerMetadata;
           delete activeReasoning[part.id];
         }
         break;
       }
+      case "reasoning-file":
+        message.parts.push({
+          type: "reasoning-file",
+          url: part.url,
+          mediaType: part.mediaType,
+          ...(part.providerMetadata
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
+        } satisfies ReasoningFileUIPart);
+        break;
+      case "custom":
+        message.parts.push({
+          type: "custom",
+          kind: part.kind,
+          ...(part.providerMetadata
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
+        } satisfies CustomContentUIPart);
+        break;
       case "tool-input-start": {
         const newToolPart: ToolUIPart | DynamicToolUIPart = part.dynamic
           ? ({
@@ -249,13 +233,32 @@ export function applyUIMessageChunksIncremental(
               toolName: part.toolName,
               state: "input-streaming",
               input: undefined,
+              ...(part.providerExecuted === undefined
+                ? {}
+                : { providerExecuted: part.providerExecuted }),
+              ...(part.title === undefined ? {} : { title: part.title }),
+              ...(part.toolMetadata === undefined
+                ? {}
+                : { toolMetadata: part.toolMetadata }),
+              ...(part.providerMetadata
+                ? { callProviderMetadata: part.providerMetadata }
+                : {}),
             } satisfies DynamicToolUIPart)
           : ({
               type: `tool-${part.toolName}`,
               toolCallId: part.toolCallId,
               state: "input-streaming",
               input: undefined,
-              providerExecuted: part.providerExecuted,
+              ...(part.providerExecuted === undefined
+                ? {}
+                : { providerExecuted: part.providerExecuted }),
+              ...(part.title === undefined ? {} : { title: part.title }),
+              ...(part.toolMetadata === undefined
+                ? {}
+                : { toolMetadata: part.toolMetadata }),
+              ...(part.providerMetadata
+                ? { callProviderMetadata: part.providerMetadata }
+                : {}),
             } satisfies ToolUIPart);
         message.parts.push(newToolPart);
         toolIndexById.set(part.toolCallId, message.parts.length - 1);
@@ -275,18 +278,42 @@ export function applyUIMessageChunksIncremental(
         break;
       }
       case "tool-input-available": {
-        const toolPart = toolPartAt(part.toolCallId);
-        if (toolPart) {
-          transitionToolPart(toolPart, {
-            state: "input-available",
-            input: part.input,
-            callProviderMetadata: mergeProviderMetadata(
-              (toolPart as { callProviderMetadata?: ProviderMetadata })
-                .callProviderMetadata,
-              part.providerMetadata,
-            ),
-          });
+        let toolPart = toolPartAt(part.toolCallId);
+        if (!toolPart) {
+          toolPart = part.dynamic
+            ? ({
+                type: "dynamic-tool",
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+                state: "input-available",
+                input: part.input,
+              } satisfies DynamicToolUIPart)
+            : ({
+                type: `tool-${part.toolName}`,
+                toolCallId: part.toolCallId,
+                state: "input-available",
+                input: part.input,
+              } satisfies ToolUIPart);
+          message.parts.push(toolPart);
+          toolIndexById.set(part.toolCallId, message.parts.length - 1);
         }
+        const callProviderMetadata = mergeProviderMetadata(
+          (toolPart as { callProviderMetadata?: ProviderMetadata })
+            .callProviderMetadata,
+          part.providerMetadata,
+        );
+        transitionToolPart(toolPart, {
+          state: "input-available",
+          input: part.input,
+          ...(part.providerExecuted === undefined
+            ? {}
+            : { providerExecuted: part.providerExecuted }),
+          ...(part.title === undefined ? {} : { title: part.title }),
+          ...(part.toolMetadata === undefined
+            ? {}
+            : { toolMetadata: part.toolMetadata }),
+          ...(callProviderMetadata ? { callProviderMetadata } : {}),
+        });
         touchedTools.delete(part.toolCallId);
         // The raw JSON buffer is no longer needed; drop it so it doesn't get
         // carried through every later batch on the hot path.
@@ -294,22 +321,53 @@ export function applyUIMessageChunksIncremental(
         break;
       }
       case "tool-input-error": {
-        const toolPart = toolPartAt(part.toolCallId);
-        if (toolPart) {
-          transitionToolPart(toolPart, {
-            state: "output-error",
-            errorText: part.errorText,
-            providerExecuted: part.providerExecuted,
-            ...(toolPart.type === "dynamic-tool"
-              ? { input: part.input }
-              : { input: undefined, rawInput: part.input }),
-            callProviderMetadata: mergeProviderMetadata(
-              (toolPart as { callProviderMetadata?: ProviderMetadata })
-                .callProviderMetadata,
-              part.providerMetadata,
-            ),
-          });
+        let toolPart = toolPartAt(part.toolCallId);
+        if (!toolPart) {
+          toolPart = part.dynamic
+            ? ({
+                type: "dynamic-tool",
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+                state: "output-error",
+                input: part.input,
+                errorText: part.errorText,
+              } satisfies DynamicToolUIPart)
+            : ({
+                type: `tool-${part.toolName}`,
+                toolCallId: part.toolCallId,
+                state: "output-error",
+                input: undefined,
+                rawInput: part.input,
+                errorText: part.errorText,
+              } satisfies ToolUIPart);
+          message.parts.push(toolPart);
+          toolIndexById.set(part.toolCallId, message.parts.length - 1);
         }
+        const resultProviderMetadata = mergeProviderMetadata(
+          (toolPart as { resultProviderMetadata?: ProviderMetadata })
+            .resultProviderMetadata,
+          part.providerMetadata,
+        );
+        transitionToolPart(toolPart, {
+          state: "output-error",
+          errorText: part.errorText,
+          ...(part.providerExecuted === undefined
+            ? {}
+            : { providerExecuted: part.providerExecuted }),
+          ...(toolPart.type === "dynamic-tool"
+            ? {
+                input: part.input,
+              }
+            : {
+                input: undefined,
+                rawInput: part.input,
+              }),
+          ...(part.title === undefined ? {} : { title: part.title }),
+          ...(part.toolMetadata === undefined
+            ? {}
+            : { toolMetadata: part.toolMetadata }),
+          ...(resultProviderMetadata ? { resultProviderMetadata } : {}),
+        });
         touchedTools.delete(part.toolCallId);
         delete toolInputText[part.toolCallId];
         break;
@@ -321,7 +379,15 @@ export function applyUIMessageChunksIncremental(
             state: "output-available",
             output: part.output,
             preliminary: part.preliminary,
-            providerExecuted: part.providerExecuted,
+            ...(part.providerExecuted === undefined
+              ? {}
+              : { providerExecuted: part.providerExecuted }),
+            ...(part.providerMetadata
+              ? { resultProviderMetadata: part.providerMetadata }
+              : {}),
+            ...(part.toolMetadata === undefined
+              ? {}
+              : { toolMetadata: part.toolMetadata }),
           });
         }
         break;
@@ -332,8 +398,20 @@ export function applyUIMessageChunksIncremental(
           transitionToolPart(toolPart, {
             state: "output-error",
             errorText: part.errorText,
-            providerExecuted: part.providerExecuted,
+            output: undefined,
+            ...(part.providerExecuted === undefined
+              ? {}
+              : { providerExecuted: part.providerExecuted }),
+            ...(part.providerMetadata
+              ? { resultProviderMetadata: part.providerMetadata }
+              : {}),
+            ...(part.toolMetadata === undefined
+              ? {}
+              : { toolMetadata: part.toolMetadata }),
           });
+          // The SDK clears a prior preliminary result when the final outcome
+          // is an error. `preliminary` is not part of the error-state type.
+          Object.assign(toolPart, { preliminary: undefined });
         }
         break;
       }
@@ -349,7 +427,43 @@ export function applyUIMessageChunksIncremental(
         if (toolPart) {
           transitionToolPart(toolPart, {
             state: "approval-requested",
-            approval: { id: part.approvalId },
+            approval: {
+              id: part.approvalId,
+              ...(part.isAutomatic === undefined
+                ? {}
+                : { isAutomatic: part.isAutomatic }),
+              ...(part.signature === undefined
+                ? {}
+                : { signature: part.signature }),
+            },
+          });
+        }
+        break;
+      }
+      case "tool-approval-response": {
+        const toolPart = message.parts.find(
+          (candidate) =>
+            "approval" in candidate &&
+            (candidate as ToolPart).approval?.id === part.approvalId,
+        ) as ToolPart | undefined;
+        if (toolPart) {
+          const callProviderMetadata = mergeProviderMetadata(
+            (toolPart as { callProviderMetadata?: ProviderMetadata })
+              .callProviderMetadata,
+            part.providerMetadata,
+          );
+          transitionToolPart(toolPart, {
+            state: "approval-responded",
+            approval: {
+              ...toolPart.approval,
+              id: part.approvalId,
+              approved: part.approved,
+              ...(part.reason === undefined ? {} : { reason: part.reason }),
+            },
+            ...(part.providerExecuted === undefined
+              ? {}
+              : { providerExecuted: part.providerExecuted }),
+            ...(callProviderMetadata ? { callProviderMetadata } : {}),
           });
         }
         break;
@@ -378,6 +492,7 @@ export function applyUIMessageChunksIncremental(
           type: "file",
           mediaType: part.mediaType,
           url: part.url,
+          providerMetadata: part.providerMetadata,
         });
         break;
       case "start-step":
@@ -414,6 +529,9 @@ export function applyUIMessageChunksIncremental(
                     (p as { id?: string }).id === dataPart.id,
                 )
               : -1;
+          if (dataPart.transient) {
+            break;
+          }
           if (existingIdx >= 0) {
             (message.parts[existingIdx] as { data?: unknown }).data =
               dataPart.data;
@@ -445,7 +563,7 @@ export function applyUIMessageChunksIncremental(
 
   message.text = joinText(message.parts);
   return {
-    message,
+    message: message as UIMessage<METADATA, DATA_PARTS, TOOLS>,
     streamState: { activeText, activeReasoning, toolInputText },
   };
 }
@@ -466,10 +584,11 @@ export async function deriveUIMessagesFromDeltas(
       allDeltas.filter((d) => d.streamId === streamMessage.streamId),
       0,
     );
-    const uiMessage = await updateFromUIMessageChunks(
+    const uiMessage = applyUIMessageChunksIncremental(
       blankUIMessage(streamMessage, threadId),
       parts,
-    );
+      emptyIncrementalStreamState(),
+    ).message;
     messages.push(uiMessage);
   }
   return sorted(messages);
@@ -510,21 +629,5 @@ function mergeProviderMetadata(
   existing: ProviderMetadata | undefined,
   part: ProviderMetadata | undefined,
 ): ProviderMetadata | undefined {
-  if (!existing && !part) {
-    return undefined;
-  }
-  if (!existing) {
-    return part;
-  }
-  if (!part) {
-    return existing;
-  }
-  const merged: ProviderMetadata = existing;
-  for (const [provider, metadata] of Object.entries(part)) {
-    merged[provider] = {
-      ...merged[provider],
-      ...metadata,
-    };
-  }
-  return merged;
+  return part ?? existing;
 }

--- a/src/vercel/index.ts
+++ b/src/vercel/index.ts
@@ -1,5 +1,5 @@
 /**
- * Internal AI SDK 6 implementation for the Agent API.
+ * Internal AI SDK implementation for the Agent API.
  *
  * Consumers continue to import this API from `@convex-dev/agent`. A public
  * `@convex-dev/agent/vercel` entry point is intentionally deferred until its
@@ -8,24 +8,26 @@
 
 import type { JSONValue } from "@ai-sdk/provider";
 import type {
+  Context,
   FlexibleSchema,
   IdGenerator,
   InferSchema,
 } from "@ai-sdk/provider-utils";
 import type {
-  CallSettings,
   EmbeddingModel,
   GenerateObjectResult,
   GenerateTextResult,
   LanguageModel,
+  Instructions,
   ModelMessage,
+  Output as AISDKOutput,
   StepResult,
   StopCondition,
   StreamTextResult,
   ToolChoice,
   ToolSet,
 } from "ai";
-import { generateObject, generateText, stepCountIs, streamObject } from "ai";
+import { generateObject, generateText, isStepCount, streamObject } from "ai";
 
 const MIGRATION_URL = "node_modules/@convex-dev/agent/MIGRATION.md";
 const warnedDeprecations = new Set<string>();
@@ -51,7 +53,7 @@ import { type VectorDimension } from "../component/vector/tables.js";
 import {
   toModelMessage,
   serializeMessage,
-  serializeNewMessagesInStep,
+  serializeResponseMessages,
   serializeObjectResult,
 } from "./mapping.js";
 import { getModelName, getProviderName } from "../shared.js";
@@ -104,7 +106,7 @@ import type {
   UsageHandler,
   QueryCtx,
   AgentPrompt,
-  Output,
+  AgentCallSettings,
 } from "./client/types.js";
 import { streamText } from "./client/streamText.js";
 import {
@@ -113,7 +115,7 @@ import {
   willContinue,
 } from "./client/utils.js";
 
-export { stepCountIs } from "ai";
+export { isStepCount, stepCountIs } from "ai";
 export { hasSuccessfulToolCall };
 export {
   docsToModelMessages,
@@ -248,7 +250,7 @@ export class Agent<
        * The default system prompt to put in each request.
        * Override per-prompt by passing the "system" parameter.
        */
-      instructions?: string;
+      instructions?: Instructions;
       /**
        * Tools that the agent can call out to and get responses from.
        * They can be AI SDK tools (import {tool} from "ai")
@@ -397,6 +399,7 @@ export class Agent<
     T extends {
       _internal?: { generateId?: IdGenerator };
     },
+    RUNTIME_CONTEXT extends Context = Context,
   >(
     ctx: ActionCtx & CustomCtx,
     /**
@@ -419,19 +422,34 @@ export class Agent<
          * aborted, it will trigger this signal when detected.
          */
         abortSignal?: AbortSignal;
+        runtimeContext?: RUNTIME_CONTEXT;
         stopWhen?:
-          | StopCondition<TOOLS extends undefined ? AgentTools : TOOLS>
-          | Array<StopCondition<TOOLS extends undefined ? AgentTools : TOOLS>>;
+          | StopCondition<
+              TOOLS extends undefined ? AgentTools : TOOLS,
+              RUNTIME_CONTEXT
+            >
+          | Array<
+              StopCondition<
+                TOOLS extends undefined ? AgentTools : TOOLS,
+                RUNTIME_CONTEXT
+              >
+            >;
       },
     options?: Options & { userId?: string | null; threadId?: string },
+    operation?:
+      | "generateText"
+      | "streamText"
+      | "generateObject"
+      | "streamObject",
   ): Promise<{
     args: T & {
-      system?: string;
+      instructions?: Instructions;
       model: LanguageModel;
       prompt?: never;
       messages: ModelMessage[];
+      runtimeContext?: RUNTIME_CONTEXT;
       tools?: TOOLS extends undefined ? AgentTools : TOOLS;
-    } & CallSettings;
+    } & AgentCallSettings;
     order: number;
     stepOrder: number;
     userId: string | undefined;
@@ -439,7 +457,10 @@ export class Agent<
     updateModel: (model: LanguageModel | undefined) => void;
     save: <TOOLS extends ToolSet>(
       toSave:
-        | { step: StepResult<TOOLS> }
+        | {
+            step: StepResult<TOOLS, RUNTIME_CONTEXT>;
+            responseMessages?: ModelMessage[];
+          }
         | { object: GenerateObjectResult<unknown> },
       createPendingMessage?: boolean,
     ) => Promise<void>;
@@ -447,13 +468,14 @@ export class Agent<
     getSavedMessages: () => MessageDoc[];
   }> {
     type Tools = TOOLS extends undefined ? AgentTools : TOOLS;
-    return startGeneration<T, Tools, CustomCtx>(
+    return startGeneration<T, Tools, CustomCtx, RUNTIME_CONTEXT>(
       ctx,
       this.component,
       {
         ...args,
         tools: (args.tools ?? this.options.tools) as Tools,
-        system: args.system ?? this.options.instructions,
+        instructions:
+          args.instructions ?? args.system ?? this.options.instructions,
         stopWhen: (args.stopWhen ?? this.options.stopWhen) as any,
       },
       {
@@ -462,6 +484,7 @@ export class Agent<
         agentName: this.options.name,
         agentForToolCtx: this,
       },
+      operation,
     );
   }
 
@@ -480,7 +503,11 @@ export class Agent<
    */
   async generateText<
     TOOLS extends ToolSet | undefined = undefined,
-    OUTPUT extends Output<any, any, any> = never,
+    OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+      string,
+      string
+    >,
+    RUNTIME_CONTEXT extends Context = Context,
   >(
     ctx: ActionCtx & CustomCtx,
     threadOpts: { userId?: string | null; threadId?: string },
@@ -488,34 +515,56 @@ export class Agent<
      * The arguments to the generateText function, similar to the ai sdk's
      * {@link generateText} function, along with Agent prompt options.
      */
-    generateTextArgs: AgentPrompt & TextArgs<AgentTools, TOOLS, OUTPUT>,
+    generateTextArgs: TextArgs<AgentTools, TOOLS, OUTPUT, RUNTIME_CONTEXT>,
     options?: Options,
   ): Promise<
-    GenerateTextResult<TOOLS extends undefined ? AgentTools : TOOLS, OUTPUT> &
+    GenerateTextResult<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    > &
       GenerationOutputMetadata
   > {
     const { args, promptMessageId, order, ...call } = await this.start(
       ctx,
       generateTextArgs,
       { ...threadOpts, ...options },
+      "generateText",
     );
 
     type Tools = TOOLS extends undefined ? AgentTools : TOOLS;
-    const steps: StepResult<Tools>[] = [];
+    const steps: StepResult<Tools, RUNTIME_CONTEXT>[] = [];
+    let initialResponseMessages: ModelMessage[] = [];
+    let initialResponseMessagesSaved = false;
     try {
-      const result = (await generateText<Tools, OUTPUT>({
+      const result = (await generateText<Tools, RUNTIME_CONTEXT, OUTPUT>({
         ...args,
         prepareStep: async (options) => {
+          if (options.stepNumber === 0) {
+            initialResponseMessages = [...options.responseMessages];
+          }
           const result = await generateTextArgs.prepareStep?.(options);
           call.updateModel(result?.model ?? options.model);
           return result;
         },
-        onStepFinish: async (step) => {
+        onStepEnd: async (step) => {
           steps.push(step);
-          await call.save({ step }, await willContinue(steps, args.stopWhen));
-          return generateTextArgs.onStepFinish?.(step);
+          await call.save(
+            {
+              step,
+              responseMessages: [
+                ...(initialResponseMessagesSaved ? [] : initialResponseMessages),
+                ...step.response.messages,
+              ],
+            },
+            await willContinue(steps, args.stopWhen),
+          );
+          initialResponseMessagesSaved = true;
+          return (
+            generateTextArgs.onStepEnd ?? generateTextArgs.onStepFinish
+          )?.(step);
         },
-      })) as GenerateTextResult<Tools, OUTPUT>;
+      })) as GenerateTextResult<Tools, RUNTIME_CONTEXT, OUTPUT>;
       const metadata: GenerationOutputMetadata = {
         promptMessageId,
         order,
@@ -538,7 +587,12 @@ export class Agent<
    */
   async streamText<
     TOOLS extends ToolSet | undefined = undefined,
-    OUTPUT extends Output<any, any, any> = never,
+    OUTPUT extends AISDKOutput.Output<any, any, any> = AISDKOutput.Output<
+      string,
+      string,
+      never
+    >,
+    RUNTIME_CONTEXT extends Context = Context,
   >(
     ctx: ActionCtx & CustomCtx,
     threadOpts: { userId?: string | null; threadId?: string },
@@ -546,7 +600,12 @@ export class Agent<
      * The arguments to the streamText function, similar to the ai sdk's
      * {@link streamText} function, along with Agent prompt options.
      */
-    streamTextArgs: AgentPrompt & StreamingTextArgs<AgentTools, TOOLS, OUTPUT>,
+    streamTextArgs: StreamingTextArgs<
+      AgentTools,
+      TOOLS,
+      OUTPUT,
+      RUNTIME_CONTEXT
+    >,
     /**
      * The {@link ContextOptions} and {@link StorageOptions}
      * options to use for fetching contextual messages and saving input/output messages.
@@ -565,18 +624,25 @@ export class Agent<
       saveStreamDeltas?: boolean | StreamingOptions;
     },
   ): Promise<
-    StreamTextResult<TOOLS extends undefined ? AgentTools : TOOLS, OUTPUT> &
+    StreamTextResult<
+      TOOLS extends undefined ? AgentTools : TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    > &
       GenerationOutputMetadata
   > {
     type Tools = TOOLS extends undefined ? AgentTools : TOOLS;
-    return streamText<Tools, OUTPUT>(
+    return streamText<AgentTools, TOOLS, OUTPUT, RUNTIME_CONTEXT>(
       ctx,
       this.component,
       {
         ...streamTextArgs,
         model: streamTextArgs.model ?? this.options.languageModel,
         tools: (streamTextArgs.tools ?? this.options.tools) as Tools,
-        system: streamTextArgs.system ?? this.options.instructions,
+        instructions:
+          streamTextArgs.instructions ??
+          streamTextArgs.system ??
+          this.options.instructions,
         stopWhen: (streamTextArgs.stopWhen ?? this.options.stopWhen) as any,
       },
       {
@@ -611,8 +677,7 @@ export class Agent<
      * The arguments to the generateObject function, similar to the ai sdk's
      * {@link generateObject} function, along with Agent prompt options.
      */
-    generateObjectArgs: AgentPrompt &
-      GenerateObjectArgs<SCHEMA, OUTPUT, RESULT>,
+    generateObjectArgs: GenerateObjectArgs<SCHEMA, OUTPUT, RESULT>,
     /**
      * The {@link ContextOptions} and {@link StorageOptions}
      * options to use for fetching contextual messages and saving input/output messages.
@@ -620,7 +685,12 @@ export class Agent<
     options?: Options,
   ): Promise<GenerateObjectResult<RESULT> & GenerationOutputMetadata> {
     const { args, promptMessageId, order, fail, save, getSavedMessages } =
-      await this.start(ctx, generateObjectArgs, { ...threadOpts, ...options });
+      await this.start(
+        ctx,
+        generateObjectArgs,
+        { ...threadOpts, ...options },
+        "generateObject",
+      );
 
     try {
       const result = (await generateObject(
@@ -663,7 +733,7 @@ export class Agent<
      * The arguments to the streamObject function, similar to the ai sdk's
      * {@link streamObject} function, along with Agent prompt options.
      */
-    streamObjectArgs: AgentPrompt & StreamObjectArgs<SCHEMA, OUTPUT, RESULT>,
+    streamObjectArgs: StreamObjectArgs<SCHEMA, OUTPUT, RESULT>,
     /**
      * The {@link ContextOptions} and {@link StorageOptions}
      * options to use for fetching contextual messages and saving input/output messages.
@@ -674,7 +744,12 @@ export class Agent<
       GenerationOutputMetadata
   > {
     const { args, promptMessageId, order, fail, save, getSavedMessages } =
-      await this.start(ctx, streamObjectArgs, { ...threadOpts, ...options });
+      await this.start(
+        ctx,
+        streamObjectArgs,
+        { ...threadOpts, ...options },
+        "streamObject",
+      );
 
     const stream = streamObject<SCHEMA, OUTPUT, RESULT>({
       ...(args as any),
@@ -1194,8 +1269,7 @@ export class Agent<
 
   /**
    * Explicitly save a "step" created by the AI SDK. For multi-step generation
-   * loops, pass `previousStep` so we save only the new response messages —
-   * see the arg JSDoc for why.
+   * loops, each SDK 7 step already owns its response messages.
    * @param ctx The ctx argument to a mutation or action.
    * @param args The Step generated by the AI SDK.
    */
@@ -1212,14 +1286,7 @@ export class Agent<
        * The step to save, possibly including multiple tool calls.
        */
       step: StepResult<TOOLS>;
-      /**
-       * The previous step in the same generation loop, if any. Pass it so we
-       * can compute how many of `step.response.messages` are already saved.
-       * Omit for the first step. AI SDK v6's `step.response.messages` is
-       * cumulative across steps; without this, multi-step callers duplicate
-       * every prior message on every save — the exact failure mode this fix
-       * addresses, just at the public-API layer.
-       */
+      /** @deprecated SDK 7 response messages are step-local. */
       previousStep?: StepResult<TOOLS>;
       /**
        * The model used to generate the step.
@@ -1233,19 +1300,7 @@ export class Agent<
       provider?: string;
     },
   ): Promise<{ messages: MessageDoc[] }> {
-    const previousResponseMessageCount =
-      args.previousStep?.response.messages.length ?? 0;
-    if (
-      args.previousStep !== undefined &&
-      args.step.response.messages.length < previousResponseMessageCount
-    ) {
-      throw new Error(
-        `saveStep: step.response.messages length (${args.step.response.messages.length}) is less than ` +
-          `previousStep.response.messages length (${previousResponseMessageCount}). ` +
-          `Ensure previousStep is from the immediately preceding step in the same generation loop.`,
-      );
-    }
-    const { messages } = await serializeNewMessagesInStep(
+    const { messages } = await serializeResponseMessages(
       ctx,
       this.component,
       args.step,
@@ -1253,7 +1308,9 @@ export class Agent<
         provider: args.provider ?? getProviderName(this.options.languageModel),
         model: args.model ?? getModelName(this.options.languageModel),
       },
-      previousResponseMessageCount,
+      args.step.response.messages.length > 0
+        ? args.step.response.messages
+        : [{ role: "assistant", content: [] }],
     );
     const embeddings = await this.generateEmbeddings(
       ctx,
@@ -1568,25 +1625,34 @@ export class Agent<
        */
       stopWhen?: StopCondition<AgentTools> | Array<StopCondition<AgentTools>>;
     } & Options,
-    overrides?: CallSettings,
+    overrides?: AgentCallSettings,
   ) {
     return internalActionGeneric({
       args: vTextArgs,
       handler: async (ctx_, args) => {
         const stream =
           args.stream === true ? spec?.stream || true : (spec?.stream ?? false);
-        const { userId, threadId, prompt, messages, maxSteps, ...rest } = args;
+        const {
+          userId,
+          threadId,
+          prompt,
+          messages,
+          maxSteps,
+          system,
+          ...rest
+        } = args;
         const targetArgs = { userId, threadId };
         const llmArgs = {
           stopWhen: spec?.stopWhen,
           ...overrides,
           ...omit(rest, ["storageOptions", "contextOptions", "stream"]),
+          instructions: system,
           messages: messages?.map(toModelMessage),
           prompt: Array.isArray(prompt) ? prompt.map(toModelMessage) : prompt,
           toolChoice: args.toolChoice as ToolChoice<AgentTools>,
-        } satisfies StreamingTextArgs<AgentTools>;
+        } as any;
         if (maxSteps) {
-          llmArgs.stopWhen = stepCountIs(maxSteps);
+          llmArgs.stopWhen = isStepCount(maxSteps);
         }
         const opts = {
           ...pick(spec, ["contextOptions", "storageOptions"]),
@@ -1647,13 +1713,19 @@ export class Agent<
     return internalActionGeneric({
       args: vSafeObjectArgs,
       handler: async (ctx_, args) => {
-        const { userId, threadId, callSettings, ...rest } = args;
+        const { userId, threadId, callSettings, system, ...rest } = args;
+        const {
+          instructions: configuredInstructions,
+          system: configuredSystem,
+          ...configuredObjectArgs
+        } = objectArgs;
         const overrides = pick(rest, ["contextOptions", "storageOptions"]);
         const targetArgs = { userId, threadId };
         const llmArgs = {
-          ...objectArgs,
+          ...configuredObjectArgs,
           ...callSettings,
           ...omit(rest, ["storageOptions", "contextOptions"]),
+          instructions: system ?? configuredInstructions ?? configuredSystem,
           messages: args.messages?.map(toModelMessage),
           prompt: Array.isArray(args.prompt)
             ? args.prompt.map(toModelMessage)

--- a/src/vercel/mapping.test.ts
+++ b/src/vercel/mapping.test.ts
@@ -4,25 +4,31 @@ import {
   serializeDataOrUrl,
   toModelMessageDataOrUrl,
   serializeMessage,
-  serializeNewMessagesInStep,
   serializeResponseMessages,
   toModelMessage,
   serializeContent,
   toModelMessageContent,
+  toUIFilePart,
   autoDenyUnresolvedApprovals,
+  serializeWarnings,
 } from "./mapping.js";
 import { api } from "../component/_generated/api.js";
-import type {
-  AgentComponent,
-  ActionCtx,
-} from "./client/types.js";
+import type { AgentComponent, ActionCtx } from "./client/types.js";
 import { vMessage, vToolResultPart } from "../validators.js";
 import fs from "fs";
 import path from "path";
 import type { SerializedContent } from "./mapping.js";
 import { validate } from "convex-helpers/validators";
-import type { ModelMessage, StepResult, ToolResultPart, ToolSet } from "ai";
+import type {
+  FilePart,
+  ModelMessage,
+  StepResult,
+  ToolResultPart,
+  ToolSet,
+  CallWarning,
+} from "ai";
 import type { Infer } from "convex/values";
+import { mockModel } from "./client/mockModel.js";
 
 const testAssetsDir = path.join(__dirname, "../../test-assets");
 const testFiles = [
@@ -40,6 +46,21 @@ function fileToArrayBuffer(filePath: string): ArrayBuffer {
 }
 
 describe("mapping", () => {
+  test("serializes every AI SDK 7 warning discriminant", () => {
+    const warnings: CallWarning[] = [
+      { type: "unsupported", feature: "feature", details: "details" },
+      { type: "compatibility", feature: "feature", details: "details" },
+      {
+        type: "deprecated",
+        setting: "setting",
+        message: "message",
+      },
+      { type: "other", message: "message" },
+    ];
+
+    expect(serializeWarnings(warnings)).toEqual(warnings);
+  });
+
   test("infers correct mimeType for all test-assets", () => {
     const expected: { [key: string]: string } = {
       "book.svg": "image/svg+xml", // <svg
@@ -139,6 +160,266 @@ describe("mapping", () => {
     expect(serialized).toMatchObject(expected);
   });
 
+  test("legacy result JSON with a type field is not treated as SDK output", async () => {
+    const weather = { type: "weather", temperature: 72 };
+    const toolResult = {
+      type: "tool-result" as const,
+      toolCallId: "tool-call-id",
+      toolName: "weather",
+      result: weather,
+    } satisfies Infer<typeof vToolResultPart>;
+    const expected = { type: "json", value: weather };
+
+    const [deserialized] = toModelMessageContent([
+      toolResult,
+    ]) as ToolResultPart[];
+    expect(deserialized.output).toEqual(expected);
+    const { content } = await serializeContent(
+      {} as ActionCtx,
+      {} as AgentComponent,
+      [toolResult],
+    );
+    expect((content[0] as Infer<typeof vToolResultPart>).output).toEqual(
+      expected,
+    );
+  });
+
+  test.each([
+    [
+      "tagged data",
+      {
+        type: "file",
+        data: { type: "data", data: new Uint8Array([1, 2]) },
+        mediaType: "application/octet-stream",
+      },
+      { type: "data" },
+    ],
+    [
+      "tagged URL",
+      {
+        type: "file",
+        data: { type: "url", url: new URL("https://example.com/file") },
+        mediaType: "application/pdf",
+      },
+      { type: "url", url: new URL("https://example.com/file") },
+    ],
+    [
+      "tagged text",
+      {
+        type: "file",
+        data: { type: "text", text: "hello" },
+        mediaType: "text/plain",
+      },
+      { type: "text", text: "hello" },
+    ],
+    [
+      "tagged reference",
+      {
+        type: "file",
+        data: { type: "reference", reference: { openai: "file-1" } },
+        mediaType: "application/pdf",
+      },
+      { type: "reference", reference: { openai: "file-1" } },
+    ],
+    [
+      "legacy file-data",
+      {
+        type: "file-data",
+        data: "AQI=",
+        mediaType: "application/octet-stream",
+      },
+      { type: "data", data: "AQI=" },
+    ],
+    [
+      "legacy file-url",
+      {
+        type: "file-url",
+        url: "https://example.com/file",
+        mediaType: "application/pdf",
+      },
+      { type: "url", url: new URL("https://example.com/file") },
+    ],
+    [
+      "legacy file ID",
+      { type: "file-id", fileId: "file-1" },
+      { type: "file-id", fileId: "file-1" },
+    ],
+    [
+      "provider-keyed legacy file ID",
+      { type: "file-id", fileId: { openai: "file-1" } },
+      { type: "reference", reference: { openai: "file-1" } },
+    ],
+    [
+      "legacy file reference",
+      { type: "file-reference", providerReference: { openai: "file-1" } },
+      { type: "reference", reference: { openai: "file-1" } },
+    ],
+    [
+      "legacy image data",
+      { type: "image-data", data: "AQI=", mediaType: "image/png" },
+      { type: "data", data: "AQI=" },
+    ],
+    [
+      "legacy image URL",
+      { type: "image-url", url: "https://example.com/image" },
+      { type: "url", url: new URL("https://example.com/image") },
+    ],
+    [
+      "legacy image ID",
+      { type: "image-file-id", fileId: "image-1" },
+      { type: "image-file-id", fileId: "image-1" },
+    ],
+    [
+      "provider-keyed legacy image ID",
+      { type: "image-file-id", fileId: { openai: "image-1" } },
+      { type: "reference", reference: { openai: "image-1" } },
+    ],
+    [
+      "legacy image reference",
+      {
+        type: "image-file-reference",
+        providerReference: { openai: "image-1" },
+      },
+      { type: "reference", reference: { openai: "image-1" } },
+    ],
+  ])("round-trips AI SDK 7 tool-result %s", async (_name, value, expected) => {
+    const result = {
+      type: "tool-result",
+      toolCallId: "call-1",
+      toolName: "lookup",
+      output: { type: "content", value: [value] },
+    } as ToolResultPart;
+    const { content } = await serializeContent(
+      {} as ActionCtx,
+      {} as AgentComponent,
+      [result],
+    );
+    const [restored] = toModelMessageContent(content) as ToolResultPart[];
+    const restoredPart = (restored.output as { value: unknown[] }).value[0]!;
+    if ("fileId" in expected) {
+      expect(restoredPart).toMatchObject(expected);
+    } else {
+      expect((restoredPart as { data: unknown }).data).toMatchObject(expected);
+    }
+  });
+
+  test("deserializes persisted legacy media tool output to a canonical file", () => {
+    const [restored] = toModelMessageContent([
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "render",
+        output: {
+          type: "content",
+          value: [{ type: "media", data: "AQI=", mediaType: "image/png" }],
+        },
+      },
+    ]) as ToolResultPart[];
+    expect(restored.output).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "data", data: "AQI=" },
+          mediaType: "image/png",
+        },
+      ],
+    });
+  });
+
+  test("reasoning files persist tagged data and URLs, and reject missing data", async () => {
+    const { content } = await serializeContent(
+      {} as ActionCtx,
+      {} as AgentComponent,
+      [
+        {
+          type: "reasoning-file",
+          data: { type: "url", url: new URL("https://example.com/reasoning") },
+          mediaType: "text/plain",
+        },
+        {
+          type: "reasoning-file",
+          data: { type: "data", data: new Uint8Array([1, 2]) },
+          mediaType: "application/octet-stream",
+        },
+        { type: "custom", kind: "provider.annotation" },
+      ] as ModelMessage["content"],
+    );
+    expect(content).toMatchObject([
+      { type: "reasoning-file", url: "https://example.com/reasoning" },
+      { type: "reasoning-file", data: expect.any(ArrayBuffer) },
+      { type: "custom", kind: "provider.annotation" },
+    ]);
+    expect(toModelMessageContent(content)).toMatchObject([
+      {
+        type: "reasoning-file",
+        data: { type: "url", url: new URL("https://example.com/reasoning") },
+      },
+      {
+        type: "reasoning-file",
+        data: { type: "data", data: expect.any(ArrayBuffer) },
+      },
+      { type: "custom", kind: "provider.annotation" },
+    ]);
+    expect(
+      (await serializeContent({} as ActionCtx, {} as AgentComponent, content))
+        .content,
+    ).toEqual(content);
+    expect(() =>
+      toModelMessageContent([
+        { type: "reasoning-file", mediaType: "text/plain" },
+      ] as SerializedContent),
+    ).toThrow("reasoning-file requires data or url");
+  });
+
+  test("reserializing persisted provider fields preserves them", async () => {
+    const content: SerializedContent = [
+      { type: "reasoning", text: "private", signature: "signed" },
+      {
+        type: "tool-result",
+        toolCallId: "provider-call",
+        toolName: "search",
+        providerExecuted: true,
+        output: { type: "text", value: "found" },
+      },
+    ];
+    await expect(
+      serializeContent({} as ActionCtx, {} as AgentComponent, content),
+    ).resolves.toEqual({ content, fileIds: undefined });
+  });
+
+  test.each([
+    [
+      "ArrayBuffer",
+      {
+        type: "file",
+        data: new Uint8Array([1, 2]).buffer,
+        mediaType: "application/octet-stream",
+      },
+      { url: "data:application/octet-stream;base64,AQI=" },
+    ],
+    [
+      "tagged data",
+      {
+        type: "file",
+        data: { type: "data", data: new Uint8Array([1, 2]) },
+        mediaType: "application/octet-stream",
+      },
+      { url: "data:application/octet-stream;base64,AQI=" },
+    ],
+    [
+      "provider reference",
+      {
+        type: "file",
+        data: { type: "reference", reference: { openai: "file-1" } },
+        mediaType: "application/pdf",
+      },
+      { url: "", providerReference: { openai: "file-1" } },
+    ],
+  ])("renders file UI part for %s", (_name, part, expected) => {
+    expect(toUIFilePart(part as FilePart)).toMatchObject(expected);
+  });
+
   test("saving files returns fileIds when too big", async () => {
     // Make a big file
     const bigArr = new Uint8Array(1024 * 65).fill(1);
@@ -229,6 +510,7 @@ describe("mapping", () => {
     );
     expect(content).toHaveLength(1);
     expect((content as unknown[])[0]).toMatchObject(approvalRequest);
+    expect(toModelMessageContent(content)).toMatchObject([approvalRequest]);
   });
 
   test("tool-approval-response with approved: true is preserved", async () => {
@@ -280,7 +562,7 @@ describe("mapping", () => {
     expect(content).toEqual(reasoningFile);
   });
 
-  describe("serializeNewMessagesInStep", () => {
+  describe("serializeResponseMessages", () => {
     const ctx = {
       runAction: async () => undefined,
       runMutation: async () => undefined,
@@ -296,7 +578,12 @@ describe("mapping", () => {
       {
         role: "assistant",
         content: [
-          { type: "tool-call", toolCallId: "c1", toolName: "search", input: {} },
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "search",
+            input: {},
+          },
         ],
       },
       {
@@ -312,15 +599,18 @@ describe("mapping", () => {
       },
     ];
     const step1Messages: ModelMessage[] = [
-      ...step0Messages,
       { role: "assistant", content: [{ type: "text", text: "thinking" }] },
     ];
     const step2Messages: ModelMessage[] = [
-      ...step1Messages,
       {
         role: "assistant",
         content: [
-          { type: "tool-call", toolCallId: "c2", toolName: "search", input: {} },
+          {
+            type: "tool-call",
+            toolCallId: "c2",
+            toolName: "search",
+            input: {},
+          },
         ],
       },
       {
@@ -381,13 +671,13 @@ describe("mapping", () => {
       expect(res.messages).toEqual([]);
     });
 
-    test("first step (count=0) serializes all response messages", async () => {
-      const res = await serializeNewMessagesInStep(
+    test("serializes all response messages for a step", async () => {
+      const res = await serializeResponseMessages(
         ctx,
         component,
         makeStep(step0Messages),
         undefined,
-        0,
+        step0Messages,
       );
       expect(res.messages).toHaveLength(2);
       expect(res.messages[0].message.role).toBe("assistant");
@@ -396,26 +686,50 @@ describe("mapping", () => {
       expect(contentTypes(res.messages[1].message)).toEqual(["tool-result"]);
     });
 
-    test("middle step (count=2) serializes only the new text message", async () => {
-      const res = await serializeNewMessagesInStep(
+    test("serializes the text response from a later step", async () => {
+      const res = await serializeResponseMessages(
         ctx,
         component,
         makeStep(step1Messages),
         undefined,
-        2,
+        step1Messages,
       );
       expect(res.messages).toHaveLength(1);
       expect(res.messages[0].message.role).toBe("assistant");
       expect(contentTypes(res.messages[0].message)).toEqual(["text"]);
     });
 
-    test("multi-message step (count=3) serializes the new tool-call + tool-result pair", async () => {
-      const res = await serializeNewMessagesInStep(
+    test("persists the model that generated an SDK 7 step over the fallback", async () => {
+      const routedModel = mockModel({
+        provider: "routed-provider",
+        modelId: "routed-model",
+      });
+      const step = {
+        ...makeStep(step1Messages),
+        model: routedModel,
+      } as StepResult<ToolSet>;
+
+      const res = await serializeResponseMessages(
+        ctx,
+        component,
+        step,
+        { provider: "fallback-provider", model: "fallback-model" },
+        step1Messages,
+      );
+
+      expect(res.messages[0]).toMatchObject({
+        model: "routed-model",
+        provider: "routed-provider",
+      });
+    });
+
+    test("serializes a tool-call and tool-result from the same step", async () => {
+      const res = await serializeResponseMessages(
         ctx,
         component,
         makeStep(step2Messages),
         undefined,
-        3,
+        step2Messages,
       );
       expect(res.messages).toHaveLength(2);
       expect(res.messages[0].message.role).toBe("assistant");
@@ -424,19 +738,21 @@ describe("mapping", () => {
       expect(contentTypes(res.messages[1].message)).toEqual(["tool-result"]);
     });
 
-    // Regression test for the actually-broken shape: a single step appended
-    // assistant(text) + assistant(tool-call) + tool(tool-result), so the new
-    // tail has length 3 and the last message is a tool message. The old
-    // heuristic took `slice(-2)` whenever the last role was "tool" and would
-    // have dropped the leading text. The watermark returns all three.
-    test("returns all three messages when a step adds text + tool-call + tool-result", async () => {
+    test("preserves text, a tool call, and its result from one step", async () => {
       const stepMessages: ModelMessage[] = [
-        ...step0Messages, // length 2
-        { role: "assistant", content: [{ type: "text", text: "Let me check..." }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Let me check..." }],
+        },
         {
           role: "assistant",
           content: [
-            { type: "tool-call", toolCallId: "c3", toolName: "search", input: {} },
+            {
+              type: "tool-call",
+              toolCallId: "c3",
+              toolName: "search",
+              input: {},
+            },
           ],
         },
         {
@@ -451,12 +767,12 @@ describe("mapping", () => {
           ],
         },
       ];
-      const res = await serializeNewMessagesInStep(
+      const res = await serializeResponseMessages(
         ctx,
         component,
         makeStep(stepMessages),
         undefined,
-        step0Messages.length,
+        stepMessages,
       );
       expect(res.messages).toHaveLength(3);
       expect(res.messages[0].message.role).toBe("assistant");
@@ -465,68 +781,6 @@ describe("mapping", () => {
       expect(contentTypes(res.messages[1].message)).toEqual(["tool-call"]);
       expect(res.messages[2].message.role).toBe("tool");
       expect(contentTypes(res.messages[2].message)).toEqual(["tool-result"]);
-    });
-
-    test("empty response messages slice falls back to synthetic empty assistant", async () => {
-      const res = await serializeNewMessagesInStep(
-        ctx,
-        component,
-        makeStep(step1Messages),
-        undefined,
-        step1Messages.length,
-      );
-      expect(res.messages).toHaveLength(1);
-      expect(res.messages[0].message.role).toBe("assistant");
-      expect(res.messages[0].message.content).toEqual([]);
-    });
-
-    // Pin the caller-drift behavior: if the watermark is past the end of
-    // response.messages (e.g. the caller mistracked), the slice is empty and
-    // we fall through to the synthetic anchor. Future "fixes" should not
-    // accidentally change this without intent.
-    test("watermark beyond response.messages.length returns the synthetic fallback", async () => {
-      const res = await serializeNewMessagesInStep(
-        ctx,
-        component,
-        makeStep(step1Messages),
-        undefined,
-        step1Messages.length + 5,
-      );
-      expect(res.messages).toHaveLength(1);
-      expect(res.messages[0].message.role).toBe("assistant");
-      expect(res.messages[0].message.content).toEqual([]);
-    });
-
-    // AI SDK v6 makes step.response.messages cumulative across steps:
-    // step N's array contains all messages from steps 0..N. Without the
-    // previousResponseMessageCount watermark, every multi-step save duplicates
-    // all prior messages. These tests demonstrate the bug and the fix.
-    describe("multi-step loop — previousStep watermark", () => {
-      test("without watermark, step 2 re-saves all cumulative messages (demonstrates the bug)", async () => {
-        // step2Messages = step0 (2 msgs) + step1 (1 msg) + step2 new (2 msgs) = 5 total
-        const res = await serializeNewMessagesInStep(
-          ctx,
-          component,
-          makeStep(step2Messages),
-          undefined,
-          0,
-        );
-        expect(res.messages).toHaveLength(5);
-      });
-
-      test("with watermark, step 2 saves only its 2 new messages", async () => {
-        const step1 = makeStep(step1Messages);
-        const res = await serializeNewMessagesInStep(
-          ctx,
-          component,
-          makeStep(step2Messages),
-          undefined,
-          step1.response.messages.length,
-        );
-        expect(res.messages).toHaveLength(2);
-        expect(contentTypes(res.messages[0].message)).toEqual(["tool-call"]);
-        expect(contentTypes(res.messages[1].message)).toEqual(["tool-result"]);
-      });
     });
   });
 

--- a/src/vercel/mapping.ts
+++ b/src/vercel/mapping.ts
@@ -39,6 +39,7 @@ import {
   type MessageDoc,
   vToolApprovalRequest,
   vToolApprovalResponse,
+  vProviderReference,
 } from "../validators.js";
 import type { ActionCtx, AgentComponent } from "./client/types.js";
 import type { MutationCtx } from "./client/types.js";
@@ -46,8 +47,12 @@ import { MAX_FILE_SIZE, storeFile } from "./client/files.js";
 import type { Infer } from "convex/values";
 import {
   convertUint8ArrayToBase64,
+  type FileData,
   type ProviderOptions,
+  type ProviderReference,
+  type ReasoningFilePart,
   type ReasoningPart,
+  type ToolResultOutput,
 } from "@ai-sdk/provider-utils";
 import { parse, validate } from "convex-helpers/validators";
 import {
@@ -234,32 +239,15 @@ export function autoDenyUnresolvedApprovals(
 
 export function serializeUsage(usage: LanguageModelUsage): Usage {
   return {
-    promptTokens: usage.inputTokens ?? 0,
-    completionTokens: usage.outputTokens ?? 0,
-    totalTokens: usage.totalTokens ?? 0,
-    reasoningTokens: usage.reasoningTokens,
-    cachedInputTokens: usage.cachedInputTokens,
-  };
-}
-
-export function toModelMessageUsage(usage: Usage): LanguageModelUsage {
-  return {
-    inputTokens: usage.promptTokens,
-    outputTokens: usage.completionTokens,
+    promptTokens: usage.inputTokens,
+    completionTokens: usage.outputTokens,
     totalTokens: usage.totalTokens,
-    reasoningTokens: usage.reasoningTokens,
-    cachedInputTokens: usage.cachedInputTokens,
-    // These detail fields are required by LanguageModelUsage type but we don't
-    // have the granular data, so we provide empty objects with undefined values.
-    inputTokenDetails: {
-      cacheReadTokens: undefined,
-      cacheWriteTokens: undefined,
-      noCacheTokens: undefined,
-    },
-    outputTokenDetails: {
-      textTokens: undefined,
-      reasoningTokens: undefined,
-    },
+    reasoningTokens: usage.outputTokenDetails?.reasoningTokens,
+    cachedInputTokens: usage.inputTokenDetails?.cacheReadTokens,
+    nonCachedInputTokens: usage.inputTokenDetails?.noCacheTokens,
+    cacheWriteInputTokens: usage.inputTokenDetails?.cacheWriteTokens,
+    textOutputTokens: usage.outputTokenDetails?.textTokens,
+    raw: usage.raw,
   };
 }
 
@@ -270,33 +258,24 @@ export function serializeWarnings(
     return undefined;
   }
   return warnings.map((warning) => {
-    if (warning.type === "compatibility") {
-      return {
-        type: "unsupported-setting",
-        setting: warning.feature,
-        details: warning.details,
-      };
+    switch (warning.type) {
+      case "unsupported":
+      case "compatibility":
+        return {
+          type: warning.type,
+          feature: warning.feature,
+          details: warning.details,
+        };
+      case "deprecated":
+        return {
+          type: warning.type,
+          setting: warning.setting,
+          message: warning.message,
+        };
+      case "other":
+        return { type: warning.type, message: warning.message };
     }
-    return warning;
-  }) as any;
-}
-
-export function toModelMessageWarnings(
-  warnings: MessageWithMetadata["warnings"],
-): CallWarning[] | undefined {
-  if (!warnings) {
-    return undefined;
-  }
-  return warnings.map((warning) => {
-    if (warning.type === "unsupported-setting") {
-      return {
-        type: "compatibility",
-        feature: warning.setting,
-        details: warning.details,
-      };
-    }
-    return warning;
-  }) as any;
+  });
 }
 
 /**
@@ -314,42 +293,6 @@ export async function serializeResponseMessages<TOOLS extends ToolSet>(
   return serializeStepMessages(ctx, component, step, model, responseMessages);
 }
 
-/**
- * Serialize the new response messages produced by this step.
- *
- * `step.response.messages` is cumulative across steps in AI SDK v6 — each
- * step's array contains all messages from prior steps too. Pass
- * `previousResponseMessageCount` (the prior step's `response.messages.length`,
- * or `0` for the first step) so we slice only the new tail. The parameter is
- * required: defaulting it would silently duplicate every prior message on
- * every multi-step save.
- */
-export async function serializeNewMessagesInStep<TOOLS extends ToolSet>(
-  ctx: ActionCtx,
-  component: AgentComponent,
-  step: StepResult<TOOLS>,
-  model: ModelOrMetadata | undefined,
-  previousResponseMessageCount: number,
-): Promise<{ messages: MessageWithMetadata[] }> {
-  const newMessages = step.response.messages.slice(
-    previousResponseMessageCount,
-  );
-  // Keep at least one message in the output so the step still anchors an
-  // order slot — downstream `addMessages` relies on each step contributing a
-  // row even when AI SDK produced no response messages.
-  const messagesToSerialize: ModelMessage[] =
-    newMessages.length > 0
-      ? newMessages
-      : [{ role: "assistant" as const, content: [] }];
-  return serializeStepMessages(
-    ctx,
-    component,
-    step,
-    model,
-    messagesToSerialize,
-  );
-}
-
 async function serializeStepMessages<TOOLS extends ToolSet>(
   ctx: ActionCtx,
   component: AgentComponent,
@@ -360,12 +303,15 @@ async function serializeStepMessages<TOOLS extends ToolSet>(
   // If there are tool results, there's another message with the tool results
   // ref: https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/to-response-messages.ts#L120
   const hasToolMessage = step.response.messages.at(-1)?.role === "tool";
+  const resolvedModel = step.model ?? model;
   const assistantFields = {
-    model: model ? getModelName(model) : undefined,
-    provider: model ? getProviderName(model) : undefined,
+    model: resolvedModel ? getModelName(resolvedModel) : undefined,
+    provider: resolvedModel ? getProviderName(resolvedModel) : undefined,
     providerMetadata: step.providerMetadata,
     reasoning: step.reasoningText,
-    reasoningDetails: step.reasoning,
+    reasoningDetails: step.reasoning.filter(
+      (part) => part.type !== "reasoning-file",
+    ),
     usage: serializeUsage(step.usage),
     warnings: serializeWarnings(step.warnings),
     finishReason: step.finishReason,
@@ -457,7 +403,9 @@ export async function serializeContent(
           } satisfies Infer<typeof vTextPart>;
         }
         case "image": {
-          let image = serializeDataOrUrl(part.image);
+          let image =
+            toStoredProviderReference(part.image) ??
+            serializeDataOrUrl(part.image);
           if (
             image instanceof ArrayBuffer &&
             image.byteLength > MAX_FILE_SIZE
@@ -480,7 +428,9 @@ export async function serializeContent(
           } satisfies Infer<typeof vImagePart>;
         }
         case "file": {
-          let data = serializeDataOrUrl(part.data);
+          let data =
+            toStoredProviderReference(part.data) ??
+            serializeDataOrUrl(part.data);
           if (data instanceof ArrayBuffer && data.byteLength > MAX_FILE_SIZE) {
             const { file } = await storeFile(
               ctx,
@@ -516,30 +466,23 @@ export async function serializeContent(
           } satisfies Infer<typeof vToolCallPart>;
         }
         case "tool-result": {
-          return normalizeToolResult(part, metadata);
+          return serializeToolResult(part, metadata);
         }
         case "reasoning": {
           return {
             type: part.type,
             text: part.text,
+            signature:
+              "signature" in part && typeof part.signature === "string"
+                ? part.signature
+                : undefined,
             ...metadata,
           } satisfies Infer<typeof vReasoningPart>;
         }
         case "reasoning-file": {
-          if ("url" in part && part.url !== undefined) {
-            return {
-              type: part.type,
-              url: part.url,
-              mediaType: part.mediaType,
-              ...metadata,
-            } satisfies Infer<typeof vReasoningFilePart>;
-          }
-          if (part.data === undefined) {
-            throw new Error("reasoning-file requires data or url");
-          }
           return {
             type: part.type,
-            data: serializeDataOrUrl(part.data),
+            ...serializeReasoningFile(part),
             mediaType: part.mediaType,
             ...metadata,
           } satisfies Infer<typeof vReasoningFilePart>;
@@ -567,8 +510,7 @@ export async function serializeContent(
             type: part.type,
             approvalId: part.approvalId,
             toolCallId: part.toolCallId,
-            isAutomatic:
-              "isAutomatic" in part ? part.isAutomatic : undefined,
+            isAutomatic: "isAutomatic" in part ? part.isAutomatic : undefined,
             signature: "signature" in part ? part.signature : undefined,
             ...metadata,
           } satisfies Infer<typeof vToolApprovalRequest>;
@@ -618,12 +560,16 @@ export function fromModelMessageContent(content: Content): Message["content"] {
             type: part.type,
             mediaType: getMimeOrMediaType(part),
             ...metadata,
-            image: serializeDataOrUrl(part.image),
+            image:
+              toStoredProviderReference(part.image) ??
+              serializeDataOrUrl(part.image),
           } satisfies Infer<typeof vImagePart>;
         case "file":
           return {
             type: part.type,
-            data: serializeDataOrUrl(part.data),
+            data:
+              toStoredProviderReference(part.data) ??
+              serializeDataOrUrl(part.data),
             filename: part.filename,
             mediaType: getMimeOrMediaType(part)!,
             ...metadata,
@@ -641,18 +587,38 @@ export function fromModelMessageContent(content: Content): Message["content"] {
             ...metadata,
           } satisfies Infer<typeof vToolCallPart>;
         case "tool-result":
-          return normalizeToolResult(part, metadata);
+          return serializeToolResult(part, metadata);
         case "reasoning":
           return {
             type: part.type,
             text: part.text,
+            signature:
+              "signature" in part && typeof part.signature === "string"
+                ? part.signature
+                : undefined,
             ...metadata,
           } satisfies Infer<typeof vReasoningPart>;
+        case "reasoning-file": {
+          return {
+            type: part.type,
+            ...serializeReasoningFile(part),
+            mediaType: part.mediaType,
+            ...metadata,
+          } satisfies Infer<typeof vReasoningFilePart>;
+        }
+        case "custom":
+          return {
+            type: part.type,
+            kind: part.kind,
+            ...metadata,
+          } satisfies Infer<typeof vCustomContentPart>;
         case "tool-approval-request":
           return {
             type: part.type,
             approvalId: part.approvalId,
             toolCallId: part.toolCallId,
+            isAutomatic: "isAutomatic" in part ? part.isAutomatic : undefined,
+            signature: "signature" in part ? part.signature : undefined,
             ...metadata,
           } satisfies Infer<typeof vToolApprovalRequest>;
         case "tool-approval-response":
@@ -700,14 +666,18 @@ export function toModelMessageContent(
         case "image":
           return {
             type: part.type,
-            image: toModelMessageDataOrUrl(part.image),
+            image: (isStoredProviderReference(part.image)
+              ? part.image.reference
+              : toModelMessageDataOrUrl(part.image)) as ImagePart["image"],
             mediaType: getMimeOrMediaType(part),
             ...metadata,
           } satisfies ImagePart;
         case "file":
           return {
             type: part.type,
-            data: toModelMessageDataOrUrl(part.data),
+            data: (isStoredProviderReference(part.data)
+              ? { type: "reference" as const, reference: part.data.reference }
+              : toModelMessageDataOrUrl(part.data)) as FilePart["data"],
             filename: part.filename,
             mediaType: getMimeOrMediaType(part)!,
             ...metadata,
@@ -725,7 +695,7 @@ export function toModelMessageContent(
           } satisfies ToolCallPart;
         }
         case "tool-result": {
-          return normalizeToolResult(part, metadata);
+          return deserializeToolResult(part, metadata);
         }
         case "reasoning":
           return {
@@ -734,8 +704,16 @@ export function toModelMessageContent(
             ...metadata,
           } satisfies ReasoningPart;
         case "reasoning-file":
+          return {
+            type: "reasoning-file",
+            data: deserializeReasoningFile(
+              part as Infer<typeof vReasoningFilePart>,
+            ),
+            mediaType: part.mediaType,
+            ...metadata,
+          } satisfies ReasoningFilePart;
         case "custom":
-          return null;
+          return { type: "custom", kind: part.kind, ...metadata };
         case "redacted-reasoning":
           // Legacy v5 part: round-trip the redacted payload via providerOptions.
           return {
@@ -743,16 +721,14 @@ export function toModelMessageContent(
             text: "",
             ...metadata,
             providerOptions: metadata.providerOptions
-              ? {
-                  ...Object.fromEntries(
-                    Object.entries(metadata.providerOptions ?? {}).map(
-                      ([key, value]) => [
-                        key,
-                        { ...value, redactedData: part.data },
-                      ],
-                    ),
+              ? Object.fromEntries(
+                  Object.entries(metadata.providerOptions ?? {}).map(
+                    ([key, value]) => [
+                      key,
+                      { ...value, redactedData: part.data },
+                    ],
                   ),
-                }
+                )
               : undefined,
           } satisfies ReasoningPart;
         case "source":
@@ -762,6 +738,8 @@ export function toModelMessageContent(
             type: part.type,
             approvalId: part.approvalId,
             toolCallId: part.toolCallId,
+            isAutomatic: "isAutomatic" in part ? part.isAutomatic : undefined,
+            signature: "signature" in part ? part.signature : undefined,
             ...metadata,
           } satisfies Infer<typeof vToolApprovalRequest>;
         case "tool-approval-response":
@@ -790,7 +768,7 @@ export function normalizeToolOutput(
     };
   }
   if (validate(vToolResultOutput, result)) {
-    return result;
+    return result as unknown as ToolResultOutput;
   }
   return {
     type: "json",
@@ -798,26 +776,275 @@ export function normalizeToolOutput(
   };
 }
 
-function normalizeToolResult(
+function serializeToolResult(
   part: ToolResultPart | Infer<typeof vToolResultPart>,
   metadata: {
     providerOptions?: ProviderOptions;
     providerMetadata?: ProviderMetadata;
   },
-): ToolResultPart & Infer<typeof vToolResultPart> {
+): Infer<typeof vToolResultPart> {
   return {
     type: part.type,
-    output: part.output
-      ? validate(vToolResultOutput, part.output)
-        ? (part.output as any)
-        : normalizeToolOutput(JSON.stringify(part.output))
-      : normalizeToolOutput("result" in part ? part.result : undefined),
+    output:
+      "output" in part && part.output !== undefined
+        ? serializeToolResultOutput(part.output)
+        : (normalizeToolOutput(
+            "result" in part ? part.result : undefined,
+          ) as Infer<typeof vToolResultOutput>),
     toolCallId: part.toolCallId,
     toolName: part.toolName,
+    ...("providerExecuted" in part
+      ? { providerExecuted: part.providerExecuted }
+      : {}),
     // Preserve isError flag for error reporting
     ...("isError" in part && part.isError ? { isError: true } : {}),
     ...metadata,
+  } as Infer<typeof vToolResultPart>;
+}
+
+function deserializeToolResult(
+  part: ToolResultPart | Infer<typeof vToolResultPart>,
+  metadata: {
+    providerOptions?: ProviderOptions;
+    providerMetadata?: ProviderMetadata;
+  },
+): ToolResultPart {
+  return {
+    type: part.type,
+    output:
+      "output" in part && part.output !== undefined
+        ? deserializeToolResultOutput(part.output)
+        : normalizeToolOutput("result" in part ? part.result : undefined),
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    ...("isError" in part && part.isError ? { isError: true } : {}),
+    ...metadata,
   } satisfies ToolResultPart;
+}
+
+function serializeToolResultOutput(
+  output: unknown,
+): Infer<typeof vToolResultOutput> {
+  if (output === undefined) {
+    return normalizeToolOutput(undefined) as Infer<typeof vToolResultOutput>;
+  }
+  if (!isRecord(output) || typeof output.type !== "string") {
+    return normalizeToolOutput(output as JSONValue) as Infer<
+      typeof vToolResultOutput
+    >;
+  }
+  if (output.type !== "content") {
+    if (validate(vToolResultOutput, output)) {
+      return output as Infer<typeof vToolResultOutput>;
+    }
+    throw new Error(`Invalid AI SDK 7 tool-result output: ${output.type}`);
+  }
+  if (!Array.isArray(output.value)) {
+    throw new Error("Invalid AI SDK 7 tool-result content output");
+  }
+  const serialized = {
+    ...output,
+    value: output.value.map(serializeToolResultContentPart),
+  };
+  if (!validate(vToolResultOutput, serialized)) {
+    throw new Error("Invalid AI SDK 7 tool-result content part");
+  }
+  return serialized as Infer<typeof vToolResultOutput>;
+}
+
+function serializeToolResultContentPart(part: unknown): unknown {
+  if (!isRecord(part) || typeof part.type !== "string") {
+    throw new Error("Invalid AI SDK 7 tool-result content part");
+  }
+  if (part.type !== "file") return part;
+  if (!isRecord(part.data) || typeof part.data.type !== "string") {
+    throw new Error("Invalid AI SDK 7 tool-result file data");
+  }
+
+  const common = {
+    type: "file" as const,
+    mediaType: part.mediaType,
+    ...(typeof part.filename === "string" ? { filename: part.filename } : {}),
+    ...(isRecord(part.providerOptions)
+      ? { providerOptions: part.providerOptions }
+      : {}),
+  };
+  switch (part.data.type) {
+    case "data":
+      return {
+        ...common,
+        data: {
+          type: "data" as const,
+          data: serializeDataOrUrl(part.data.data as DataContent),
+        },
+      };
+    case "url": {
+      const { url } = part.data;
+      if (typeof url !== "string" && !(url instanceof URL)) {
+        throw new Error("Invalid AI SDK 7 tool-result file URL");
+      }
+      return { ...common, data: { type: "url" as const, url: url.toString() } };
+    }
+    case "text":
+      if (typeof part.data.text !== "string") {
+        throw new Error("Invalid AI SDK 7 tool-result file text");
+      }
+      return {
+        ...common,
+        data: { type: "text" as const, text: part.data.text },
+      };
+    case "reference":
+      if (!isProviderReference(part.data.reference)) {
+        throw new Error("Invalid AI SDK 7 tool-result file reference");
+      }
+      return {
+        ...common,
+        data: { type: "reference" as const, reference: part.data.reference },
+      };
+    default:
+      throw new Error(
+        `Invalid AI SDK 7 tool-result file data: ${part.data.type}`,
+      );
+  }
+}
+
+function deserializeToolResultOutput(output: unknown): ToolResultOutput {
+  if (!validate(vToolResultOutput, output)) {
+    return normalizeToolOutput(output as JSONValue);
+  }
+  const stored = output as Infer<typeof vToolResultOutput>;
+  if (stored.type !== "content") return stored as unknown as ToolResultOutput;
+  return {
+    type: "content",
+    value: stored.value.map(deserializeToolResultContentPart),
+  } as ToolResultOutput;
+}
+
+function deserializeToolResultContentPart(
+  part: Extract<
+    Infer<typeof vToolResultOutput>,
+    { type: "content" }
+  >["value"][number],
+) {
+  if (part.type === "file") {
+    return {
+      ...part,
+      data:
+        part.data.type === "url"
+          ? { type: "url" as const, url: new URL(part.data.url) }
+          : part.data,
+    };
+  }
+  switch (part.type) {
+    case "media":
+      return {
+        type: "file" as const,
+        data: { type: "data" as const, data: part.data },
+        mediaType: part.mediaType,
+      };
+    case "file-data":
+      return {
+        type: "file" as const,
+        data: { type: "data" as const, data: part.data },
+        mediaType: part.mediaType,
+        ...(part.filename !== undefined ? { filename: part.filename } : {}),
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    case "file-url":
+      return {
+        type: "file" as const,
+        data: { type: "url" as const, url: new URL(part.url) },
+        mediaType: part.mediaType ?? "application/octet-stream",
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    case "file-id":
+    case "image-file-id":
+      if (typeof part.fileId === "string") return part;
+      return {
+        type: "file" as const,
+        data: {
+          type: "reference" as const,
+          reference: part.fileId,
+        },
+        mediaType:
+          part.type === "image-file-id" ? "image" : "application/octet-stream",
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    case "file-reference":
+    case "image-file-reference":
+      return {
+        type: "file" as const,
+        data: { type: "reference" as const, reference: part.providerReference },
+        mediaType:
+          part.type === "image-file-reference"
+            ? "image"
+            : "application/octet-stream",
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    case "image-data":
+      return {
+        type: "file" as const,
+        data: { type: "data" as const, data: part.data },
+        mediaType: part.mediaType,
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    case "image-url":
+      return {
+        type: "file" as const,
+        data: { type: "url" as const, url: new URL(part.url) },
+        mediaType: "image",
+        ...(part.providerOptions !== undefined
+          ? { providerOptions: part.providerOptions }
+          : {}),
+      };
+    default:
+      return part;
+  }
+}
+
+function serializeReasoningFile(
+  part: ReasoningFilePart | Infer<typeof vReasoningFilePart>,
+): Pick<Infer<typeof vReasoningFilePart>, "url" | "data"> {
+  if ("url" in part && part.url !== undefined) {
+    return { url: part.url.toString() };
+  }
+  if (!("data" in part) || part.data === undefined) {
+    throw new Error("reasoning-file requires data or url");
+  }
+  const { data } = part;
+  if (data instanceof URL) return { url: data.toString() };
+  if (isRecord(data) && data.type === "url" && data.url instanceof URL) {
+    return { url: data.url.toString() };
+  }
+  if (isRecord(data) && data.type === "data") {
+    return { data: serializeDataOrUrl(data.data as DataContent) };
+  }
+  if (isRecord(data) && "type" in data) {
+    throw new Error("Invalid AI SDK 7 reasoning-file data");
+  }
+  return { data: serializeDataOrUrl(data) };
+}
+
+function deserializeReasoningFile(
+  part: Infer<typeof vReasoningFilePart>,
+): Extract<ReasoningFilePart["data"], { type: string }> {
+  if (part.url !== undefined) {
+    return { type: "url", url: new URL(part.url) };
+  }
+  if (part.data !== undefined) {
+    return { type: "data", data: part.data };
+  }
+  throw new Error("reasoning-file requires data or url");
 }
 
 /**
@@ -893,7 +1120,7 @@ export function guessMimeType(buf: ArrayBuffer | string): string {
  * @returns The serialized data as an ArrayBuffer or the URL as a string.
  */
 export function serializeDataOrUrl(
-  dataOrUrl: DataContent | URL,
+  dataOrUrl: DataContent | URL | ProviderReference | FileData,
 ): ArrayBuffer | string {
   if (typeof dataOrUrl === "string") {
     return dataOrUrl;
@@ -904,6 +1131,23 @@ export function serializeDataOrUrl(
   if (dataOrUrl instanceof URL) {
     return dataOrUrl.toString();
   }
+  if ("type" in dataOrUrl) {
+    switch (dataOrUrl.type) {
+      case "data":
+        return serializeDataOrUrl(dataOrUrl.data);
+      case "url":
+        return dataOrUrl.url.toString();
+      case "text":
+        return convertUint8ArrayToBase64(
+          new TextEncoder().encode(dataOrUrl.text),
+        );
+      case "reference":
+        throw new Error("Provider references must be stored as references");
+    }
+  }
+  if (!(dataOrUrl instanceof Uint8Array)) {
+    throw new Error("Unsupported provider reference");
+  }
   return dataOrUrl.buffer.slice(
     dataOrUrl.byteOffset,
     dataOrUrl.byteOffset + dataOrUrl.byteLength,
@@ -911,8 +1155,14 @@ export function serializeDataOrUrl(
 }
 
 export function toModelMessageDataOrUrl(
-  urlOrString: string | ArrayBuffer | URL | DataContent,
-): URL | DataContent {
+  urlOrString:
+    | string
+    | ArrayBuffer
+    | URL
+    | DataContent
+    | ProviderReference
+    | FileData,
+): URL | DataContent | ProviderReference | FileData {
   if (urlOrString instanceof URL) {
     return urlOrString;
   }
@@ -928,19 +1178,107 @@ export function toModelMessageDataOrUrl(
   return urlOrString;
 }
 
+type StoredProviderReference = Infer<typeof vProviderReference>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isProviderReference(value: unknown): value is ProviderReference {
+  return (
+    isRecord(value) &&
+    !(value instanceof ArrayBuffer) &&
+    !(value instanceof Uint8Array) &&
+    !(value instanceof URL) &&
+    !("type" in value) &&
+    Object.values(value).every((id) => typeof id === "string")
+  );
+}
+
+function isStoredProviderReference(
+  value: unknown,
+): value is StoredProviderReference {
+  return (
+    isRecord(value) &&
+    value.type === "reference" &&
+    isProviderReference(value.reference)
+  );
+}
+
+function toStoredProviderReference(
+  value: unknown,
+): StoredProviderReference | undefined {
+  if (isStoredProviderReference(value)) return value;
+  if (isProviderReference(value))
+    return { type: "reference", reference: value };
+  if (
+    isRecord(value) &&
+    value.type === "reference" &&
+    isProviderReference(value.reference)
+  ) {
+    return { type: "reference", reference: value.reference };
+  }
+  return undefined;
+}
+
+function isFileReference(
+  value: unknown,
+): value is { type: "reference"; reference: ProviderReference } {
+  return (
+    isRecord(value) &&
+    value.type === "reference" &&
+    isProviderReference(value.reference)
+  );
+}
+
 export function toUIFilePart(part: ImagePart | FilePart): FileUIPart {
   const dataOrUrl = part.type === "image" ? part.image : part.data;
-  const url =
-    dataOrUrl instanceof ArrayBuffer
-      ? convertUint8ArrayToBase64(new Uint8Array(dataOrUrl))
-      : dataOrUrl.toString();
+  const providerReference = isProviderReference(dataOrUrl)
+    ? dataOrUrl
+    : isFileReference(dataOrUrl)
+      ? dataOrUrl.reference
+      : undefined;
+  const url = providerReference
+    ? ""
+    : toUIFileUrl(dataOrUrl, part.mediaType ?? "application/octet-stream");
 
   return {
     type: "file",
     mediaType: part.mediaType!,
     filename: part.type === "file" ? part.filename : undefined,
     url,
+    ...(providerReference !== undefined ? { providerReference } : {}),
     providerMetadata: part.providerOptions,
   };
 }
 
+function toUIFileUrl(data: unknown, mediaType: string): string {
+  if (isFileReference(data)) return "";
+  if (isRecord(data) && typeof data.type === "string") {
+    switch (data.type) {
+      case "url":
+        return (data.url as URL).toString();
+      case "data":
+        return toUIFileDataUrl(data.data as DataContent, mediaType);
+      case "text":
+        return toUIFileDataUrl(
+          new TextEncoder().encode(data.text as string),
+          mediaType,
+        );
+    }
+  }
+  if (data instanceof URL) return data.toString();
+  if (typeof data === "string") return data;
+  return toUIFileDataUrl(data as DataContent, mediaType);
+}
+
+function toUIFileDataUrl(data: DataContent, mediaType: string): string {
+  if (typeof data === "string") {
+    return data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+  }
+  const bytes =
+    data instanceof ArrayBuffer
+      ? new Uint8Array(data)
+      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return `data:${mediaType};base64,${convertUint8ArrayToBase64(bytes)}`;
+}

--- a/src/vercel/react/useStreamingUIMessages.ts
+++ b/src/vercel/react/useStreamingUIMessages.ts
@@ -13,7 +13,7 @@ import {
 } from "../deltas.js";
 import { useDeltaStreams } from "./useDeltaStreams.js";
 
-// Polyfill structuredClone to support readUIMessageStream on ReactNative
+// Polyfill structuredClone to support incremental UI-message reduction on React Native.
 if (!("structuredClone" in globalThis)) {
   void import("@ungap/structured-clone" as any).then(
     ({ default: structuredClone }) =>
@@ -23,7 +23,7 @@ if (!("structuredClone" in globalThis)) {
 
 /**
  * A hook that fetches streaming messages from a thread and converts them to UIMessages
- * using AI SDK's readUIMessageStream.
+ * using the adapter's incremental UI-message reducer.
  * This ONLY returns streaming UIMessages. To get both full and streaming messages,
  * use `useUIMessages`.
  *

--- a/src/vercel/toUIMessages.test.ts
+++ b/src/vercel/toUIMessages.test.ts
@@ -56,6 +56,43 @@ describe("toUIMessages", () => {
     });
   });
 
+  it("projects finalized reasoning-file and custom parts", () => {
+    const messages = [
+      baseMessageDoc({
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning-file",
+              url: "https://example.com/reasoning.pdf",
+              mediaType: "application/pdf",
+              providerOptions: { openai: { file: "reasoning" } },
+            },
+            {
+              type: "custom",
+              kind: "openai.annotation",
+              providerOptions: { openai: { annotation: "kept" } },
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(toUIMessages(messages)[0].parts).toEqual([
+      {
+        type: "reasoning-file",
+        url: "https://example.com/reasoning.pdf",
+        mediaType: "application/pdf",
+        providerMetadata: { openai: { file: "reasoning" } },
+      },
+      {
+        type: "custom",
+        kind: "openai.annotation",
+        providerMetadata: { openai: { annotation: "kept" } },
+      },
+    ]);
+  });
+
   it("handles multiple messages", () => {
     const messages = [
       baseMessageDoc({
@@ -993,6 +1030,8 @@ describe("toUIMessages", () => {
                 type: "tool-approval-request",
                 approvalId: "approval1",
                 toolCallId: "call1",
+                isAutomatic: true,
+                signature: "signed-request",
               },
             ],
           },
@@ -1007,7 +1046,11 @@ describe("toUIMessages", () => {
       ) as any;
       expect(toolPart).toBeDefined();
       expect(toolPart.state).toBe("approval-requested");
-      expect(toolPart.approval).toEqual({ id: "approval1" });
+      expect(toolPart.approval).toEqual({
+        id: "approval1",
+        isAutomatic: true,
+        signature: "signed-request",
+      });
     });
 
     it("sets state to approval-responded when tool-approval-response with approved: true", () => {
@@ -1031,6 +1074,8 @@ describe("toUIMessages", () => {
                 type: "tool-approval-request",
                 approvalId: "approval1",
                 toolCallId: "call1",
+                isAutomatic: true,
+                signature: "signed-request",
               },
             ],
           },
@@ -1066,6 +1111,8 @@ describe("toUIMessages", () => {
         id: "approval1",
         approved: true,
         reason: "User confirmed",
+        isAutomatic: true,
+        signature: "signed-request",
       });
     });
 


### PR DESCRIPTION
## Summary

- Upgrade the Vercel adapter and examples to AI SDK 7 across prompts, callbacks, usage, tools, approvals, runtime context, provider models, and registry model IDs.
- Write AI SDK 7 chunks through the single persisted `UIMessageChunk` reducer/projector introduced by #305.
- Preserve existing saved message and stream data without retaining an AI SDK 6 runtime.
- Make stream cancellation terminal and race-safe for pre-aborted signals, in-flight stream creation, failed delta writes, and overlapping cleanup.
- Add the AI SDK 7 migration guide and 0.7.0 release notes.

## Release boundary

With #304–#306 merged, Agent is ready for the AI SDK 7 runtime release. A dedicated release commit will bump the package and lockfile from 0.6.4 to 0.7.0.

This release does not yet offload every oversized inline file encoding. Reasoning files, nested tool-result files, and tagged/base64/data-URL payloads will gain durable persistence in #307.

## Dependency status

This PR pins `@convex-dev/rag@0.8.0-alpha.0`, whose published peer dependency is `ai@^7.0.0`. The lockfile contains one AI SDK 7 dependency graph and no nested AI SDK 6 runtime.

## Validation

- Typecheck
- Lint
- Build
- 29 test files / 327 tests
- Two independent final reviews: clean

## Stack

1. #304 — isolate the provider adapter behind a neutral stream codec
2. #305 — extend the codec for the AI SDK 7 chunk superset
3. **#306 — migrate the runtime to AI SDK 7**
4. #307 — add durable persistence for oversized inline files