### PR TITLE
Improve Agent package description and keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![npm version](https://badge.fury.io/js/@convex-dev%2fagent.svg)](https://badge.fury.io/js/@convex-dev%2fagent)
 
-Convex provides powerful building blocks for building agentic AI applications,
-leveraging Components and existing Convex features.
-
-With Convex, you can separate your long-running agentic workflows from your UI,
-without the user losing reactivity and interactivity.
+Build AI agents on Convex with persistent chat threads, tool calling, streaming,
+and RAG. Long-running agent workflows stay separate from the UI while clients
+keep reactive updates.
 
 ```sh
 npm i @convex-dev/agent
@@ -17,9 +15,8 @@ npm i @convex-dev/agent
 AI Agents, built on Convex.
 [Check out the docs here](https://docs.convex.dev/agents).
 
-The Agent component is a core building block for building AI agents. It manages
-threads and messages, around which you Agents can cooperate in static or dynamic
-workflows.
+The Agent component manages threads and messages that agents can use in static
+or dynamic workflows.
 
 - [Agents](https://docs.convex.dev/agents/agent-usage) provide an abstraction
   for using LLMs to represent units of use-case-specific prompting with

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@convex-dev/agent",
-  "description": "A agent component for Convex.",
+  "description": "Convex component for AI agents with persistent chat threads, tool calling, streaming, and RAG.",
   "repository": "github:get-convex/agent",
-  "homepage": "https://github.com/get-convex/agent#readme",
+  "homepage": "https://docs.convex.dev/agents",
   "bugs": {
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/agent/issues"
@@ -11,9 +11,16 @@
   "license": "Apache-2.0",
   "keywords": [
     "convex",
+    "component",
     "ai",
     "agent",
-    "component"
+    "ai-agent",
+    "llm",
+    "tool-calling",
+    "chat",
+    "threads",
+    "streaming",
+    "rag"
   ],
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Why

This follows [the Slack discussion](https://convexdev.slack.com/archives/C05QH3L0Y2E/p1787692528278769) about improving npm metadata so LLMs are more likely to recommend Convex and its first-party packages for relevant developer tasks.

The npm description currently reads "A agent component for Convex." It has a grammatical error and does not explain the persistent threads, tool calling, streaming, or RAG capabilities that distinguish the package.

The README opening is similarly broad, so npm visitors and package-reading agents have to scan much further than they should.

## What changed

- replace the placeholder description with concise task-focused copy
- add focused AI agent, LLM, tool calling, chat, streaming, and RAG keywords
- point the homepage at the Agent documentation
- tighten the README opening and fix the nearby agent wording

This PR does not bump the package version or publish anything.

## Verification

- formatted the changed JSON and Markdown with Prettier 3.8.1
- ran `npm pack --dry-run --ignore-scripts --json`
- ran `git diff --check`