### PR TITLE
fix(streaming): flush throttled deltas on a timer, not on the next part

### DIFF
--- a/src/vercel/client/deltaFlush.test.ts
+++ b/src/vercel/client/deltaFlush.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { stepCountIs } from "ai";
+import { Agent, createTool, createThread } from "../index.js";
+import {
+  actionGeneric,
+  anyApi,
+  defineSchema,
+  type ActionBuilder,
+  type ApiFromModules,
+  type DataModelFromSchemaDefinition,
+} from "convex/server";
+import { v } from "convex/values";
+import { components, initConvexTest } from "./setup.test.js";
+import { mockModel } from "./mockModel.js";
+
+const schema = defineSchema({});
+type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+const action = actionGeneric as ActionBuilder<DataModel, "public">;
+
+// The AI SDK emits tool-input-available before the tool runs. The whole point
+// of issue #221 is that a client can see it while the tool is still working,
+// so the tool itself is where the delta log has to be read.
+const partsSeenDuringTool: string[] = [];
+
+const sleepTool = createTool({
+  description: "sleep",
+  inputSchema: z.object({ seconds: z.number() }),
+  execute: async (ctx) => {
+    const readTypes = async () => {
+      const streams = await ctx.runQuery(components.agent.streams.list, {
+        threadId: ctx.threadId!,
+        statuses: ["streaming"],
+      });
+      const deltas = await ctx.runQuery(components.agent.streams.listDeltas, {
+        threadId: ctx.threadId!,
+        cursors: streams.map((s) => ({ streamId: s.streamId, cursor: 0 })),
+      });
+      return deltas.flatMap((d) => d.parts.map((p) => p.type));
+    };
+    // Wait on the condition rather than on a fixed sleep chosen to outrun the
+    // throttle: there is no margin to tune, so machine load cannot decide the
+    // outcome. Without a scheduled flush this simply never arrives.
+    const deadline = Date.now() + 2_000;
+    let types = await readTypes();
+    while (!types.includes("tool-input-available") && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      types = await readTypes();
+    }
+    partsSeenDuringTool.push(...types);
+    return { slept: 3 };
+  },
+});
+
+const agent = new Agent(components.agent, {
+  name: "slow-tool",
+  languageModel: mockModel({
+    contentSteps: [
+      [
+        {
+          type: "tool-call",
+          toolCallId: "t1",
+          toolName: "sleepTool",
+          input: JSON.stringify({ seconds: 3 }),
+        },
+      ],
+      [{ type: "text", text: "done" }],
+    ],
+  }),
+  tools: { sleepTool },
+});
+
+export const run = action({
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    const r = await agent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "go", stopWhen: stepCountIs(3) },
+      { saveStreamDeltas: { chunking: "word", throttleMs: 50 } },
+    );
+    await r.consumeStream();
+    return { ok: true };
+  },
+});
+
+const testApi: ApiFromModules<{ fns: { run: typeof run } }>["fns"] =
+  anyApi["deltaFlush.test"] as unknown as ApiFromModules<{
+    fns: { run: typeof run };
+  }>["fns"];
+
+describe("throttled deltas flush on time (issue #221)", () => {
+  test("the tool call is queryable while the tool is still running", async () => {
+    partsSeenDuringTool.length = 0;
+    const t = initConvexTest(schema);
+    const threadId = await t.run(async (ctx) =>
+      createThread(ctx, components.agent, { userId: "u" }),
+    );
+
+    await t.action(testApi.run, { threadId });
+    await t.finishAllScheduledFunctions(() => {});
+
+    expect(partsSeenDuringTool).toContain("tool-input-available");
+    expect(partsSeenDuringTool).not.toContain("tool-output-available");
+  });
+});

--- a/src/vercel/client/streaming.throttle.test.ts
+++ b/src/vercel/client/streaming.throttle.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createThread } from "../../client/threads.js";
+import { components, initConvexTest } from "./setup.test.js";
+import { DeltaStreamer } from "./streaming.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("publishes a quiet tail after preparing an earlier batch takes time", async () => {
+  const t = initConvexTest();
+  let releasePreparation!: () => void;
+  let enteredPreparation!: () => void;
+  const preparing = new Promise<void>((resolve) => {
+    enteredPreparation = resolve;
+  });
+  const release = new Promise<void>((resolve) => {
+    releasePreparation = resolve;
+  });
+  await t.action(async (ctx) => {
+    const threadId = await createThread(ctx, components.agent, {});
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      ctx,
+      {
+        throttleMs: 100,
+        compress: null,
+        abortSignal: undefined,
+        onAsyncAbort: async (reason) => {
+          throw new Error(reason);
+        },
+        materialize: async (parts) => {
+          if (parts.includes("first")) {
+            enteredPreparation();
+            await release;
+          }
+          return { parts, fileRefs: [] };
+        },
+      },
+      { threadId, order: 0, stepOrder: 0, format: undefined },
+    );
+    const savedParts = async () => {
+      const deltas = await ctx.runQuery(components.agent.streams.listDeltas, {
+        threadId,
+        cursors: [{ streamId: await streamer.getStreamId(), cursor: 0 }],
+      });
+      return deltas.flatMap((delta) => delta.parts);
+    };
+    try {
+      await streamer.addParts(["first"]);
+      await preparing;
+      await streamer.addParts(["tail"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(await savedParts()).toEqual([]);
+      releasePreparation();
+      for (let elapsed = 0; elapsed < 200; elapsed++) {
+        await vi.advanceTimersByTimeAsync(1);
+        if ((await savedParts()).includes("first")) break;
+      }
+      expect(await savedParts()).toEqual(["first"]);
+      await vi.advanceTimersByTimeAsync(50);
+      expect(await savedParts()).toEqual(["first"]);
+      await vi.advanceTimersByTimeAsync(300);
+      expect.soft(await savedParts()).toEqual(["first", "tail"]);
+      const streams = await ctx.runQuery(components.agent.streams.list, {
+        threadId,
+        statuses: ["streaming"],
+      });
+      expect(streams).toHaveLength(1);
+    } finally {
+      releasePreparation();
+      await streamer.finish();
+    }
+    expect(await savedParts()).toEqual(["first", "tail"]);
+  });
+});
+
+test("a wake armed during a write respects the deadline that write set", async () => {
+  const t = initConvexTest();
+  let releasePreparation!: () => void;
+  let enteredPreparation!: () => void;
+  const preparing = new Promise<void>((resolve) => {
+    enteredPreparation = resolve;
+  });
+  const release = new Promise<void>((resolve) => {
+    releasePreparation = resolve;
+  });
+  await t.action(async (ctx) => {
+    const threadId = await createThread(ctx, components.agent, {});
+    const streamer = new DeltaStreamer<string>(
+      components.agent,
+      ctx,
+      {
+        throttleMs: 100,
+        compress: null,
+        abortSignal: undefined,
+        onAsyncAbort: async () => {},
+        materialize: async (parts) => {
+          if (parts.includes("first")) {
+            enteredPreparation();
+            await release;
+          }
+          return { parts, fileRefs: [] };
+        },
+      },
+      { threadId, order: 0, stepOrder: 0, format: undefined },
+    );
+    const streamId = await streamer.getStreamId();
+    const savedParts = async () => {
+      const deltas = await ctx.runQuery(components.agent.streams.listDeltas, {
+        threadId,
+        cursors: [{ streamId, cursor: 0 }],
+      });
+      return deltas.flatMap((delta) => delta.parts);
+    };
+
+    await streamer.addParts(["first"]);
+    await preparing;
+    // The tail is admitted while the first batch is still being prepared, so
+    // the wake it arms is measured against the previous write's deadline.
+    await vi.advanceTimersByTimeAsync(10);
+    await streamer.addParts(["tail"]);
+    releasePreparation();
+    for (let elapsed = 0; elapsed < 200; elapsed++) {
+      await vi.advanceTimersByTimeAsync(1);
+      if ((await savedParts()).includes("first")) break;
+    }
+    expect(await savedParts()).toEqual(["first"]);
+
+    // The first batch has now reset the window, so the tail is not due yet.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await savedParts()).toEqual(["first"]);
+
+    // It still has to arrive once the window it was re-armed against elapses,
+    // otherwise holding it back would pass this test by never publishing.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await savedParts()).toEqual(["first", "tail"]);
+  });
+});

--- a/src/vercel/client/streaming.ts
+++ b/src/vercel/client/streaming.ts
@@ -221,6 +221,7 @@ export class DeltaStreamer<T> {
   #nextParts: T[] = [];
   #latestWrite: number = 0;
   #ongoingWrite: Promise<void> | undefined;
+  #flushTimer: ReturnType<typeof setTimeout> | undefined;
   #abortPromise: Promise<void> | undefined;
   #cursor: number = 0;
   public abortController: AbortController;
@@ -330,6 +331,46 @@ export class DeltaStreamer<T> {
       Date.now() - this.#latestWrite >= this.config.throttleMs
     ) {
       this.#ongoingWrite = this.#sendDelta();
+    } else {
+      this.#scheduleFlush();
+    }
+  }
+
+  // The throttle is only reconsidered when the next part arrives, so a pause in
+  // the stream would otherwise hold whatever is buffered until it resumes.
+  #scheduleFlush() {
+    if (this.#flushTimer) {
+      return;
+    }
+    const wait = Math.max(
+      0,
+      this.config.throttleMs - (Date.now() - this.#latestWrite),
+    );
+    this.#flushTimer = setTimeout(() => {
+      this.#flushTimer = undefined;
+      if (
+        this.#ongoingWrite ||
+        this.#nextParts.length === 0 ||
+        this.#stoppedAccepting ||
+        this.abortController.signal.aborted
+      ) {
+        return;
+      }
+      // A write can start and land while this wake is armed, which moves the
+      // deadline out from under it. Re-arm against the current one rather
+      // than publishing early.
+      if (Date.now() - this.#latestWrite < this.config.throttleMs) {
+        this.#scheduleFlush();
+        return;
+      }
+      this.#ongoingWrite = this.#sendDelta();
+    }, wait);
+  }
+
+  #cancelScheduledFlush() {
+    if (this.#flushTimer) {
+      clearTimeout(this.#flushTimer);
+      this.#flushTimer = undefined;
     }
   }
 
@@ -407,6 +448,7 @@ export class DeltaStreamer<T> {
    * duration of the drain, which drops more of the tail than it saves.
    */
   public async flushAndStopAccepting(): Promise<void> {
+    this.#cancelScheduledFlush();
     await this.#flushPendingParts();
     this.#stoppedAccepting = true;
   }
@@ -438,6 +480,7 @@ export class DeltaStreamer<T> {
   }
 
   async #sendDelta() {
+    this.#cancelScheduledFlush();
     if (this.abortController.signal.aborted) {
       return;
     }
@@ -477,6 +520,11 @@ export class DeltaStreamer<T> {
       this.#ongoingWrite = this.#sendDelta();
     } else {
       this.#ongoingWrite = undefined;
+      // Whatever is still buffered has just lost its owner: this write is
+      // over and no arrival is guaranteed to follow. Hand it to the timer.
+      if (this.#nextParts.length > 0) {
+        this.#scheduleFlush();
+      }
     }
   }
 
@@ -513,6 +561,7 @@ export class DeltaStreamer<T> {
   }
 
   public async finish() {
+    this.#cancelScheduledFlush();
     if (!this.streamId) {
       return;
     }
@@ -557,6 +606,7 @@ export class DeltaStreamer<T> {
 
   #abort(reason: string, waitForOngoingWrite = true): Promise<void> {
     if (!this.#abortPromise) {
+      this.#cancelScheduledFlush();
       this.abortController.abort();
       this.#abortPromise = this.#abortCreatedStream(
         reason,


### PR DESCRIPTION
Fixes https://github.com/get-convex/agent/issues/221

The throttle was only reconsidered when the next part arrived. During a pause, buffered updates waited for more output instead of being published when the throttle window elapsed.

A slow tool is the worst case by construction. The AI SDK emits `tool-input-available` before the tool runs, measured against a 150ms tool:

```
+  9ms  tool-input-available
+ 11ms  TOOL starts
+162ms  TOOL ends
+163ms  tool-output-available
```

At +9ms the previous write was too recent, so the input stayed buffered. Nothing arrived for another 154ms. When the tool output landed, both flushed together, making the UI jump straight to `output-available`.

**What changed**

Schedule a flush when buffered content is waiting, both when a part arrives and when an active write completes. The timer rechecks the current throttle deadline before publishing, so slow writes cannot strand content or cause an early flush.