### PR TITLE
fix(ui): preserve string user part metadata

### DIFF
--- a/src/vercel/UIMessages.ts
+++ b/src/vercel/UIMessages.ts
@@ -344,7 +344,7 @@ function createUserUIMessage<
 
   const parts: UIMessage<METADATA, DATA_PARTS, TOOLS>["parts"] = [];
   if (text && !nonStringContent.length) {
-    parts.push({ type: "text", text });
+    parts.push({ type: "text", text, ...partCommon });
   }
   for (const contentPart of nonStringContent) {
     switch (contentPart.type) {

--- a/src/vercel/toUIMessages.test.ts
+++ b/src/vercel/toUIMessages.test.ts
@@ -26,13 +26,19 @@ describe("toUIMessages", () => {
           content: "Hello!",
         },
         text: "Hello!",
+        providerMetadata: { testProvider: { traceId: "trace-123" } },
       }),
     ];
     const uiMessages = toUIMessages(messages);
     expect(uiMessages).toHaveLength(1);
     expect(uiMessages[0].role).toBe("user");
     expect(uiMessages[0].text).toBe("Hello!");
-    expect(uiMessages[0].parts[0]).toEqual({ type: "text", text: "Hello!" });
+    expect(uiMessages[0].parts[0]).toEqual({
+      type: "text",
+      text: "Hello!",
+      state: "done",
+      providerMetadata: { testProvider: { traceId: "trace-123" } },
+    });
   });
 
   it("handles assistant message", () => {


### PR DESCRIPTION
String-backed user text parts were the only text path that did not apply the existing common part fields. This applies them so `providerMetadata` and `state` match the array-content path.

This also means string-backed user text parts now include `state: "done"`.

Fixes #234
