### PR TITLE
fix(tsconfig): declare ES2022 lib to match the code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "react-jsx",
 
     "target": "ESNext",
-    "lib": ["ES2021", "dom", "dom.iterable"],
+    "lib": ["ES2022", "dom", "dom.iterable"],
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     // We enforce stricter module resolution for Node16 compatibility


### PR DESCRIPTION
`tsconfig.json` declared `"lib": ["ES2021", ...]` while `"target"` was already `ESNext`. The code uses `Array.prototype.at` in `messages.ts`, `shared.ts`, `UIMessages.ts`, `search.ts`, `saveInputMessages.ts` and others, which is ES2022.

It typechecked anyway because `@types/node` 22 supplied those signatures incidentally. `@types/node` 24 doesn't, so 42 `TS2550` errors appear:

```
error TS2550: Property 'at' does not exist on type '...'.
Do you need to change your target library?
Try changing the 'lib' compiler option to 'es2022' or later.
```

Found while triaging #339 (node v24), which is blocked on exactly this. Landing it separately since the mismatch is on main today and isn't specific to that upgrade.

Verified on both `@types/node` 22 (this branch) and 24 (#339 branch): typecheck clean, lint clean, 352 tests pass.