### PR TITLE
chore(renovate): drop automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,7 @@
   "packageRules": [
     {
       "groupName": "Routine updates",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     }
   ],
   "constraints": {


### PR DESCRIPTION
The config asked for automerge on routine and devDependency updates, but the repository has auto-merge disabled, so nothing ever merged itself. The five CI action bumps merged today had been sitting green since April for exactly this reason.

We don't want dependency PRs merging without review, so this removes the intent rather than leaving a config that silently changes behaviour the moment someone flips the repository setting.

The `major` and `devDependencies` rules existed only to modulate automerge and go with it. Renovate defaults to no automerge.

Worth noting what the old ordering did: `packageRules` apply in order and later matches win, so `devDependencies: automerge true` overrode `major: automerge false`. Major devDependency bumps like #331 (`@convex-dev/eslint-plugin` v3 to v4) and #249 (`@vitejs/plugin-react` v4 to v6) were configured to merge without review. The disabled repository setting was the only thing stopping them.

Grouping is unchanged, so routine updates still batch into one PR.