### PR TITLE
Add advanced agent orchestration examples (#313)

### DIFF
--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -49,6 +49,7 @@ import type * as usage_tracking_tables from "../usage_tracking/tables.js";
 import type * as usage_tracking_usageHandler from "../usage_tracking/usageHandler.js";
 import type * as utils from "../utils.js";
 import type * as workflows_chaining from "../workflows/chaining.js";
+import type * as workflows_coordination from "../workflows/coordination.js";
 
 import type {
   ApiFromModules,
@@ -98,6 +99,7 @@ declare const fullApi: ApiFromModules<{
   "usage_tracking/usageHandler": typeof usage_tracking_usageHandler;
   utils: typeof utils;
   "workflows/chaining": typeof workflows_chaining;
+  "workflows/coordination": typeof workflows_coordination;
 }>;
 
 /**

--- a/example/convex/workflows/coordination.test.ts
+++ b/example/convex/workflows/coordination.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="vite/client" />
+import { expect, test } from "vitest";
+import { api } from "../_generated/api.js";
+import { initConvexTest } from "../setup.test.js";
+
+test("orchestration preserves the planned agent handoff", async () => {
+  const result = await initConvexTest().action(
+    api.workflows.coordination.orchestrate,
+    { prompt: "Plan a small release" },
+  );
+
+  expect(result.steps.map(({ agent }) => agent)).toEqual([
+    "coordinator",
+    "analyst",
+    "critic",
+    "coordinator",
+  ]);
+});

--- a/example/convex/workflows/coordination.ts
+++ b/example/convex/workflows/coordination.ts
@@ -1,0 +1,311 @@
+// See the docs at https://docs.convex.dev/agents/workflows
+import { Agent, createTool, stepCountIs } from "@convex-dev/agent";
+import {
+  defineEvent,
+  type WorkflowId,
+  WorkflowManager,
+  vWorkflowId,
+} from "@convex-dev/workflow";
+import { type Infer, v } from "convex/values";
+import { z } from "zod/v3";
+import { components, internal } from "../_generated/api.js";
+import { action, mutation, query } from "../_generated/server.js";
+import { defaultConfig } from "../agents/config.js";
+
+const resultValidator = v.object({
+  steps: v.array(v.object({ agent: v.string(), output: v.string() })),
+});
+
+type ExampleResult = Infer<typeof resultValidator>;
+
+const standaloneScope = { userId: "advanced-workflow-example" };
+
+const analystAgent = new Agent(components.agent, {
+  name: "Analyst",
+  instructions:
+    "Analyze the request using concrete facts, constraints, and tradeoffs. Keep responses under 120 words.",
+  ...defaultConfig,
+});
+
+const creativeAgent = new Agent(components.agent, {
+  name: "Creative",
+  instructions:
+    "Generate practical, original options for the request. Keep responses under 120 words.",
+  ...defaultConfig,
+});
+
+const criticAgent = new Agent(components.agent, {
+  name: "Critic",
+  instructions:
+    "Find risks, weak assumptions, and useful improvements. Keep responses under 120 words.",
+  ...defaultConfig,
+});
+
+const coordinatorAgent = new Agent(components.agent, {
+  name: "Coordinator",
+  instructions:
+    "Coordinate specialists and produce concise, actionable answers. Keep responses under 160 words.",
+  ...defaultConfig,
+});
+
+const reactAgent = new Agent(components.agent, {
+  name: "ReAct Agent",
+  instructions:
+    "Reason about the request, call both available tools, then give a concise recommendation based on their results.",
+  tools: {
+    lookupProjectFacts: createTool({
+      description: "Look up fixed facts about the example software project",
+      inputSchema: z.object({
+        focus: z.string().describe("The project area to inspect"),
+      }),
+      execute: async (_ctx, { focus }) => ({
+        focus,
+        teamSize: 3,
+        releaseWindowDays: 10,
+        constraints: ["No new service", "Keep the first release small"],
+      }),
+    }),
+    estimateEffort: createTool({
+      description:
+        "Estimate implementation days from task count and complexity",
+      inputSchema: z.object({
+        tasks: z.number().int().positive(),
+        complexity: z.enum(["low", "medium", "high"]),
+      }),
+      execute: async (_ctx, { tasks, complexity }) => ({
+        days: Math.ceil(tasks * { low: 0.5, medium: 1, high: 2 }[complexity]),
+      }),
+    }),
+  },
+  stopWhen: stepCountIs(5),
+  ...defaultConfig,
+});
+
+const specialists = {
+  analyst: analystAgent,
+  creative: creativeAgent,
+  critic: criticAgent,
+};
+
+/** Route a request with one LLM call, then invoke only the selected agent. */
+export const dynamicRouting = action({
+  args: { prompt: v.string() },
+  returns: resultValidator,
+  handler: async (ctx, { prompt }): Promise<ExampleResult> => {
+    const {
+      object: { route },
+    } = await coordinatorAgent.generateObject(ctx, standaloneScope, {
+      prompt: `Choose the best specialist for this request: ${prompt}`,
+      schema: z.object({
+        route: z.enum(["analyst", "creative", "critic"]),
+      }),
+    });
+    const response = await specialists[route].generateText(
+      ctx,
+      standaloneScope,
+      { prompt },
+    );
+    return {
+      steps: [
+        { agent: "Router", output: `Selected ${route}` },
+        { agent: route, output: response.text },
+      ],
+    };
+  },
+});
+
+/** Run independent specialists in parallel, then synthesize their reports. */
+export const fanOut = action({
+  args: { prompt: v.string() },
+  returns: resultValidator,
+  handler: async (ctx, { prompt }): Promise<ExampleResult> => {
+    const reports = await Promise.all(
+      Object.entries(specialists).map(async ([name, agent]) => ({
+        agent: name,
+        output: (await agent.generateText(ctx, standaloneScope, { prompt }))
+          .text,
+      })),
+    );
+    const combined = await coordinatorAgent.generateText(ctx, standaloneScope, {
+      prompt: `Combine these specialist reports into one answer to "${prompt}":\n\n${reports
+        .map(({ agent, output }) => `${agent}: ${output}`)
+        .join("\n\n")}`,
+    });
+    return {
+      steps: [...reports, { agent: "coordinator", output: combined.text }],
+    };
+  },
+});
+
+/** Give agents distinct sequential responsibilities in one controlled flow. */
+export const orchestrate = action({
+  args: { prompt: v.string() },
+  returns: resultValidator,
+  handler: async (ctx, { prompt }): Promise<ExampleResult> => {
+    const plan = await coordinatorAgent.generateText(ctx, standaloneScope, {
+      prompt: `Create a short plan for answering: ${prompt}`,
+    });
+    const analysis = await analystAgent.generateText(ctx, standaloneScope, {
+      prompt: `Execute this plan for "${prompt}":\n${plan.text}`,
+    });
+    const critique = await criticAgent.generateText(ctx, standaloneScope, {
+      prompt: `Review this analysis and name the important corrections:\n${analysis.text}`,
+    });
+    const final = await coordinatorAgent.generateText(ctx, standaloneScope, {
+      prompt: `Answer "${prompt}" using this analysis and critique.\n\nAnalysis: ${analysis.text}\n\nCritique: ${critique.text}`,
+    });
+    return {
+      steps: [
+        { agent: "coordinator", output: plan.text },
+        { agent: "analyst", output: analysis.text },
+        { agent: "critic", output: critique.text },
+        { agent: "coordinator", output: final.text },
+      ],
+    };
+  },
+});
+
+/** Let the model alternate between reasoning and deterministic tool actions. */
+export const reasonAndAct = action({
+  args: { prompt: v.string() },
+  returns: resultValidator,
+  handler: async (ctx, { prompt }): Promise<ExampleResult> => {
+    const response = await reactAgent.generateText(ctx, standaloneScope, {
+      prompt,
+    });
+    return { steps: [{ agent: "ReAct agent", output: response.text }] };
+  },
+});
+
+/** Let several agents contribute to the same persistent conversation thread. */
+export const agentNetwork = action({
+  args: { prompt: v.string() },
+  returns: resultValidator,
+  handler: async (ctx, { prompt }): Promise<ExampleResult> => {
+    const { threadId } = await coordinatorAgent.createThread(ctx, {
+      userId: standaloneScope.userId,
+      title: `Agent network: ${prompt}`,
+    });
+    const turns = [
+      ["analyst", analystAgent, `Analyze this request: ${prompt}`],
+      [
+        "creative",
+        creativeAgent,
+        "Read the earlier analysis in this thread and propose better options.",
+      ],
+      [
+        "critic",
+        criticAgent,
+        "Review the earlier messages and identify the strongest option and its main risk.",
+      ],
+      [
+        "coordinator",
+        coordinatorAgent,
+        "Use the full discussion in this thread to give the final answer.",
+      ],
+    ] as const;
+    const steps: ExampleResult["steps"] = [];
+    for (const [agentName, agent, turnPrompt] of turns) {
+      const response = await agent.generateText(
+        ctx,
+        { threadId },
+        { prompt: turnPrompt },
+      );
+      steps.push({ agent: agentName, output: response.text });
+    }
+    return { steps };
+  },
+});
+
+const workflow = new WorkflowManager(components.workflow);
+const revisionRequested = defineEvent({
+  name: "revisionRequested",
+  validator: v.string(),
+});
+
+export const writeForReview = coordinatorAgent.asTextAction({});
+
+/** Pause durably until feedback arrives, then resume from the recorded step. */
+export const reviewWorkflow = workflow.define({
+  args: { prompt: v.string() },
+  returns: v.string(),
+  handler: async (step, { prompt }): Promise<string> => {
+    const { text: draft } = await step.runAction(
+      internal.workflows.coordination.writeForReview,
+      {
+        userId: standaloneScope.userId,
+        prompt: `Write a short draft for: ${prompt}`,
+      },
+      { name: "writeDraft", retry: true },
+    );
+    const feedback = await step.awaitEvent(revisionRequested);
+    const { text: revision } = await step.runAction(
+      internal.workflows.coordination.writeForReview,
+      {
+        userId: standaloneScope.userId,
+        prompt: `Revise this draft using the feedback.\n\nDraft: ${draft}\n\nFeedback: ${feedback}`,
+      },
+      { name: "reviseDraft", retry: true },
+    );
+    return revision;
+  },
+});
+
+export const startReviewWorkflow = mutation({
+  args: { prompt: v.string() },
+  returns: vWorkflowId,
+  handler: (ctx, { prompt }): Promise<WorkflowId> =>
+    workflow.start(
+      ctx,
+      internal.workflows.coordination.reviewWorkflow,
+      { prompt },
+      { startAsync: true },
+    ),
+});
+
+export const resumeReviewWorkflow = mutation({
+  args: { workflowId: vWorkflowId, feedback: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { workflowId, feedback }) => {
+    await workflow.sendEvent(ctx, {
+      ...revisionRequested,
+      workflowId,
+      value: feedback,
+    });
+    return null;
+  },
+});
+
+export const reviewWorkflowStatus = query({
+  args: { workflowId: vWorkflowId },
+  returns: v.union(
+    v.object({
+      state: v.union(v.literal("running"), v.literal("waiting")),
+    }),
+    v.object({ state: v.literal("completed"), result: v.string() }),
+    v.object({ state: v.literal("failed"), error: v.string() }),
+    v.object({ state: v.literal("canceled") }),
+  ),
+  handler: async (ctx, { workflowId }) => {
+    const status = await workflow.status(ctx, workflowId);
+    switch (status.type) {
+      case "inProgress":
+        return {
+          state: status.running.some((step) => step.kind === "event")
+            ? ("waiting" as const)
+            : ("running" as const),
+        };
+      case "completed":
+        if (typeof status.result !== "string") {
+          throw new Error("Review workflow returned a non-string result");
+        }
+        return { state: "completed" as const, result: status.result };
+      case "failed":
+        return { state: "failed" as const, error: status.error };
+      case "canceled":
+        return { state: "canceled" as const };
+      default:
+        return status satisfies never;
+    }
+  },
+});

--- a/example/ui/main.tsx
+++ b/example/ui/main.tsx
@@ -12,6 +12,7 @@ import RagBasic from "./rag/RagBasic";
 import { StrictMode } from "react";
 import StreamArray from "./objects/StreamArray";
 import ChatApproval from "./chat/ChatApproval";
+import { AgentCoordination } from "./workflows/AgentCoordination";
 
 const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
 
@@ -46,6 +47,7 @@ export function App() {
             <Route path="/rag-basic" element={<RagBasic />} />
             <Route path="/rate-limiting" element={<RateLimiting />} />
             <Route path="/weather-fashion" element={<WeatherFashion />} />
+            <Route path="/advanced-workflows" element={<AgentCoordination />} />
             <Route path="/stream-array" element={<StreamArray />} />
             <Route path="/chat-approval" element={<ChatApproval />} />
           </Routes>
@@ -150,6 +152,18 @@ function Index() {
               Demonstrates human-in-the-loop approval for tool calls. Tools can
               require approval before execution, and users can approve or deny
               with an optional reason.
+            </p>
+          </li>
+          <li className="border rounded p-4 hover:shadow transition">
+            <Link
+              to="/advanced-workflows"
+              className="text-xl font-semibold text-indigo-700 hover:underline"
+            >
+              Advanced Workflows
+            </Link>
+            <p className="mt-2 text-gray-700">
+              Demonstrates dynamic routing, parallel fan-out, multi-agent
+              orchestration, ReAct, agent networks, and durable pause/resume.
             </p>
           </li>
         </ul>

--- a/example/ui/workflows/AgentCoordination.tsx
+++ b/example/ui/workflows/AgentCoordination.tsx
@@ -1,0 +1,359 @@
+import { useAction, useMutation, useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
+import { useState } from "react";
+import type { WorkflowId } from "@convex-dev/workflow";
+import { api } from "../../convex/_generated/api";
+
+const patterns = [
+  {
+    id: "routing",
+    title: "Dynamic routing",
+    description: "An LLM selects one specialist, then only that agent runs.",
+    prompt:
+      "Design a migration plan for a small team moving from REST to GraphQL.",
+  },
+  {
+    id: "fanOut",
+    title: "Parallel fan-out",
+    description:
+      "Three specialists run concurrently and a coordinator combines them.",
+    prompt: "Evaluate whether a startup should launch a free tier.",
+  },
+  {
+    id: "orchestration",
+    title: "Agent orchestration",
+    description:
+      "A coordinator plans, delegates, reviews, and produces the answer.",
+    prompt: "Create a rollout plan for a customer-facing analytics dashboard.",
+  },
+  {
+    id: "react",
+    title: "Reason and act (ReAct)",
+    description:
+      "The model alternates reasoning with project lookup and estimation tools.",
+    prompt:
+      "Can this team ship an audit log feature in the next release window?",
+  },
+  {
+    id: "network",
+    title: "Agent network",
+    description:
+      "Several agents exchange messages through one persistent thread.",
+    prompt: "Choose a strategy for improving activation in a developer tool.",
+  },
+  {
+    id: "pause",
+    title: "Pause and resume",
+    description:
+      "A durable workflow waits for human feedback before revising its draft.",
+    prompt:
+      "Write a concise launch announcement for the advanced workflow examples.",
+  },
+] as const;
+
+type PatternId = (typeof patterns)[number]["id"];
+type ExampleResult = FunctionReturnType<
+  typeof api.workflows.coordination.dynamicRouting
+>;
+type ReviewWorkflowStatus = FunctionReturnType<
+  typeof api.workflows.coordination.reviewWorkflowStatus
+>;
+
+export function AgentCoordination() {
+  const [selected, setSelected] = useState<PatternId>("routing");
+  const [prompt, setPrompt] = useState<string>(patterns[0].prompt);
+  const [result, setResult] = useState<ExampleResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [workflowId, setWorkflowId] = useState<WorkflowId | null>(null);
+  const [feedback, setFeedback] = useState("Make the draft more concrete.");
+
+  const actions = {
+    routing: useAction(api.workflows.coordination.dynamicRouting),
+    fanOut: useAction(api.workflows.coordination.fanOut),
+    orchestration: useAction(api.workflows.coordination.orchestrate),
+    react: useAction(api.workflows.coordination.reasonAndAct),
+    network: useAction(api.workflows.coordination.agentNetwork),
+  };
+  const startReview = useMutation(
+    api.workflows.coordination.startReviewWorkflow,
+  );
+  const resumeReview = useMutation(
+    api.workflows.coordination.resumeReviewWorkflow,
+  );
+  const workflowStatus = useQuery(
+    api.workflows.coordination.reviewWorkflowStatus,
+    workflowId ? { workflowId } : "skip",
+  );
+  const selectedPattern = patterns.find((pattern) => pattern.id === selected)!;
+
+  const selectPattern = (id: PatternId) => {
+    setSelected(id);
+    setPrompt(patterns.find((pattern) => pattern.id === id)!.prompt);
+    setResult(null);
+    setError(null);
+  };
+
+  const runPattern = async () => {
+    if (selected === "pause" || !prompt.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await actions[selected]({ prompt: prompt.trim() }));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startPausedWorkflow = async () => {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setWorkflowId(await startReview({ prompt: prompt.trim() }));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resumePausedWorkflow = async () => {
+    if (!workflowId || !feedback.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await resumeReview({ workflowId, feedback: feedback.trim() });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-full bg-slate-50 p-6 md:p-10">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 max-w-3xl">
+          <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-indigo-700">
+            Advanced workflows
+          </p>
+          <h1 className="text-3xl font-bold text-slate-950 md:text-4xl">
+            Six ways to coordinate agents
+          </h1>
+          <p className="mt-3 text-lg text-slate-700">
+            Run each pattern with the same prompt box, then inspect which agents
+            participated and what they returned.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[18rem_1fr]">
+          <div>
+            <label
+              htmlFor="workflow-pattern"
+              className="mb-2 block font-medium text-slate-900"
+            >
+              Workflow pattern
+            </label>
+            <select
+              id="workflow-pattern"
+              value={selected}
+              onChange={(event) =>
+                selectPattern(event.target.value as PatternId)
+              }
+              disabled={loading || workflowId !== null}
+              className="w-full rounded-xl border border-slate-400 bg-white p-3 text-slate-950 focus:border-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+            >
+              {patterns.map((pattern) => (
+                <option key={pattern.id} value={pattern.id}>
+                  {pattern.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <section className="rounded-2xl border border-slate-300 bg-white p-5 shadow-sm md:p-7">
+            <div className="mb-5">
+              <h2 className="text-2xl font-bold text-slate-950">
+                {selectedPattern.title}
+              </h2>
+              <p className="mt-1 text-slate-600">
+                {selectedPattern.description}
+              </p>
+            </div>
+
+            <label
+              htmlFor="workflow-prompt"
+              className="mb-2 block font-medium text-slate-900"
+            >
+              Prompt
+            </label>
+            <textarea
+              id="workflow-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              disabled={selected === "pause" && workflowId !== null}
+              className="min-h-28 w-full rounded-xl border border-slate-400 p-4 text-slate-950 focus:border-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:bg-slate-100"
+            />
+
+            {selected === "pause" ? (
+              <PausedWorkflowControls
+                workflowId={workflowId}
+                status={workflowStatus}
+                feedback={feedback}
+                setFeedback={setFeedback}
+                loading={loading}
+                start={startPausedWorkflow}
+                resume={resumePausedWorkflow}
+                reset={() => setWorkflowId(null)}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => void runPattern()}
+                disabled={loading || !prompt.trim()}
+                className="mt-4 rounded-lg bg-indigo-600 px-5 py-3 font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? "Running…" : "Run pattern"}
+              </button>
+            )}
+
+            {error && (
+              <p
+                role="alert"
+                className="mt-5 rounded-lg border border-red-300 bg-red-50 p-4 text-red-800"
+              >
+                {error}
+              </p>
+            )}
+
+            {result && <Result result={result} />}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PausedWorkflowControls({
+  workflowId,
+  status,
+  feedback,
+  setFeedback,
+  loading,
+  start,
+  resume,
+  reset,
+}: {
+  workflowId: WorkflowId | null;
+  status: ReviewWorkflowStatus | undefined;
+  feedback: string;
+  setFeedback: (value: string) => void;
+  loading: boolean;
+  start: () => Promise<void>;
+  resume: () => Promise<void>;
+  reset: () => void;
+}) {
+  if (!workflowId) {
+    return (
+      <button
+        type="button"
+        onClick={() => void start()}
+        disabled={loading}
+        className="mt-4 rounded-lg bg-indigo-600 px-5 py-3 font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+      >
+        {loading ? "Starting…" : "Start workflow"}
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-5 space-y-4">
+      <p className="rounded-lg border border-indigo-300 bg-indigo-50 p-3 font-medium text-indigo-950">
+        Status: {status?.state ?? "starting"}
+      </p>
+      {status?.state === "waiting" && (
+        <>
+          <label
+            htmlFor="workflow-feedback"
+            className="block font-medium text-slate-900"
+          >
+            Human feedback
+          </label>
+          <textarea
+            id="workflow-feedback"
+            value={feedback}
+            onChange={(event) => setFeedback(event.target.value)}
+            className="min-h-24 w-full rounded-xl border border-slate-400 p-4 focus:border-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          <button
+            type="button"
+            onClick={() => void resume()}
+            disabled={loading || !feedback.trim()}
+            className="rounded-lg bg-indigo-600 px-5 py-3 font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {loading ? "Resuming…" : "Send feedback and resume"}
+          </button>
+        </>
+      )}
+      {status?.state === "completed" && (
+        <div className="rounded-xl border border-emerald-300 bg-emerald-50 p-5">
+          <h3 className="font-semibold text-emerald-950">Revised result</h3>
+          <p className="mt-2 whitespace-pre-wrap text-emerald-950">
+            {status.result}
+          </p>
+        </div>
+      )}
+      {status?.state === "failed" && (
+        <p role="alert" className="text-red-700">
+          {status.error}
+        </p>
+      )}
+      {(status?.state === "completed" ||
+        status?.state === "failed" ||
+        status?.state === "canceled") && (
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-slate-400 px-4 py-2 font-medium text-slate-900 hover:bg-slate-100"
+        >
+          Start over
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Result({ result }: { result: ExampleResult }) {
+  return (
+    <div className="mt-8 space-y-5">
+      <div className="rounded-xl border border-emerald-300 bg-emerald-50 p-5">
+        <h3 className="font-semibold text-emerald-950">Combined result</h3>
+        <p className="mt-2 whitespace-pre-wrap text-emerald-950">
+          {result.steps.at(-1)!.output}
+        </p>
+      </div>
+      <div>
+        <h3 className="mb-3 font-semibold text-slate-950">Agent trace</h3>
+        <ol className="space-y-3">
+          {result.steps.map((step, index) => (
+            <li
+              key={`${step.agent}-${index}`}
+              className="rounded-xl border border-slate-300 p-4"
+            >
+              <span className="text-sm font-semibold uppercase tracking-wide text-indigo-700">
+                {index + 1}. {step.agent}
+              </span>
+              <p className="mt-2 whitespace-pre-wrap text-slate-700">
+                {step.output}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #313

Issue: https://github.com/get-convex/agent/issues/313

## What changed

- Added runnable dynamic-routing, parallel fan-out, coordinated-agent, ReAct, and shared-thread agent-network examples.
- Added a durable review workflow that pauses on a typed event and resumes with human feedback.
- Added one example-app page with agent traces plus an index route, and a focused orchestration handoff check.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 29 files, 290 tests passed
- `npm run build`
- `CONVEX_AGENT_MODE=anonymous npx convex dev --once`
- `npx convex run workflows/coordination:orchestrate '{"prompt":"Plan a small release"}'` — returned the coordinator → analyst → critic → coordinator handoff\n- Browser verification: route loads with no Vite overlay or captured console errors; durable workflow reached waiting, resumed from feedback, and rendered its revised result; home-page link verified