### PR TITLE
feat(persistence): persist oversized AI SDK 7 streamed files

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -127,7 +127,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       useExistingFile: FunctionReference<
         "mutation",
         "internal",
-        { filename?: string; hash: string },
+        { filename?: string; hash: string; mediaType?: string },
         null | { fileId: string; storageId: string },
         Name
       >;
@@ -5522,7 +5522,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       addDelta: FunctionReference<
         "mutation",
         "internal",
-        { end: number; parts: Array<any>; start: number; streamId: string },
+        {
+          end: number;
+          fileRefs?: Array<{ fileId: string; url: string }>;
+          parts: Array<any>;
+          start: number;
+          streamId: string;
+        },
         boolean,
         Name
       >;

--- a/src/component/files.test.ts
+++ b/src/component/files.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
 import schema from "./schema.js";
 import { modules } from "./setup.test.js";
@@ -9,7 +9,8 @@ import type { Doc } from "./_generated/dataModel.js";
 import type { PaginationResult } from "convex/server";
 
 describe("files", () => {
-  test("addFile increments refcount and does not create a new entry", async () => {
+  afterEach(() => vi.useRealTimers());
+  test("addFile registers and reuses a file without acquiring ownership", async () => {
     const t = convexTest(schema, modules);
     const storageId = "storage-1";
     const hash = "hash-1";
@@ -34,6 +35,9 @@ describe("files", () => {
       mimeType: "text/plain",
     });
     expect(fileId2).toBe(fileId);
+    await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      refcount: 0,
+    });
     // Add the same file with a different filename (should create a new entry)
     const { fileId: fileId3 } = await t.mutation(api.files.addFile, {
       storageId,
@@ -83,7 +87,31 @@ describe("files", () => {
     expect(fileId4).toBeNull();
   });
 
+  test("reuses a legacy file row with no media type", async () => {
+    const t = convexTest(schema, modules);
+    const fileId = await t.run((ctx) =>
+      ctx.db.insert("files", {
+        storageId: "legacy-storage",
+        hash: "legacy-hash",
+        filename: "legacy.txt",
+        refcount: 0,
+        lastTouchedAt: Date.now(),
+      }),
+    );
+
+    await expect(
+      t.mutation(api.files.addFile, {
+        storageId: "new-storage",
+        hash: "legacy-hash",
+        filename: "legacy.txt",
+        mediaType: "text/plain",
+      }),
+    ).resolves.toEqual({ fileId, storageId: "legacy-storage" });
+  });
+
   test("getFilesToDelete paginates through files with refcount 0 one at a time", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     const t = convexTest(schema, modules);
     // Add 3 files with refcount 0
     const files = [];
@@ -94,12 +122,9 @@ describe("files", () => {
         filename: `file-del-${i}.txt`,
         mimeType: "text/plain",
       });
-      // Manually set refcount to 0
-      await t.run(async (ctx) => {
-        await ctx.db.patch("files", fileId, { refcount: 0 });
-      });
       files.push(fileId);
     }
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
     // Paginate through files to delete one at a time
     let cursor: string | null = null;
     const seen: string[] = [];
@@ -126,5 +151,55 @@ describe("files", () => {
     expect(isDone).toBe(true);
     // All fileIds should be seen
     expect(seen.sort()).toEqual(files.sort());
+  });
+
+  test("does not expose or delete freshly registered files", async () => {
+    const t = convexTest(schema, modules);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { fileId } = await t.mutation(api.files.addFile, {
+      storageId: "storage-fresh",
+      hash: "hash-fresh",
+      filename: "fresh.txt",
+      mimeType: "text/plain",
+    });
+
+    await expect(
+      t.query(api.files.getFilesToDelete, {
+        paginationOpts: { numItems: 10, cursor: null },
+      }),
+    ).resolves.toMatchObject({ page: [] });
+    await expect(
+      t.mutation(api.files.deleteFiles, { fileIds: [fileId] }),
+    ).resolves.toEqual([]);
+    await expect(t.query(api.files.get, { fileId })).resolves.not.toBeNull();
+    error.mockRestore();
+  });
+
+  test("refreshes a cache hit before the cleanup grace period expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const t = convexTest(schema, modules);
+    const { fileId } = await t.mutation(api.files.addFile, {
+      storageId: "storage-cache-hit",
+      hash: "cache-hit-hash",
+      filename: "cache-hit.txt",
+      mediaType: "text/plain",
+    });
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 - 60 * 1000);
+    await expect(
+      t.mutation(api.files.useExistingFile, {
+        hash: "cache-hit-hash",
+        filename: "cache-hit.txt",
+        mediaType: "text/plain",
+      }),
+    ).resolves.toMatchObject({ fileId });
+
+    vi.advanceTimersByTime(60 * 1000);
+    await expect(
+      t.query(api.files.getFilesToDelete, {
+        paginationOpts: { numItems: 10, cursor: null },
+      }),
+    ).resolves.toMatchObject({ page: [] });
   });
 });

--- a/src/component/files.ts
+++ b/src/component/files.ts
@@ -1,9 +1,11 @@
 import { paginator } from "convex-helpers/server/pagination";
-import type { Id } from "./_generated/dataModel.js";
+import type { Doc, Id } from "./_generated/dataModel.js";
 import { mutation, type MutationCtx, query } from "./_generated/server.js";
 import { schema, v } from "./schema.js";
 import { paginationOptsValidator } from "convex/server";
 import type { Infer } from "convex/values";
+
+const FILE_CLEANUP_GRACE_MS = 24 * 60 * 60 * 1000;
 
 const addFileArgs = v.object({
   storageId: v.string(),
@@ -28,18 +30,21 @@ export async function addFileHandler(
   args: Infer<typeof addFileArgs>,
 ) {
   // Support both mediaType (preferred) and mimeType (deprecated)
-  const mediaType = args.mediaType ?? args.mimeType;
+  const mediaType = normalizeMediaType(args.mediaType ?? args.mimeType);
 
-  const existingFile = await ctx.db
+  const existingFiles = await ctx.db
     .query("files")
     .withIndex("hash", (q) => q.eq("hash", args.hash))
     // eslint-disable-next-line @convex-dev/no-filter-in-query -- We do not expect many files with the same hash and different filenames
     .filter((q) => q.eq(q.field("filename"), args.filename))
-    .first();
+    .collect();
+  const existingFile = existingFiles.find((file) =>
+    sameMediaType(file, mediaType),
+  );
   if (existingFile) {
-    // increment the refcount
+    // Registration is not ownership. Persisted messages and in-flight streams
+    // acquire ownership explicitly.
     await ctx.db.patch("files", existingFile._id, {
-      refcount: existingFile.refcount + 1,
       lastTouchedAt: Date.now(),
     });
     return {
@@ -83,14 +88,18 @@ export const useExistingFile = mutation({
   args: {
     hash: v.string(),
     filename: v.optional(v.string()),
+    mediaType: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const file = await ctx.db
+    const files = await ctx.db
       .query("files")
       .withIndex("hash", (q) => q.eq("hash", args.hash))
       // eslint-disable-next-line @convex-dev/no-filter-in-query -- We do not expect many files with the same hash and different filenames
       .filter((q) => q.eq(q.field("filename"), args.filename))
-      .first();
+      .collect();
+    const file = files.find((candidate) =>
+      sameMediaType(candidate, normalizeMediaType(args.mediaType)),
+    );
     if (!file) {
       return null;
     }
@@ -108,36 +117,51 @@ export const useExistingFile = mutation({
   ),
 });
 
+function normalizeMediaType(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function sameMediaType(
+  file: Pick<Doc<"files">, "mediaType" | "mimeType">,
+  expected: string | undefined,
+) {
+  const actual = normalizeMediaType(file.mediaType ?? file.mimeType);
+  // File rows from before media-type tracking have no value to distinguish.
+  // Preserve the prior hash-and-filename reuse behavior for those rows.
+  return expected === undefined || actual === undefined || actual === expected;
+}
+
+/** Transfer ownership between two durable records. */
 export async function changeRefcount(
   ctx: MutationCtx,
-  prev: Id<"files">[],
+  previous: Id<"files">[],
   next: Id<"files">[],
 ) {
-  const prevSet = new Set(prev);
+  const previousSet = new Set(previous);
   const nextSet = new Set(next);
-  for (const fileId of prevSet) {
-    if (!nextSet.has(fileId)) {
-      const file = await ctx.db.get("files", fileId);
-      if (file) {
-        await ctx.db.patch("files", fileId, {
-          refcount: file.refcount - 1,
-        });
-      } else {
+  for (const fileId of new Set([...previousSet, ...nextSet])) {
+    const increment = Number(!previousSet.has(fileId) && nextSet.has(fileId));
+    const decrement = Number(previousSet.has(fileId) && !nextSet.has(fileId));
+    if (increment === 0 && decrement === 0) continue;
+    const file = await ctx.db.get("files", fileId);
+    if (!file) {
+      if (increment === 0) {
         console.error(`File ${fileId} not found when decrementing refcount`);
+        continue;
       }
+      throw new Error(`File ${fileId} not found when incrementing refcount`);
     }
-  }
-  for (const fileId of nextSet) {
-    if (!prevSet.has(fileId)) {
-      const file = await ctx.db.get("files", fileId);
-      if (file) {
-        await ctx.db.patch("files", fileId, {
-          refcount: file.refcount + 1,
-        });
-      } else {
-        throw new Error(`File ${fileId} not found when incrementing refcount`);
-      }
+    if (file.refcount < decrement) {
+      throw new Error(
+        `File ${fileId} refcount underflow: ${file.refcount} - ${decrement}`,
+      );
     }
+    const delta = increment - decrement;
+    await ctx.db.patch("files", fileId, {
+      refcount: file.refcount + delta,
+      lastTouchedAt: Date.now(),
+    });
   }
 }
 
@@ -153,22 +177,15 @@ export async function copyFileHandler(
   ctx: MutationCtx,
   args: { fileId: Id<"files"> },
 ) {
-  const file = await ctx.db.get("files", args.fileId);
-  if (!file) {
-    throw new Error("File not found");
-  }
-  await ctx.db.patch("files", args.fileId, {
-    refcount: file.refcount + 1,
-    lastTouchedAt: Date.now(),
-  });
+  await changeRefcount(ctx, [], [args.fileId]);
 }
 
 /**
  * Get files that are unused and can be deleted.
  * This is useful for cleaning up files that are no longer needed.
- * Note: recently added files that have not been saved yet will show up here.
- * You can inspect the `lastTouchedAt` field to see how recently it was used.
- * I'd recommend not deleting anything touched in the last 24 hours.
+ * Files remain protected for 24 hours after registration or their last
+ * ownership change, so a file cannot be removed between registration and the
+ * transaction that saves its message or stream reference.
  */
 export const getFilesToDelete = query({
   args: {
@@ -177,7 +194,11 @@ export const getFilesToDelete = query({
   handler: async (ctx, args) => {
     const files = await paginator(ctx.db, schema)
       .query("files")
-      .withIndex("refcount", (q) => q.eq("refcount", 0))
+      .withIndex("refcount_lastTouchedAt", (q) =>
+        q
+          .eq("refcount", 0)
+          .lte("lastTouchedAt", Date.now() - FILE_CLEANUP_GRACE_MS),
+      )
       .paginate(args.paginationOpts);
     return files;
   },
@@ -209,6 +230,13 @@ export const deleteFiles = mutation({
             );
             return null;
           }
+        }
+        if (
+          !args.force &&
+          file.lastTouchedAt > Date.now() - FILE_CLEANUP_GRACE_MS
+        ) {
+          console.error(`File ${fileId} is still within the cleanup grace period, skipping...`);
+          return null;
         }
         await ctx.db.delete("files", fileId);
         return fileId;

--- a/src/component/messages.test.ts
+++ b/src/component/messages.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
 import { getMaxMessage } from "./messages.js";
+import { timeoutStreamHandler } from "./streams.js";
 import schema from "./schema.js";
 import { initConvexTest, modules } from "./setup.test.js";
 
@@ -923,5 +924,96 @@ describe("agent", () => {
     });
     expect(state.messages[0].embeddingId).toBeUndefined();
     expect(state.embedding).toBeNull();
+  });
+
+  test("transfers recovered file ownership and releases timed-out streams", async () => {
+    const t = initConvexTest();
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "stream-file-recovery",
+    });
+    const { messages } = await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [
+        { message: { role: "assistant", content: [] }, status: "pending" },
+      ],
+    });
+    const pending = messages[0]!;
+    const { fileId: recoveredFileId } = await t.mutation(api.files.addFile, {
+      storageId: "recovered-storage",
+      hash: "recovered-hash",
+      filename: "recovered.txt",
+    });
+    await t.mutation(api.files.copyFile, { fileId: recoveredFileId });
+    const recoveredStreamId = await t.run((ctx) =>
+      ctx.db.insert("streamingMessages", {
+        threadId: thread._id as Id<"threads">,
+        order: pending.order,
+        stepOrder: pending.stepOrder,
+        format: "UIMessageChunk",
+        state: { kind: "aborted", reason: "interrupted" },
+        fileRefs: [
+          { url: "https://files.example/recovered", fileId: recoveredFileId },
+        ],
+      }),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("streamDeltas", {
+        streamId: recoveredStreamId,
+        start: 0,
+        end: 3,
+        parts: [
+          { type: "start" },
+          {
+            type: "file",
+            url: "https://files.example/recovered",
+            mediaType: "text/plain",
+          },
+          { type: "finish" },
+        ],
+      }),
+    );
+    await t.mutation(api.messages.finalizeMessage, {
+      messageId: pending._id as Id<"messages">,
+      result: { status: "success" },
+    });
+    await expect(
+      t.query(api.files.get, { fileId: recoveredFileId }),
+    ).resolves.toMatchObject({
+      refcount: 1,
+    });
+    expect(
+      (await t.run((ctx) => ctx.db.get("streamingMessages", recoveredStreamId)))
+        ?.fileRefs,
+    ).toBeUndefined();
+
+    const { fileId: timedOutFileId } = await t.mutation(api.files.addFile, {
+      storageId: "timeout-storage",
+      hash: "timeout-hash",
+      filename: "timeout.txt",
+    });
+    await t.mutation(api.files.copyFile, { fileId: timedOutFileId });
+    const timedOutStreamId = await t.run((ctx) =>
+      ctx.db.insert("streamingMessages", {
+        threadId: thread._id as Id<"threads">,
+        order: pending.order + 1,
+        stepOrder: 0,
+        format: "UIMessageChunk",
+        state: { kind: "streaming", lastHeartbeat: Date.now() },
+        fileRefs: [
+          { url: "https://files.example/timeout", fileId: timedOutFileId },
+        ],
+      }),
+    );
+    await t.run((ctx) =>
+      timeoutStreamHandler(ctx, { streamId: timedOutStreamId }),
+    );
+    await t.mutation(api.streams.deleteStreamSync, {
+      streamId: timedOutStreamId,
+    });
+    await expect(
+      t.query(api.files.get, { fileId: timedOutFileId }),
+    ).resolves.toMatchObject({
+      refcount: 0,
+    });
   });
 });

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -40,7 +40,11 @@ import {
   vVectorId,
 } from "./vector/tables.js";
 import { changeRefcount } from "./files.js";
-import { getStreamingMessagesWithMetadata, finishHandler } from "./streams.js";
+import {
+  getStreamingMessagesWithMetadata,
+  finishHandler,
+  releaseStreamFileOwnershipByIds,
+} from "./streams.js";
 import { partial } from "convex-helpers/validators";
 
 function publicMessage(message: Doc<"messages">): MessageDoc {
@@ -334,7 +338,10 @@ async function addMessagesHandler(
   // Atomically finish the stream if requested, preventing UI flickering
   // from separate mutations for message save and stream finish (issue #181).
   if (finishStreamId) {
-    await finishHandler(ctx, { streamId: finishStreamId });
+    await finishHandler(ctx, {
+      streamId: finishStreamId,
+    });
+    await releaseStreamFileOwnershipByIds(ctx, [finishStreamId]);
   }
   return { messages: toReturn.map(publicMessage) };
 }
@@ -409,7 +416,7 @@ export const finalizeMessage = mutation({
     }
     // See if we can add any in-progress data
     if (!message.message?.content.length) {
-      const { messages, materializationFailures } =
+      const { messages, materializationFailures, streamsToRelease } =
         await getStreamingMessagesWithMetadata(ctx, message, result);
       if (materializationFailures.length > 0) {
         console.error(
@@ -433,6 +440,7 @@ export const finalizeMessage = mutation({
           userId: message.userId,
           embeddings: undefined,
         });
+        await releaseStreamFileOwnershipByIds(ctx, streamsToRelease);
         return;
       }
     }

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -100,6 +100,15 @@ export const schema = defineSchema({
 
     threadId: v.id("threads"),
     order: v.number(),
+    /** Internal ownership sidecar for files materialized in stream deltas. */
+    fileRefs: v.optional(
+      v.array(
+        v.object({
+          url: v.string(),
+          fileId: v.id("files"),
+        }),
+      ),
+    ),
     /**
      * The step order of the first message in the stream.
      * If the stream ends up with both a tool call and a tool result,
@@ -117,7 +126,11 @@ export const schema = defineSchema({
         endedAt: v.number(),
         cleanupFnId: v.optional(v.id("_scheduled_functions")),
       }),
-      v.object({ kind: v.literal("aborted"), reason: v.string() }),
+      v.object({
+        kind: v.literal("aborted"),
+        reason: v.string(),
+        cleanupFnId: v.optional(v.id("_scheduled_functions")),
+      }),
     ),
   })
     // There should only be one per "order" index
@@ -158,7 +171,8 @@ export const schema = defineSchema({
     lastTouchedAt: v.number(),
   })
     .index("hash", ["hash"])
-    .index("refcount", ["refcount"]),
+    .index("refcount", ["refcount"])
+    .index("refcount_lastTouchedAt", ["refcount", "lastTouchedAt"]),
   ...vectorTables,
   // To authenticate playground usage
   // Delete a key to invalidate it

--- a/src/component/streams.test.ts
+++ b/src/component/streams.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api.js";
+import type { Id } from "./_generated/dataModel.js";
+import { initConvexTest } from "./setup.test.js";
+
+async function seedStream(t: ReturnType<typeof initConvexTest>) {
+  const thread = await t.mutation(api.threads.createThread, {
+    userId: "stream-files",
+  });
+  const threadId = thread._id as Id<"threads">;
+  const streamId = await t.mutation(api.streams.create, {
+    threadId,
+    order: 0,
+    stepOrder: 0,
+    format: "UIMessageChunk",
+  });
+  const { fileId } = await t.mutation(api.files.addFile, {
+    storageId: "stream-storage",
+    hash: "stream-hash",
+    filename: "stream.txt",
+  });
+  return { threadId, streamId, fileId };
+}
+
+describe("streams", () => {
+  test("stream file ownership flows from addDelta to the final message", async () => {
+    const t = initConvexTest();
+    const { threadId, streamId, fileId } = await seedStream(t);
+    const url = "https://files.example/stream";
+
+    await t.mutation(api.streams.addDelta, {
+      streamId,
+      start: 0,
+      end: 1,
+      parts: [{ type: "start" }],
+      fileRefs: [{ url, fileId }],
+    });
+    await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      refcount: 1,
+    });
+
+    // Repeating the same URL/file pair keeps a single reference.
+    await t.mutation(api.streams.addDelta, {
+      streamId,
+      start: 1,
+      end: 2,
+      parts: [{ type: "text-delta", id: "text-1", delta: "hi" }],
+      fileRefs: [{ url, fileId }],
+    });
+    await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      refcount: 1,
+    });
+
+    // A durable file can be referenced by more than one persisted URL.
+    await t.mutation(api.streams.addDelta, {
+      streamId,
+      start: 2,
+      end: 3,
+      parts: [{ type: "text-delta", id: "text-1", delta: "there" }],
+      fileRefs: [{ url: `${url}-alternate`, fileId }],
+    });
+    await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      refcount: 1,
+    });
+
+    const { fileId: otherFileId } = await t.mutation(api.files.addFile, {
+      storageId: "other-storage",
+      hash: "other-hash",
+      filename: "other.txt",
+    });
+    await expect(
+      t.mutation(api.streams.addDelta, {
+        streamId,
+        start: 3,
+        end: 4,
+        parts: [{ type: "finish" }],
+        fileRefs: [{ url, fileId: otherFileId }],
+      }),
+    ).rejects.toThrow("Stream file URL maps to multiple files");
+    await expect(
+      t.query(api.files.get, { fileId: otherFileId }),
+    ).resolves.toMatchObject({ refcount: 0 });
+    expect(
+      (await t.run((ctx) => ctx.db.get("streamingMessages", streamId)))
+        ?.fileRefs,
+    ).toEqual([{ url, fileId }, { url: `${url}-alternate`, fileId }]);
+
+    await t.mutation(api.messages.addMessages, {
+      threadId,
+      messages: [
+        {
+          message: { role: "assistant", content: "done" },
+          fileIds: [fileId],
+        },
+      ],
+      finishStreamId: streamId,
+    });
+    await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      refcount: 1,
+    });
+    const stream = await t.run((ctx) =>
+      ctx.db.get("streamingMessages", streamId),
+    );
+    expect(stream?.state.kind).toBe("finished");
+    expect(stream?.fileRefs).toBeUndefined();
+  });
+});

--- a/src/component/streams.ts
+++ b/src/component/streams.ts
@@ -25,6 +25,7 @@ import {
   getPersistedUIMessageChunkParts,
   projectPersistedUIMessageChunks,
 } from "../streaming/materializePersistedUIMessageChunks.js";
+import { changeRefcount } from "./files.js";
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
@@ -35,9 +36,16 @@ const TIMEOUT_INTERVAL = 10 * MINUTE;
 const DELETE_STREAM_DELAY = MINUTE * 5; // 5 minutes
 
 const deltaValidator = schema.tables.streamDeltas.validator;
+const streamFileRefValidator = v.object({
+  url: v.string(),
+  fileId: v.id("files"),
+});
 
 export const addDelta = mutation({
-  args: deltaValidator,
+  args: {
+    ...deltaValidator.fields,
+    fileRefs: v.optional(v.array(streamFileRefValidator)),
+  },
   returns: v.boolean(),
   handler: async (ctx, args) => {
     const stream = await ctx.db.get("streamingMessages", args.streamId);
@@ -48,7 +56,30 @@ export const addDelta = mutation({
     if (stream.state.kind !== "streaming") {
       return false;
     }
-    await ctx.db.insert("streamDeltas", args);
+    const { fileRefs, ...delta } = args;
+    if (fileRefs?.length) {
+      const previous = stream.fileRefs ?? [];
+      // The persisted chunks refer to files by URL. Several URLs can still
+      // resolve to one durable file, but a URL must resolve to exactly one.
+      const refsByUrl = new Map(previous.map((ref) => [ref.url, ref] as const));
+      for (const ref of fileRefs) {
+        const existing = refsByUrl.get(ref.url);
+        if (existing && existing.fileId !== ref.fileId) {
+          throw new Error(`Stream file URL maps to multiple files: ${ref.url}`);
+        }
+        refsByUrl.set(ref.url, ref);
+      }
+      const next = [...refsByUrl.values()];
+      await changeRefcount(
+        ctx,
+        previous.map(({ fileId }) => fileId),
+        next.map(({ fileId }) => fileId),
+      );
+      await ctx.db.patch("streamingMessages", args.streamId, {
+        fileRefs: next,
+      });
+    }
+    await ctx.db.insert("streamDeltas", delta);
     await heartbeatStream(ctx, { streamId: args.streamId });
     return true;
   },
@@ -89,7 +120,10 @@ export const listDeltas = query({
 });
 
 export const create = mutation({
-  args: omit(schema.tables.streamingMessages.validator.fields, ["state"]),
+  args: omit(schema.tables.streamingMessages.validator.fields, [
+    "state",
+    "fileRefs",
+  ]),
   returns: v.id("streamingMessages"),
   handler: async (ctx, args) => {
     const state = { kind: "streaming" as const, lastHeartbeat: Date.now() };
@@ -212,8 +246,9 @@ async function abortById(
     return false;
   }
   await cleanupTimeoutFn(ctx, stream);
+  const cleanupFnId = await scheduleStreamDeletion(ctx, args.streamId);
   await ctx.db.patch("streamingMessages", args.streamId, {
-    state: { kind: "aborted", reason: args.reason },
+    state: { kind: "aborted", reason: args.reason, cleanupFnId },
   });
   return true;
 }
@@ -264,11 +299,7 @@ export async function finishHandler(
     return;
   }
   await cleanupTimeoutFn(ctx, stream);
-  const cleanupFnId = await ctx.scheduler.runAfter(
-    DELETE_STREAM_DELAY,
-    api.streams.deleteStreamAsync,
-    { streamId: args.streamId },
-  );
+  const cleanupFnId = await scheduleStreamDeletion(ctx, args.streamId);
   await ctx.db.patch("streamingMessages", args.streamId, {
     state: { kind: "finished", endedAt: Date.now(), cleanupFnId },
   });
@@ -281,6 +312,29 @@ export const heartbeat = mutation({
   returns: v.null(),
   handler: heartbeatStream,
 });
+
+async function releaseStreamFileOwnership(
+  ctx: MutationCtx,
+  stream: Doc<"streamingMessages">,
+) {
+  if (!stream.fileRefs?.length) return;
+  await changeRefcount(
+    ctx,
+    stream.fileRefs.map(({ fileId }) => fileId),
+    [],
+  );
+}
+
+async function scheduleStreamDeletion(
+  ctx: MutationCtx,
+  streamId: Id<"streamingMessages">,
+) {
+  return ctx.scheduler.runAfter(
+    DELETE_STREAM_DELAY,
+    api.streams.deleteStreamAsync,
+    { streamId },
+  );
+}
 
 async function heartbeatStream(
   ctx: MutationCtx,
@@ -325,17 +379,23 @@ async function heartbeatStream(
 export const timeoutStream = internalMutation({
   args: { streamId: v.id("streamingMessages") },
   returns: v.null(),
-  handler: async (ctx, args) => {
-    const stream = await ctx.db.get("streamingMessages", args.streamId);
-    if (!stream || stream.state.kind !== "streaming") {
-      console.warn("Stream not found", args.streamId);
-      return;
-    }
-    await ctx.db.patch("streamingMessages", args.streamId, {
-      state: { kind: "aborted", reason: "timeout" },
-    });
-  },
+  handler: timeoutStreamHandler,
 });
+
+export async function timeoutStreamHandler(
+  ctx: MutationCtx,
+  args: { streamId: Id<"streamingMessages"> },
+) {
+  const stream = await ctx.db.get("streamingMessages", args.streamId);
+  if (!stream || stream.state.kind !== "streaming") {
+    console.warn("Stream not found", args.streamId);
+    return;
+  }
+  const cleanupFnId = await scheduleStreamDeletion(ctx, args.streamId);
+  await ctx.db.patch("streamingMessages", args.streamId, {
+    state: { kind: "aborted", reason: "timeout", cleanupFnId },
+  });
+}
 
 async function deletePageForStreamId(
   ctx: MutationCtx,
@@ -354,8 +414,12 @@ async function deletePageForStreamId(
   if (deltas.isDone) {
     const stream = await ctx.db.get("streamingMessages", args.streamId);
     if (stream) {
+      await releaseStreamFileOwnership(ctx, stream);
       await cleanupTimeoutFn(ctx, stream);
-      if (stream.state.kind === "finished" && stream.state.cleanupFnId) {
+      if (
+        (stream.state.kind === "finished" || stream.state.kind === "aborted") &&
+        stream.state.cleanupFnId
+      ) {
         const scheduledFunction = await ctx.db.system.get(
           "_scheduled_functions",
           stream.state.cleanupFnId,
@@ -368,6 +432,18 @@ async function deletePageForStreamId(
     }
   }
   return deltas;
+}
+
+export async function releaseStreamFileOwnershipByIds(
+  ctx: MutationCtx,
+  streamIds: Id<"streamingMessages">[],
+) {
+  for (const streamId of new Set(streamIds)) {
+    const stream = await ctx.db.get("streamingMessages", streamId);
+    if (!stream?.fileRefs?.length) continue;
+    await releaseStreamFileOwnership(ctx, stream);
+    await ctx.db.patch("streamingMessages", streamId, { fileRefs: undefined });
+  }
 }
 
 export async function deleteStreamsPageForThreadId(
@@ -544,6 +620,7 @@ export async function getStreamingMessagesWithMetadata(
     streamId: Id<"streamingMessages">;
     reason: string;
   }>;
+  streamsToRelease: Id<"streamingMessages">[];
 }> {
   // See if there are any streaming messages for this order
   const streamingMessages = await getStreamingMessages(
@@ -570,8 +647,10 @@ export async function getStreamingMessagesWithMetadata(
             streamMessage,
             parts,
             metadata,
+            streamingMessage.fileRefs,
           ).slice(numToSkip),
           failure: undefined,
+          streamToRelease: streamingMessage._id,
         };
       } catch (error) {
         return {
@@ -580,6 +659,7 @@ export async function getStreamingMessagesWithMetadata(
             streamId: streamingMessage._id,
             reason: error instanceof Error ? error.message : String(error),
           },
+          streamToRelease: undefined,
         };
       }
     }),
@@ -588,6 +668,9 @@ export async function getStreamingMessagesWithMetadata(
     messages: materializedStreams.flatMap(({ messages }) => messages),
     materializationFailures: materializedStreams.flatMap(({ failure }) =>
       failure ? [failure] : [],
+    ),
+    streamsToRelease: materializedStreams.flatMap(({ streamToRelease }) =>
+      streamToRelease ? [streamToRelease] : [],
     ),
   };
 }

--- a/src/streaming/materializePersistedUIMessageChunks.test.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.test.ts
@@ -51,6 +51,39 @@ describe("projectPersistedUIMessageChunks", () => {
     expect(validate(vMessageWithMetadataInternal, actual[1])).toBe(true);
   });
 
+  it("attaches materialized canonical tool-result files during recovery", () => {
+    const url = "https://files.example/tool-result";
+    const actual = projectPersistedUIMessageChunks(
+      stream,
+      [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "render",
+          input: {},
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "call-1",
+          output: {
+            type: "content",
+            value: [
+              {
+                type: "file",
+                data: { type: "url", url },
+                mediaType: "application/octet-stream",
+              },
+            ],
+          },
+        },
+      ],
+      { status: "success" },
+      [{ url, fileId: "file-1" }],
+    );
+
+    expect(actual[1]).toMatchObject({ fileIds: ["file-1"] });
+  });
+
   it("keeps persisted sources on the step that produced them", () => {
     const chunks = [
       { type: "start-step" },

--- a/src/streaming/materializePersistedUIMessageChunks.ts
+++ b/src/streaming/materializePersistedUIMessageChunks.ts
@@ -33,6 +33,7 @@ export function projectPersistedUIMessageChunks(
   stream: StreamMessage,
   chunks: readonly unknown[],
   metadata: PersistedStreamMetadata,
+  fileRefs: readonly { url: string; fileId: string }[] = [],
 ): MessageWithMetadataInternal[] {
   if (stream.format !== "UIMessageChunk") {
     throw new Error(
@@ -60,6 +61,7 @@ export function projectPersistedUIMessageChunks(
     reduced.state.parts,
     stream,
     metadata,
+    fileRefs,
   );
 }
 
@@ -91,6 +93,7 @@ export function projectPersistedUIMessageChunkParts(
   parts: PersistedUIMessagePart[],
   stream: StreamMessage,
   metadata: PersistedStreamMetadata,
+  fileRefs: readonly { url: string; fileId: string }[] = [],
 ): MessageWithMetadataInternal[] {
   const blocks: PersistedUIMessagePart[][] = [];
   let block: PersistedUIMessagePart[] = [];
@@ -267,6 +270,7 @@ export function projectPersistedUIMessageChunkParts(
     const hasToolCall =
       message.role === "tool" ||
       content.some((part) => part.type === "tool-call");
+    const fileIds = referencedFileIds(message, fileRefs);
     return {
       message,
       status: metadata.status,
@@ -284,6 +288,9 @@ export function projectPersistedUIMessageChunkParts(
         )
         .map((part) => part.text)
         .join(" "),
+      ...(fileIds.length > 0
+        ? { fileIds: fileIds as MessageWithMetadataInternal["fileIds"] }
+        : {}),
       ...(metadata.error !== undefined ? { error: metadata.error } : {}),
     } satisfies MessageWithMetadataInternal;
   });
@@ -314,6 +321,36 @@ function projectSources(parts: PersistedUIMessagePart[]) {
             filename: part.filename,
           },
     );
+}
+
+function referencedFileIds(
+  message: Message,
+  fileRefs: readonly { url: string; fileId: string }[],
+) {
+  if (typeof message.content === "string") return [];
+  const urls = new Set<string>();
+  for (const part of message.content) {
+    if (part.type === "file") {
+      if (typeof part.data === "string") urls.add(part.data);
+    } else if (part.type === "reasoning-file") {
+      if ("url" in part && part.url) urls.add(part.url);
+    } else if (part.type === "tool-result" && part.output?.type === "content") {
+      for (const outputPart of part.output.value) {
+        if (
+          outputPart.type === "file" &&
+          outputPart.data.type === "url" &&
+          typeof outputPart.data.url === "string"
+        ) {
+          urls.add(outputPart.data.url);
+        }
+      }
+    }
+  }
+  return [
+    ...new Set(
+      fileRefs.filter((ref) => urls.has(ref.url)).map((ref) => ref.fileId),
+    ),
+  ];
 }
 
 function toolResult(

--- a/src/vercel/client/files.test.ts
+++ b/src/vercel/client/files.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, test } from "vitest";
+import { storeFile } from "./files.js";
+
+describe("storeFile", () => {
+  test("throws a clear error when a reused file is missing from storage", async () => {
+    const ctx = {
+      runAction: async () => null,
+      runMutation: async () => ({
+        fileId: "existing-file",
+        storageId: "existing-storage",
+      }),
+      storage: {
+        getUrl: async () => null,
+      },
+    } as unknown as Parameters<typeof storeFile>[0];
+    const component = {
+      files: { useExistingFile: {}, addFile: {} },
+    } as unknown as Parameters<typeof storeFile>[1];
+
+    await expect(storeFile(ctx, component, new Blob(["x"]))).rejects.toThrow(
+      "File not found in storage: existing-storage",
+    );
+  });
+
+  test("cleans its losing blob before an existing URL read fails", async () => {
+    const deleted: string[] = [];
+    let mutationCount = 0;
+    const ctx = {
+      runAction: async () => null,
+      runMutation: async () => {
+        mutationCount++;
+        return mutationCount === 1
+          ? null
+          : { fileId: "existing-file", storageId: "existing-storage" };
+      },
+      storage: {
+        store: async () => "new-storage",
+        getMetadata: async () => null,
+        getUrl: async () => null,
+        delete: async (storageId: string) => {
+          deleted.push(storageId);
+        },
+      },
+    } as unknown as Parameters<typeof storeFile>[0];
+    const component = {
+      files: { useExistingFile: {}, addFile: {} },
+    } as unknown as Parameters<typeof storeFile>[1];
+
+    await expect(storeFile(ctx, component, new Blob(["x"]))).rejects.toThrow(
+      "File not found in storage: existing-storage",
+    );
+    expect(deleted).toEqual(["new-storage"]);
+  });
+});

--- a/src/vercel/client/files.ts
+++ b/src/vercel/client/files.ts
@@ -67,9 +67,13 @@ export async function storeFile(
   const reused = await ctx.runMutation(component.files.useExistingFile, {
     hash,
     filename,
+    mediaType: blob.type || undefined,
   });
   if (reused) {
-    const url = (await ctx.storage.getUrl(reused.storageId))!;
+    const url = await ctx.storage.getUrl(reused.storageId);
+    if (!url) {
+      throw new Error(`File not found in storage: ${reused.storageId}`);
+    }
     return {
       ...getParts(url, blob.type, filename),
       file: {
@@ -82,35 +86,56 @@ export async function storeFile(
     };
   }
   const newStorageId = await ctx.storage.store(blob);
-  if (sha256) {
-    const metadata = await ctx.storage.getMetadata(newStorageId);
-    if (metadata?.sha256 !== sha256) {
-      throw new Error("Hash mismatch: " + metadata?.sha256 + " != " + sha256);
-    }
-  }
-  const { fileId, storageId } = await ctx.runMutation(component.files.addFile, {
-    storageId: newStorageId,
-    hash,
-    filename,
-    mediaType: blob.type,
-  });
-  const url = (await ctx.storage.getUrl(storageId as Id<"_storage">))!;
-  if (storageId !== newStorageId) {
-    // We're re-using another file's storageId
-    // Because we try to reuse the file above, this should be very very rare
-    // and only in the case of racing to check then store the file.
+  let newStorageRegistered = false;
+  let cleanupAttempted = false;
+  const cleanupNewStorage = async () => {
+    if (cleanupAttempted) return;
+    cleanupAttempted = true;
     await ctx.storage.delete(newStorageId);
-  }
-  return {
-    ...getParts(url, blob.type, filename),
-    file: {
-      url,
-      fileId,
-      storageId: storageId as Id<"_storage">,
-      hash,
-      filename,
-    },
   };
+  try {
+    if (sha256) {
+      const metadata = await ctx.storage.getMetadata(newStorageId);
+      if (metadata?.sha256 !== sha256) {
+        throw new Error("Hash mismatch: " + metadata?.sha256 + " != " + sha256);
+      }
+    }
+    const { fileId, storageId } = await ctx.runMutation(
+      component.files.addFile,
+      {
+        storageId: newStorageId,
+        hash,
+        filename,
+        mediaType: blob.type,
+      },
+    );
+    newStorageRegistered = storageId === newStorageId;
+    // A competing request can win after useExistingFile but before addFile.
+    // Delete our losing blob before the existing file's URL is read, so a
+    // failed getUrl cannot leave the raw object orphaned.
+    if (!newStorageRegistered) {
+      await cleanupNewStorage();
+    }
+    const url = await ctx.storage.getUrl(storageId as Id<"_storage">);
+    if (!url) {
+      throw new Error(`File not found in storage: ${storageId}`);
+    }
+    return {
+      ...getParts(url, blob.type, filename),
+      file: {
+        url,
+        fileId,
+        storageId: storageId as Id<"_storage">,
+        hash,
+        filename,
+      },
+    };
+  } catch (error) {
+    if (!newStorageRegistered && !cleanupAttempted) {
+      await cleanupNewStorage().catch(() => {});
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/vercel/client/streamText.ts
+++ b/src/vercel/client/streamText.ts
@@ -25,6 +25,7 @@ import { startGeneration } from "./start.js";
 import type { Agent } from "../index.js";
 import { getModelName, getProviderName } from "../../shared.js";
 import { errorToString, willContinue } from "./utils.js";
+import { materializeUIMessageChunkFiles } from "../fileMaterialization.js";
 
 /** Finish every abort cleanup path before surfacing an internal failure. */
 export async function runAbortCleanup(cleanup: {
@@ -152,6 +153,8 @@ export async function streamText<
                 : undefined,
             onAsyncAbort: call.fail,
             compress: compressUIMessageChunks,
+            materialize: (parts) =>
+              materializeUIMessageChunkFiles(ctx, component, parts),
             abortSignal: args.abortSignal,
           },
           {

--- a/src/vercel/client/streaming.test.ts
+++ b/src/vercel/client/streaming.test.ts
@@ -249,6 +249,49 @@ describe("DeltaStreamer", () => {
     );
   });
 
+  test("waits for signal cleanup when the source throws", async () => {
+    let resolveDelta!: (value: boolean) => void;
+    const deltaWrite = new Promise<boolean>((resolve) => {
+      resolveDelta = resolve;
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce("stream-1")
+      .mockImplementationOnce(() => deltaWrite)
+      .mockResolvedValueOnce(undefined);
+    const abortController = new AbortController();
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      { ...defaultTestOptions, abortSignal: abortController.signal },
+      { ...testMetadata, threadId },
+    );
+    const sourceError = new Error("provider aborted");
+    const source = {
+      async *[Symbol.asyncIterator]() {
+        yield "chunk";
+        abortController.abort();
+        throw sourceError;
+      },
+    } as unknown as Parameters<typeof streamer.consumeStream>[0];
+
+    const consuming = streamer.consumeStream(source);
+    let settled = false;
+    void consuming.catch(() => {
+      settled = true;
+    });
+    await vi.waitFor(() => expect(runMutation).toHaveBeenCalledTimes(2));
+    expect(settled).toBe(false);
+
+    resolveDelta(true);
+    await expect(consuming).rejects.toBe(sourceError);
+    expect(runMutation).toHaveBeenNthCalledWith(
+      3,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "abortSignal" },
+    );
+  });
+
   test("aborts the component stream when a delta write fails", async () => {
     const runMutation = vi
       .fn()
@@ -276,6 +319,34 @@ describe("DeltaStreamer", () => {
       3,
       components.agent.streams.abort,
       { streamId: "stream-1", reason: "delta failed" },
+    );
+  });
+
+  test("aborts the component stream when file materialization fails", async () => {
+    const materializationFailure = new Error("storage failed");
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce("stream-1")
+      .mockResolvedValueOnce(undefined);
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      { runMutation } as unknown as MutationCtx,
+      {
+        ...defaultTestOptions,
+        onAsyncAbort: async () => {},
+        materialize: async () => {
+          throw materializationFailure;
+        },
+      },
+      { ...testMetadata, threadId },
+    );
+
+    await streamer.addParts(["A"]);
+    await expect(streamer.finish()).resolves.toBeUndefined();
+    expect(runMutation).toHaveBeenNthCalledWith(
+      2,
+      components.agent.streams.abort,
+      { streamId: "stream-1", reason: "storage failed" },
     );
   });
 

--- a/src/vercel/client/streaming.ts
+++ b/src/vercel/client/streaming.ts
@@ -204,6 +204,12 @@ export class DeltaStreamer<T> {
     throttleMs: number;
     onAsyncAbort: (reason: string) => Promise<void>;
     compress: ((parts: T[]) => T[]) | null;
+    materialize:
+      | ((parts: T[]) => Promise<{
+          parts: T[];
+          fileRefs: Array<{ url: string; fileId: string }>;
+        }>)
+      | null;
   };
   #nextParts: T[] = [];
   #latestWrite: number = 0;
@@ -223,6 +229,10 @@ export class DeltaStreamer<T> {
       onAsyncAbort: (reason: string) => Promise<void>;
       abortSignal: AbortSignal | undefined;
       compress: ((parts: T[]) => T[]) | null;
+      materialize?: (parts: T[]) => Promise<{
+        parts: T[];
+        fileRefs: Array<{ url: string; fileId: string }>;
+      }>;
     },
     public readonly metadata: {
       threadId: string;
@@ -240,6 +250,7 @@ export class DeltaStreamer<T> {
       throttleMs: config.throttleMs ?? DEFAULT_STREAMING_OPTIONS.throttleMs,
       onAsyncAbort: config.onAsyncAbort,
       compress: config.compress,
+      materialize: config.materialize ?? null,
     };
     this.#nextParts = [];
     this.abortController = new AbortController();
@@ -300,8 +311,18 @@ export class DeltaStreamer<T> {
   }
 
   public async consumeStream(stream: AsyncIterableStream<T>) {
-    for await (const chunk of stream) {
-      await this.addParts([chunk]);
+    try {
+      for await (const chunk of stream) {
+        await this.addParts([chunk]);
+      }
+    } catch (error) {
+      // A provider can throw while responding to an abort. Join the durable
+      // abort transition here, outside the active delta writer, before
+      // preserving the provider error for the caller.
+      await this.#abort(
+        error instanceof Error ? error.message : "stream consumption failed",
+      ).catch(() => {});
+      throw error;
     }
     // Skip finish if it will be handled externally (atomically with message save)
     // or if the stream was aborted (e.g., due to a failed delta write).
@@ -335,21 +356,19 @@ export class DeltaStreamer<T> {
     if (this.abortController.signal.aborted) {
       return;
     }
-    const delta = this.#createDelta();
-    if (!delta) {
-      return;
-    }
-    this.#latestWrite = Date.now();
     let success: boolean;
     try {
+      const delta = await this.#createDelta();
+      if (!delta) {
+        return;
+      }
+      this.#latestWrite = Date.now();
       success = await this.ctx.runMutation(
         this.component.streams.addDelta,
         delta,
       );
     } catch (e) {
-      await this.#abortDelta(
-        e instanceof Error ? e.message : "unknown error",
-      );
+      await this.#abortDelta(e instanceof Error ? e.message : "unknown error");
       return;
     }
     if (!success) {
@@ -375,21 +394,36 @@ export class DeltaStreamer<T> {
     }
   }
 
-  #createDelta(): StreamDelta | undefined {
+  async #createDelta(): Promise<
+    | (StreamDelta & { fileRefs?: Array<{ url: string; fileId: string }> })
+    | undefined
+  > {
     if (this.#nextParts.length === 0) {
       return undefined;
     }
     const start = this.#cursor;
-    const end = start + this.#nextParts.length;
+    const pendingParts = this.#nextParts;
+    const end = start + pendingParts.length;
     this.#cursor = end;
-    const parts = this.config.compress
-      ? this.config.compress(this.#nextParts)
-      : this.#nextParts;
     this.#nextParts = [];
+    const materialized = this.config.materialize
+      ? await this.config.materialize(pendingParts)
+      : { parts: pendingParts, fileRefs: [] };
+    const parts = this.config.compress
+      ? this.config.compress(materialized.parts)
+      : materialized.parts;
     if (!this.streamId) {
       throw new Error("Creating a delta before the stream is created");
     }
-    return { streamId: this.streamId, start, end, parts };
+    return {
+      streamId: this.streamId,
+      start,
+      end,
+      parts,
+      ...(materialized.fileRefs.length > 0
+        ? { fileRefs: materialized.fileRefs }
+        : {}),
+    };
   }
 
   public async finish() {

--- a/src/vercel/fileMaterialization.ts
+++ b/src/vercel/fileMaterialization.ts
@@ -1,0 +1,174 @@
+import type { UIMessageChunk } from "ai";
+import { MAX_FILE_SIZE, storeFile } from "./client/files.js";
+import type { ActionCtx, AgentComponent, MutationCtx } from "./client/types.js";
+
+export type MaterializedFileRef = { url: string; fileId: string };
+
+/**
+ * Replaces oversized inline files in persisted UI chunks with storage URLs.
+ * Recovery uses the accompanying URL-to-file ownership references to attach
+ * the stored files to the durable messages it creates.
+ */
+export async function materializeUIMessageChunkFiles(
+  ctx: ActionCtx,
+  component: AgentComponent,
+  parts: readonly UIMessageChunk[],
+): Promise<{ parts: UIMessageChunk[]; fileRefs: MaterializedFileRef[] }> {
+  const fileRefs: MaterializedFileRef[] = [];
+  const materialized = await Promise.all(
+    parts.map(async (part): Promise<UIMessageChunk> => {
+      if (part.type === "tool-output-available") {
+        const result = await materializeCanonicalToolResultContentFiles(
+          ctx,
+          component,
+          part.output,
+        );
+        fileRefs.push(...result.fileRefs);
+        return { ...part, output: result.output };
+      }
+      if (part.type !== "file" && part.type !== "reasoning-file") {
+        return { ...part };
+      }
+      const file = await materializeInlineFile(
+        ctx,
+        component,
+        part.url,
+        part.mediaType,
+      );
+      if (!file) {
+        return { ...part };
+      }
+      fileRefs.push({ url: file.url, fileId: file.fileId });
+      return { ...part, url: file.url };
+    }),
+  );
+  return { parts: materialized, fileRefs };
+}
+
+/**
+ * Materializes files in the AI SDK's canonical tool-result content output.
+ * Other tool outputs are application-defined and intentionally remain opaque.
+ */
+export async function materializeCanonicalToolResultContentFiles(
+  ctx: ActionCtx | MutationCtx,
+  component: AgentComponent,
+  output: unknown,
+): Promise<{ output: unknown; fileRefs: MaterializedFileRef[] }> {
+  if (!isCanonicalToolResultContent(output)) {
+    return { output, fileRefs: [] };
+  }
+  const fileRefs: MaterializedFileRef[] = [];
+  const value = await Promise.all(
+    output.value.map(async (part): Promise<unknown> => {
+      if (!isCanonicalToolResultFile(part)) return part;
+      const file = await materializeInlineFile(
+        ctx,
+        component,
+        part.data.type === "url"
+          ? part.data.url
+          : part.data.type === "data"
+            ? part.data.data
+            : new TextEncoder().encode(part.data.text),
+        part.mediaType,
+        part.filename,
+      );
+      if (!file) return part;
+      fileRefs.push({ url: file.url, fileId: file.fileId });
+      return {
+        ...part,
+        data: { type: "url", url: file.url },
+      };
+    }),
+  );
+  return { output: { ...output, value }, fileRefs };
+}
+
+async function materializeInlineFile(
+  ctx: ActionCtx | MutationCtx,
+  component: AgentComponent,
+  data: unknown,
+  mediaType: string,
+  filename?: string,
+) {
+  const bytes = decodeInlineFileData(data);
+  if (!bytes) return undefined;
+  if (bytes.byteLength <= MAX_FILE_SIZE) return undefined;
+  const blobBytes = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  const { file } = await storeFile(
+    ctx,
+    component,
+    new Blob([blobBytes], {
+      type: mediaType || "application/octet-stream",
+    }),
+    filename ? { filename } : {},
+  );
+  return file;
+}
+
+function isCanonicalToolResultContent(
+  value: unknown,
+): value is { type: "content"; value: unknown[] } {
+  return (
+    isRecord(value) && value.type === "content" && Array.isArray(value.value)
+  );
+}
+
+function isCanonicalToolResultFile(value: unknown): value is {
+  type: "file";
+  data:
+    | { type: "url"; url: string }
+    | { type: "data"; data: unknown }
+    | { type: "text"; text: string };
+  mediaType: string;
+  filename?: string;
+} {
+  return (
+    isRecord(value) &&
+    value.type === "file" &&
+    typeof value.mediaType === "string" &&
+    isRecord(value.data) &&
+    ((value.data.type === "url" && typeof value.data.url === "string") ||
+      value.data.type === "data" ||
+      (value.data.type === "text" && typeof value.data.text === "string"))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeInlineFileData(value: unknown): Uint8Array | undefined {
+  if (typeof value === "string") {
+    if (!value.startsWith("data:")) {
+      // Remote and already-stored files are references, not inline payloads.
+      if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return undefined;
+      return decodeBase64(value);
+    }
+    const separator = value.indexOf(",");
+    if (separator === -1) return undefined;
+    const metadata = value.slice(5, separator);
+    const payload = value.slice(separator + 1);
+    try {
+      return metadata.includes(";base64")
+        ? decodeBase64(payload)
+        : new TextEncoder().encode(decodeURIComponent(payload));
+    } catch {
+      return undefined;
+    }
+  }
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return undefined;
+}
+
+function decodeBase64(value: string): Uint8Array | undefined {
+  try {
+    const binary = atob(value);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/vercel/mapping.test.ts
+++ b/src/vercel/mapping.test.ts
@@ -465,6 +465,123 @@ describe("mapping", () => {
     );
   });
 
+  test("materializes oversized canonical tool-result files", async () => {
+    const bytes = new Uint8Array(1024 * 65).fill(1);
+    const ctx = {
+      runAction: async () => undefined,
+      runMutation: async () => ({
+        fileId: "file-123",
+        storageId: "storage-123",
+      }),
+      storage: {
+        getUrl: async () => "https://example.com/file",
+      },
+    } as unknown as ActionCtx;
+    const result = {
+      type: "tool-result" as const,
+      toolCallId: "call-1",
+      toolName: "render",
+      output: {
+        type: "content" as const,
+        value: [
+          {
+            type: "file" as const,
+            data: { type: "data" as const, data: bytes },
+            mediaType: "application/octet-stream",
+            filename: "result.bin",
+          },
+        ],
+      },
+    } satisfies ToolResultPart;
+
+    const { content, fileIds } = await serializeContent(
+      ctx,
+      api as unknown as AgentComponent,
+      [result],
+    );
+
+    expect(fileIds).toEqual(["file-123"]);
+    expect(content).toMatchObject([
+      {
+        type: "tool-result",
+        output: {
+          type: "content",
+          value: [
+            {
+              type: "file",
+              data: { type: "url", url: "https://example.com/file" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const opaque = { attachment: "data:application/octet-stream,opaque" };
+    await expect(
+      serializeContent(ctx, api as unknown as AgentComponent, [
+        {
+          type: "tool-result",
+          toolCallId: "call-2",
+          toolName: "render",
+          result: opaque,
+        } satisfies Infer<typeof vToolResultPart>,
+      ]),
+    ).resolves.toMatchObject({
+      content: [{ output: { type: "json", value: opaque } }],
+    });
+  });
+
+  test("materializes oversized canonical tool-result text files", async () => {
+    const ctx = {
+      runAction: async () => undefined,
+      runMutation: async () => ({
+        fileId: "file-123",
+        storageId: "storage-123",
+      }),
+      storage: {
+        getUrl: async () => "https://example.com/file",
+      },
+    } as unknown as ActionCtx;
+    const result = {
+      type: "tool-result" as const,
+      toolCallId: "call-1",
+      toolName: "render",
+      output: {
+        type: "content" as const,
+        value: [
+          {
+            type: "file" as const,
+            data: { type: "text" as const, text: "x".repeat(1024 * 65) },
+            mediaType: "text/plain",
+            filename: "result.txt",
+          },
+        ],
+      },
+    } satisfies ToolResultPart;
+
+    const { content, fileIds } = await serializeContent(
+      ctx,
+      api as unknown as AgentComponent,
+      [result],
+    );
+
+    expect(fileIds).toEqual(["file-123"]);
+    expect(content).toMatchObject([
+      {
+        type: "tool-result",
+        output: {
+          type: "content",
+          value: [
+            {
+              type: "file",
+              data: { type: "url", url: "https://example.com/file" },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
   test("sanity: fileIds are not returned for small files", async () => {
     const arr = new Uint8Array([1, 2, 3, 4, 5]);
     const ab = arr.buffer.slice(

--- a/src/vercel/mapping.ts
+++ b/src/vercel/mapping.ts
@@ -44,6 +44,7 @@ import {
 import type { ActionCtx, AgentComponent } from "./client/types.js";
 import type { MutationCtx } from "./client/types.js";
 import { MAX_FILE_SIZE, storeFile } from "./client/files.js";
+import { materializeCanonicalToolResultContentFiles } from "./fileMaterialization.js";
 import type { Infer } from "convex/values";
 import {
   convertUint8ArrayToBase64,
@@ -466,7 +467,20 @@ export async function serializeContent(
           } satisfies Infer<typeof vToolCallPart>;
         }
         case "tool-result": {
-          return serializeToolResult(part, metadata);
+          const output =
+            "output" in part && part.output !== undefined
+              ? part.output
+              : normalizeToolOutput("result" in part ? part.result : undefined);
+          const materialized = await materializeCanonicalToolResultContentFiles(
+            ctx,
+            component,
+            output,
+          );
+          fileIds.push(...materialized.fileRefs.map((ref) => ref.fileId));
+          return serializeToolResult(
+            { ...part, output: materialized.output } as ToolResultPart,
+            metadata,
+          );
         }
         case "reasoning": {
           return {


### PR DESCRIPTION
## Summary

- Persist oversized streamed AI SDK 7 file content through the component's existing storage-reference lifecycle.
- Materialize supported image, reasoning-file, and canonical tool-result file payloads while leaving arbitrary tool output opaque.
- Balance file ownership across stream writes, pending-message replacement, normal finalization, recovery, deletion, and failure cleanup.
- Reuse generic component storage references and refcounts instead of adding provider-specific storage state.
- Preserve file metadata, nested tool-output ownership, deduplication, and cleanup behavior across serialization and recovery.

## Review boundary

This PR adds durable streamed-file persistence on top of the completed AI SDK 7 runtime migration in #306. It does not add another message representation or broaden the runtime migration.

## Compatibility

- Existing persisted AI SDK 6 and AI SDK 7 rows remain readable.
- Schema changes are additive and require no data migration.
- Registration remains ownership-neutral; references and refcounts define durable ownership.

## Validation

Clean install, typecheck, lint, build, and all 348 tests pass on the stack tip.

## Stack

1. #304 — isolate the provider adapter behind a neutral stream codec
2. #305 — extend the codec for the AI SDK 7 chunk superset
3. #306 — migrate the Vercel runtime to AI SDK 7
4. **#307 — persist oversized streamed files**

