### PR TITLE
Support explicit ordering when saving messages

### DIFF
--- a/docs/human-agents.mdx
+++ b/docs/human-agents.mdx
@@ -31,7 +31,9 @@ await saveMessage(ctx, components.agent, {
 ## Saving a message from a human as an agent
 
 Similarly, you can save a message from a human as an agent in the same way,
-using the `message` field to specify the role and agent name:
+using `message` for the role and content and `agentName` for attribution. To
+render a standalone operator reply separately from the previous agent turn, pass
+`order: "next"`:
 
 ```ts
 import { saveMessage } from "@convex-dev/agent";
@@ -39,10 +41,15 @@ import { components } from "./_generated/api";
 
 await saveMessage(ctx, components.agent, {
   threadId,
+  order: "next",
   agentName: "Alex",
   message: { role: "assistant", content: "The human reply" },
 });
 ```
+
+`order: "next"` allocates the next order atomically. Passing a number places
+the reply at that exact order. An unused numeric order starts at `stepOrder: 0`;
+an existing order appends at its next `stepOrder`.
 
 ## Storing additional metadata about human agents
 
@@ -50,8 +57,12 @@ You can store additional metadata about human agents by using the `saveMessage`
 function, and adding the `metadata` field.
 
 ```ts
+import { saveMessage } from "@convex-dev/agent";
+import { components } from "./_generated/api";
+
 await saveMessage(ctx, components.agent, {
   threadId,
+  order: "next",
   agentName: "Alex",
   message: { role: "assistant", content: "The human reply" },
   metadata: {

--- a/docs/messages.mdx
+++ b/docs/messages.mdx
@@ -262,14 +262,23 @@ const result = await thread.generateText({ messages }, {
 Each message has `order` and `stepOrder` fields, which are incrementing integers
 specific to a thread.
 
-When `saveMessage` or `generateText` is called, the message is added to the
-thread's next `order` with a `stepOrder` of 0.
+User messages saved by `saveMessage` or `generateText` are added to the thread's
+next `order` with a `stepOrder` of 0. Standalone assistant or tool messages
+append to the latest order by default.
 
 As response message(s) are generated in response to that message, they are added
 at the same `order` with the next `stepOrder`.
 
 To associate a response message with a previous message, you can pass in the
 `promptMessageId` to `generateText` and others.
+
+To start a standalone message at the next order, pass `order: "next"` to
+`saveMessage` or `saveMessages`. The component allocates that order
+atomically. To place a standalone message at a specific order, pass a number
+instead. If that order is empty, the first message is saved with `stepOrder: 0`;
+otherwise it is appended at the next `stepOrder`. `order` cannot be combined
+with `promptMessageId` or `pendingMessageId`; numeric orders must be
+non-negative safe integers less than `Number.MAX_SAFE_INTEGER`.
 
 Note: if the `promptMessageId` is not the latest message in the thread, the
 context for the message generation will not include any messages following the

--- a/example/convex/chat/human.ts
+++ b/example/convex/chat/human.ts
@@ -39,6 +39,9 @@ export const sendMessageFromHumanAgent = internalMutation({
   handler: async (ctx, args) => {
     const { messageId } = await saveMessage(ctx, components.agent, {
       threadId: args.threadId,
+      // Start a new order so the reply renders separately from the previous
+      // agent turn instead of merging into its UI message.
+      order: "next",
       agentName: args.agentName,
       message: {
         role: "assistant",

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -59,9 +59,20 @@ export async function listMessages(
   });
 }
 
+export type MessageOrder = number | "next";
+
 export type SaveMessagesArgs = {
   threadId: string;
   userId?: string | null;
+  /**
+   * Save the first message at this order. Pass `"next"` to allocate a new
+   * order after the current latest message. If the numeric order already
+   * contains messages, the message is appended at the next stepOrder.
+   * Numeric orders must be non-negative safe integers less than
+   * Number.MAX_SAFE_INTEGER.
+   * Cannot be combined with promptMessageId or pendingMessageId.
+   */
+  order?: MessageOrder;
   /**
    * The message that these messages are in response to. They will be
    * the same "order" as this message, at increasing stepOrder(s).
@@ -121,6 +132,7 @@ export async function saveMessages(
     userId: args.userId ?? undefined,
     agentName: args.agentName,
     promptMessageId: args.promptMessageId,
+    order: args.order,
     pendingMessageId: args.pendingMessageId,
     embeddings,
     messages: args.messages.map((message, i) =>

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -835,6 +835,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
               | { message: string; type: "other" }
             >;
           }>;
+          order?: number | "next";
           pendingMessageId?: string;
           promptMessageId?: string;
           threadId: string;

--- a/src/component/messages.test.ts
+++ b/src/component/messages.test.ts
@@ -163,6 +163,251 @@ describe("agent", () => {
     });
   });
 
+  test("an explicit order starts, appends, and avoids later order collisions", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [
+        { message: { role: "user", content: "hello" } },
+        { message: { role: "assistant", content: "agent reply" } },
+      ],
+    });
+
+    const { messages: firstHumanReply } = await t.mutation(
+      api.messages.addMessages,
+      {
+        threadId: thread._id as Id<"threads">,
+        order: 1,
+        agentName: "human:Alex",
+        messages: [{ message: { role: "assistant", content: "human reply" } }],
+      },
+    );
+    expect(firstHumanReply[0]).toMatchObject({
+      order: 1,
+      stepOrder: 0,
+      agentName: "human:Alex",
+    });
+
+    const { messages: secondHumanReply } = await t.mutation(
+      api.messages.addMessages,
+      {
+        threadId: thread._id as Id<"threads">,
+        order: 1,
+        agentName: "human:Sam",
+        messages: [{ message: { role: "assistant", content: "follow-up" } }],
+      },
+    );
+    expect(secondHumanReply[0]).toMatchObject({
+      order: 1,
+      stepOrder: 1,
+      agentName: "human:Sam",
+    });
+
+    const { messages: backdatedBatch } = await t.mutation(
+      api.messages.addMessages,
+      {
+        threadId: thread._id as Id<"threads">,
+        order: 0,
+        messages: [
+          { message: { role: "assistant", content: "backdated reply" } },
+          { message: { role: "user", content: "new user turn" } },
+        ],
+      },
+    );
+    expect(
+      backdatedBatch.map(({ order, stepOrder }) => [order, stepOrder]),
+    ).toEqual([
+      [0, 2],
+      [2, 0],
+    ]);
+  });
+
+  test("concurrent saves to an explicit order receive distinct step orders", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    const saveReply = (agentName: string) =>
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        order: 3,
+        agentName,
+        messages: [
+          { message: { role: "assistant" as const, content: agentName } },
+        ],
+      });
+
+    const replies = await Promise.all([saveReply("Alex"), saveReply("Sam")]);
+
+    expect(
+      replies
+        .map(({ messages }) => messages[0].stepOrder)
+        .sort((a, b) => a - b),
+    ).toEqual([0, 1]);
+  });
+
+  test("next order is allocated after the latest message", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [{ message: { role: "user", content: "hello" } }],
+    });
+
+    const { messages } = await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      order: "next",
+      messages: [
+        { message: { role: "assistant", content: "separate reply" } },
+      ],
+    });
+
+    expect(messages[0]).toMatchObject({ order: 1, stepOrder: 0 });
+  });
+
+  test("concurrent next orders receive distinct orders", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [{ message: { role: "user", content: "hello" } }],
+    });
+    const saveReply = (agentName: string) =>
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        order: "next",
+        agentName,
+        messages: [
+          { message: { role: "assistant" as const, content: agentName } },
+        ],
+      });
+
+    const replies = await Promise.all([saveReply("Alex"), saveReply("Sam")]);
+
+    expect(
+      replies
+        .map(({ messages }) => messages[0])
+        .sort((a, b) => a.order - b.order)
+        .map(({ order, stepOrder }) => [order, stepOrder]),
+    ).toEqual([
+      [1, 0],
+      [2, 0],
+    ]);
+  });
+
+  test("an explicit order ahead of the thread places the batch there", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [{ message: { role: "user", content: "hello" } }],
+    });
+
+    const { messages } = await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      order: 5,
+      messages: [
+        { message: { role: "assistant", content: "imported reply" } },
+        { message: { role: "user", content: "imported question" } },
+      ],
+    });
+    expect(messages.map(({ order, stepOrder }) => [order, stepOrder])).toEqual([
+      [5, 0],
+      [6, 0],
+    ]);
+  });
+
+  test("an explicit order cannot conflict with another placement argument", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    const { messages } = await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      messages: [{ message: { role: "user", content: "hello" } }],
+    });
+
+    await expect(
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        order: 1,
+        promptMessageId: messages[0]._id as Id<"messages">,
+        messages: [{ message: { role: "assistant", content: "reply" } }],
+      }),
+    ).rejects.toThrow("order and promptMessageId cannot both be provided");
+
+    await expect(
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        order: "next",
+        promptMessageId: messages[0]._id as Id<"messages">,
+        messages: [{ message: { role: "assistant", content: "reply" } }],
+      }),
+    ).rejects.toThrow("order and promptMessageId cannot both be provided");
+
+    for (const order of [-1, 1.5, Number.MAX_SAFE_INTEGER]) {
+      await expect(
+        t.mutation(api.messages.addMessages, {
+          threadId: thread._id as Id<"threads">,
+          order,
+          messages: [{ message: { role: "assistant", content: "reply" } }],
+        }),
+      ).rejects.toThrow("order must be a non-negative safe integer");
+    }
+  });
+
+  test("derived message positions cannot exceed safe integers", async () => {
+    const t = convexTest(schema, modules);
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "test",
+    });
+    const { messages } = await t.mutation(api.messages.addMessages, {
+      threadId: thread._id as Id<"threads">,
+      order: 1,
+      messages: [{ message: { role: "assistant", content: "reply" } }],
+    });
+    const messageId = messages[0]._id as Id<"messages">;
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch("messages", messageId, {
+        stepOrder: Number.MAX_SAFE_INTEGER,
+      });
+    });
+    await expect(
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        order: 1,
+        messages: [{ message: { role: "assistant", content: "follow-up" } }],
+      }),
+    ).rejects.toThrow(
+      "stepOrder cannot be incremented past Number.MAX_SAFE_INTEGER",
+    );
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch("messages", messageId, {
+        order: Number.MAX_SAFE_INTEGER,
+        stepOrder: 0,
+      });
+    });
+    await expect(
+      t.mutation(api.messages.addMessages, {
+        threadId: thread._id as Id<"threads">,
+        messages: [{ message: { role: "user", content: "new turn" } }],
+      }),
+    ).rejects.toThrow(
+      "order cannot be incremented past Number.MAX_SAFE_INTEGER",
+    );
+  });
+
   test("order is incremented for user messages on to addMessages for the same promptMessageId", async () => {
     const t = convexTest(schema, modules);
     const thread = await t.mutation(api.threads.createThread, {

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -153,6 +153,7 @@ const addMessagesArgs = {
   userId: v.optional(v.string()),
   threadId: v.id("threads"),
   promptMessageId: v.optional(v.id("messages")),
+  order: v.optional(v.union(v.number(), v.literal("next"))),
   agentName: v.optional(v.string()),
   messages: v.array(vMessageWithMetadataInternal),
   embeddings: v.optional(vMessageEmbeddingsWithDimension),
@@ -171,6 +172,15 @@ export const addMessages = mutation({
   handler: addMessagesHandler,
   returns: v.object({ messages: v.array(vMessageDoc) }),
 });
+
+function incrementMessagePosition(value: number, field: "order" | "stepOrder") {
+  assert(
+    Number.isSafeInteger(value) && value < Number.MAX_SAFE_INTEGER,
+    `${field} cannot be incremented past Number.MAX_SAFE_INTEGER`,
+  );
+  return value + 1;
+}
+
 async function addMessagesHandler(
   ctx: MutationCtx,
   args: ObjectType<typeof addMessagesArgs>,
@@ -189,12 +199,29 @@ async function addMessagesHandler(
     finishStreamId,
     messages,
     promptMessageId,
+    order: requestedOrder,
     pendingMessageId,
     hideFromUserIdSearch,
     ...rest
   } = args;
   const promptMessage =
     promptMessageId && (await ctx.db.get("messages", promptMessageId));
+  assert(
+    requestedOrder === undefined ||
+      requestedOrder === "next" ||
+      (Number.isSafeInteger(requestedOrder) &&
+        requestedOrder >= 0 &&
+        requestedOrder < Number.MAX_SAFE_INTEGER),
+    "order must be a non-negative safe integer less than Number.MAX_SAFE_INTEGER",
+  );
+  assert(
+    requestedOrder === undefined || !promptMessageId,
+    "order and promptMessageId cannot both be provided",
+  );
+  assert(
+    requestedOrder === undefined || !pendingMessageId,
+    "order and pendingMessageId cannot both be provided",
+  );
   if (failPendingSteps) {
     assert(args.threadId, "threadId is required to fail pending steps");
     const pendingMessages = await ctx.db
@@ -224,7 +251,18 @@ async function addMessagesHandler(
   let order, stepOrder;
   let fail = false;
   let error: string | undefined;
-  if (promptMessageId) {
+  const startsAtNextOrder = requestedOrder === "next";
+  const explicitOrder =
+    typeof requestedOrder === "number" ? requestedOrder : undefined;
+  if (startsAtNextOrder) {
+    const maxMessage = await getMaxMessage(ctx, threadId);
+    order = incrementMessagePosition(maxMessage?.order ?? -1, "order");
+    stepOrder = -1;
+  } else if (explicitOrder !== undefined) {
+    order = explicitOrder;
+    const maxMessage = await getMaxMessage(ctx, threadId, order);
+    stepOrder = maxMessage?.stepOrder ?? -1;
+  } else if (promptMessageId) {
     assert(promptMessage, `Parent message ${promptMessageId} not found`);
     if (promptMessage.status === "failed") {
       fail = true;
@@ -305,20 +343,28 @@ async function addMessagesHandler(
       toReturn.push((await ctx.db.get("messages", pendingMessage._id))!);
       continue;
     }
-    if (message.message.role === "user") {
-      if (promptMessage && promptMessage.order === order) {
-        // see if there's a later message than the parent message order
+    if ((startsAtNextOrder || explicitOrder !== undefined) && i === 0) {
+      stepOrder = incrementMessagePosition(stepOrder, "stepOrder");
+    } else if (message.message.role === "user") {
+      if (
+        (explicitOrder !== undefined && order === explicitOrder) ||
+        (promptMessage && promptMessage.order === order)
+      ) {
+        // Avoid colliding with a later order when saving from an older one.
         const maxMessage = await getMaxMessage(ctx, threadId);
-        order = (maxMessage?.order ?? order) + 1;
+        order = incrementMessagePosition(
+          Math.max(maxMessage?.order ?? order, order),
+          "order",
+        );
       } else {
-        order++;
+        order = incrementMessagePosition(order, "order");
       }
       stepOrder = 0;
     } else {
       if (order < 0) {
         order = 0;
       }
-      stepOrder++;
+      stepOrder = incrementMessagePosition(stepOrder, "stepOrder");
     }
     const messageId = await ctx.db.insert("messages", {
       ...messageDoc,

--- a/src/vercel/client/index.test.ts
+++ b/src/vercel/client/index.test.ts
@@ -4,6 +4,8 @@ import {
   createThread,
   createTool,
   filterOutOrphanedToolMessages,
+  saveMessage,
+  toUIMessages,
   type MessageDoc,
 } from "../index.js";
 import type { DataModelFromSchemaDefinition } from "convex/server";
@@ -457,6 +459,51 @@ describe("Agent message operations", () => {
     );
     expect(messages.length).toBe(2);
     expect(messages[1]._id).toBeDefined();
+  });
+
+  test("saveMessage can place a standalone assistant message on a new order", async () => {
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "operator-test" }),
+    );
+    const { message: agentReply } = await t.run(async (ctx) =>
+      agent.saveMessage(ctx, {
+        threadId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "handoff-1",
+              toolName: "handoff",
+              input: {},
+            },
+          ],
+        },
+      }),
+    );
+    const { message: operatorReply } = await t.run(async (ctx) =>
+      saveMessage(ctx, components.agent, {
+        threadId,
+        order: "next",
+        agentName: "human:Alex",
+        message: { role: "assistant", content: "Operator reply" },
+      }),
+    );
+    const uiMessages = toUIMessages([agentReply, operatorReply]);
+
+    expect(agentReply).toMatchObject({ order: 0, stepOrder: 0 });
+    expect(operatorReply).toMatchObject({
+      order: 1,
+      stepOrder: 0,
+      agentName: "human:Alex",
+    });
+    expect(uiMessages).toHaveLength(2);
+    expect(uiMessages[1]).toMatchObject({
+      order: 1,
+      agentName: "human:Alex",
+      text: "Operator reply",
+    });
   });
 });
 

--- a/src/vercel/client/messages.ts
+++ b/src/vercel/client/messages.ts
@@ -11,6 +11,7 @@ import { toUIMessages, type UIMessage } from "../UIMessages.js";
 import {
   listMessages,
   saveMessages as saveCanonicalMessages,
+  type MessageOrder,
 } from "../../client/messages.js";
 import type {
   AgentComponent,
@@ -36,6 +37,15 @@ export async function listUIMessages(
 export type SaveMessagesArgs = {
   threadId: string;
   userId?: string | null;
+  /**
+   * Save the first message at this order. Pass `"next"` to allocate a new
+   * order after the current latest message. If the numeric order already
+   * contains messages, the message is appended at the next stepOrder.
+   * Numeric orders must be non-negative safe integers less than
+   * Number.MAX_SAFE_INTEGER.
+   * Cannot be combined with promptMessageId or pendingMessageId.
+   */
+  order?: MessageOrder;
   /**
    * The message that these messages are in response to. They will be
    * the same "order" as this message, at increasing stepOrder(s).
@@ -86,6 +96,7 @@ export async function saveMessages(
     userId: args.userId ?? undefined,
     agentName: args.agentName,
     promptMessageId: args.promptMessageId,
+    order: args.order,
     pendingMessageId: args.pendingMessageId,
     embeddings: args.embeddings,
     messages: serialized.map(({ message }) => message),
@@ -105,6 +116,14 @@ export async function saveMessages(
 export type SaveMessageArgs = {
   threadId: string;
   userId?: string | null;
+  /**
+   * Save the message at this order. Pass `"next"` to allocate a new order
+   * after the current latest message. If the numeric order already contains
+   * messages, the message is appended at the next stepOrder. Numeric orders
+   * must be non-negative safe integers less than Number.MAX_SAFE_INTEGER.
+   * Cannot be combined with promptMessageId or pendingMessageId.
+   */
+  order?: MessageOrder;
   /**
    * The message that these messages are in response to. They will be
    * the same "order" as this message, at increasing stepOrder(s).
@@ -169,6 +188,7 @@ export async function saveMessage(
     userId: args.userId ?? undefined,
     agentName: args.agentName,
     promptMessageId: args.promptMessageId,
+    order: args.order,
     pendingMessageId: args.pendingMessageId,
     messages:
       args.prompt !== undefined

--- a/src/vercel/index.ts
+++ b/src/vercel/index.ts
@@ -818,6 +818,7 @@ export class Agent<
       metadata: args.metadata ? [args.metadata] : undefined,
       skipEmbeddings: args.skipEmbeddings,
       promptMessageId: args.promptMessageId,
+      order: args.order,
       pendingMessageId: args.pendingMessageId,
     });
     const message = messages.at(-1)!;
@@ -1765,6 +1766,7 @@ export class Agent<
         threadId: v.string(),
         userId: v.optional(v.string()),
         promptMessageId: v.optional(v.string()),
+        order: v.optional(v.union(v.number(), v.literal("next"))),
         messages: v.array(vMessageWithMetadata),
         failPendingSteps: v.optional(v.boolean()),
         embeddings: v.optional(vMessageEmbeddings),


### PR DESCRIPTION
Closes #282.

Adds an optional order to saveMessage and saveMessages, with stepOrder assigned transactionally by the component. This lets standalone assistant messages, including human operator replies, start a separate UI turn without changing existing default placement.

Explicit orders append when the target order already exists, reject conflicting placement inputs, and preserve ordering for backdated or future batches. The human-agent documentation and example now calculate the next order within the same mutation so concurrent replies remain serializable.