### PR TITLE
fix(streaming): finish the stream row when messages aren't stored

### DIFF
--- a/src/vercel/client/streamText.test.ts
+++ b/src/vercel/client/streamText.test.ts
@@ -264,6 +264,24 @@ export const streamTextAbortedMidStream = action({
   },
 });
 
+// An empty generation on the awaited path with nothing stored: no part ever
+// reaches the streamer, so no row exists when consumption ends.
+export const streamTextEmptyNoStorageAwaited = action({
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    await emptyAgent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "Test" },
+      {
+        saveStreamDeltas: { chunking: "word", throttleMs: 0 },
+        storageOptions: { saveMessages: "none" },
+      },
+    );
+    return { ok: true };
+  },
+});
+
 const testApi: ApiFromModules<{
   fns: {
     streamTextReturnImmediately: typeof streamTextReturnImmediately;
@@ -272,6 +290,7 @@ const testApi: ApiFromModules<{
     streamTextAbortedMidStream: typeof streamTextAbortedMidStream;
     streamTextNoStorage: typeof streamTextNoStorage;
     streamTextNoStorageImmediate: typeof streamTextNoStorageImmediate;
+    streamTextEmptyNoStorageAwaited: typeof streamTextEmptyNoStorageAwaited;
     streamTextEmptyAwaited: typeof streamTextEmptyAwaited;
     streamTextEmptyReturnImmediately: typeof streamTextEmptyReturnImmediately;
     streamTextCleanupFailure: typeof streamTextCleanupFailure;
@@ -596,6 +615,24 @@ describe("stream finish ownership without message storage", () => {
       }),
     );
     expect(streams.map((s) => s.status)).toEqual(["finished"]);
+  });
+
+  test("leaves no row behind when the generation produces nothing", async () => {
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "u1" }),
+    );
+
+    await t.action(testApi.streamTextEmptyNoStorageAwaited, { threadId });
+    await t.finishAllScheduledFunctions(() => {});
+
+    const streams = await t.run(async (ctx) =>
+      ctx.runQuery(components.agent.streams.list, {
+        threadId,
+        statuses: ["streaming", "finished", "aborted"],
+      }),
+    );
+    expect(streams.filter((s) => s.status === "streaming")).toEqual([]);
   });
 
   test("the row still terminates on the returnImmediately path", async () => {

--- a/src/vercel/client/streamText.test.ts
+++ b/src/vercel/client/streamText.test.ts
@@ -153,6 +153,43 @@ export const streamTextThrottledAwaited = action({
   },
 });
 
+export const streamTextNoStorage = action({
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    await agent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "Test" },
+      {
+        saveStreamDeltas: { chunking: "word", throttleMs: 0 },
+        storageOptions: { saveMessages: "none" },
+      },
+    );
+    return { ok: true };
+  },
+});
+
+export const streamTextNoStorageImmediate = action({
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    const r = await agent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "Test" },
+      {
+        saveStreamDeltas: {
+          returnImmediately: true,
+          chunking: "word",
+          throttleMs: 0,
+        },
+        storageOptions: { saveMessages: "none" },
+      },
+    );
+    await r.consumeStream();
+    return { ok: true };
+  },
+});
+
 export const streamTextCleanupFailure = action({
   args: { threadId: v.string() },
   handler: async (ctx, { threadId }) => {
@@ -233,6 +270,8 @@ const testApi: ApiFromModules<{
     streamTextThrottled: typeof streamTextThrottled;
     streamTextThrottledAwaited: typeof streamTextThrottledAwaited;
     streamTextAbortedMidStream: typeof streamTextAbortedMidStream;
+    streamTextNoStorage: typeof streamTextNoStorage;
+    streamTextNoStorageImmediate: typeof streamTextNoStorageImmediate;
     streamTextEmptyAwaited: typeof streamTextEmptyAwaited;
     streamTextEmptyReturnImmediately: typeof streamTextEmptyReturnImmediately;
     streamTextCleanupFailure: typeof streamTextCleanupFailure;
@@ -537,5 +576,43 @@ describe("saveStreamDeltas flushes buffered parts (issue #323)", () => {
         .map((p) => (p as { delta?: string }).delta ?? "")
         .join(""),
     ).toBe(FINAL_TEXT);
+  });
+});
+
+describe("stream finish ownership without message storage", () => {
+  test("the row still terminates when saveMessages is none", async () => {
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "u1" }),
+    );
+
+    await t.action(testApi.streamTextNoStorage, { threadId });
+    await t.finishAllScheduledFunctions(() => {});
+
+    const streams = await t.run(async (ctx) =>
+      ctx.runQuery(components.agent.streams.list, {
+        threadId,
+        statuses: ["streaming", "finished", "aborted"],
+      }),
+    );
+    expect(streams.map((s) => s.status)).toEqual(["finished"]);
+  });
+
+  test("the row still terminates on the returnImmediately path", async () => {
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "u1" }),
+    );
+
+    await t.action(testApi.streamTextNoStorageImmediate, { threadId });
+    await t.finishAllScheduledFunctions(() => {});
+
+    const streams = await t.run(async (ctx) =>
+      ctx.runQuery(components.agent.streams.list, {
+        threadId,
+        statuses: ["streaming", "finished", "aborted"],
+      }),
+    );
+    expect(streams.map((s) => s.status)).toEqual(["finished"]);
   });
 });

--- a/src/vercel/client/streamText.ts
+++ b/src/vercel/client/streamText.ts
@@ -134,6 +134,7 @@ export async function streamText<
   // When false (saveStreamDeltas.returnImmediately === true), we cannot
   // defer the final-step save to a post-await block — the function has
   // already returned by the time onStepFinish fires. See issue #265.
+  const savesMessages = options?.storageOptions?.saveMessages !== "none";
   const willAwaitStream =
     Boolean(threadId) &&
     (options.saveStreamDeltas === true ||
@@ -155,10 +156,10 @@ export async function streamText<
             materialize: (parts) =>
               materializeUIMessageChunkFiles(ctx, component, parts),
             abortSignal: args.abortSignal,
-            // Both paths below finish the stream row atomically with the
-            // message save (issue #181), so the streamer must never finish it
-            // itself at end-of-stream.
-            finishHandledExternally: true,
+            // The message save finishes the stream row atomically (issue
+            // #181) — but only when there is a save. With saveMessages set to
+            // "none" nothing does, so the streamer keeps finish ownership.
+            finishHandledExternally: savesMessages,
           },
           {
             threadId,
@@ -256,6 +257,11 @@ export async function streamText<
               false,
               finishStreamId,
             );
+            // The save finishes the row only when it stores messages. With
+            // saveMessages "none" nothing else will, so do it here.
+            if (!savesMessages) {
+              await streamer.finish();
+            }
             initialResponseMessagesSaved = true;
           }
         }


### PR DESCRIPTION
With `storageOptions.saveMessages: "none"`, nothing terminated the stream row and it sat `streaming` until the 10 minute timeout.

`startGeneration`'s `save` closure is gated on `threadId && saveMessages !== "none"` (`src/vercel/client/start.ts:346`), so the `finishStreamId` never reached `addMessages` and the atomic finish never ran. Both paths were affected. It reproduces on `main`, so it predates this branch.

**What changed**

- `finishHandledExternally` is derived from whether messages are actually stored, rather than assumed true, so the awaited path finishes the row itself when the save won't.
- The `returnImmediately` path finishes explicitly after the inline save, since that save stores nothing.

Three tests, one per case: the awaited path, the `returnImmediately` path, and an empty generation, which is the case where no part reaches the streamer and nothing else would terminate the row.
