### PR TITLE
fix(playground): react-resizable-panels v4 + component update

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -54,7 +54,7 @@
         "react-day-picker": "^9.8.0",
         "react-dom": "^19.2.3",
         "react-hook-form": "^7.53.0",
-        "react-resizable-panels": "^2.1.3",
+        "react-resizable-panels": "^4.0.0",
         "react-router-dom": "^7.18.2",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
@@ -141,7 +141,7 @@
         "eslint-plugin-react-refresh": "0.5.2",
         "globals": "17.11.0",
         "lucide-react": "0.577.0",
-        "openai": "5.23.2",
+        "openai": "7.5.0",
         "pkg-pr-new": "0.0.66",
         "postcss": "8.5.23",
         "prettier": "3.8.1",
@@ -6073,13 +6073,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
-      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.3.tgz",
+      "integrity": "sha512-GHMJWnDXui/3RX4bT+cgBP+N3N2nkwcoZATr/2xLFpqQQe7TlBrE0cGM0dUa9ceT7A90tUrSRsiqgRG+g0/2AA==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-router": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -87,7 +87,7 @@
     "react-day-picker": "^9.8.0",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.53.0",
-    "react-resizable-panels": "^2.1.3",
+    "react-resizable-panels": "^4.0.0",
     "react-router-dom": "^7.18.2",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",

--- a/playground/src/components/ui/resizable.tsx
+++ b/playground/src/components/ui/resizable.tsx
@@ -6,8 +6,8 @@ import { cn } from "@/lib/utils";
 const ResizablePanelGroup = ({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
-  <ResizablePrimitive.PanelGroup
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
+  <ResizablePrimitive.Group
     className={cn(
       "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
       className,
@@ -22,10 +22,10 @@ const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean;
 }) => (
-  <ResizablePrimitive.PanelResizeHandle
+  <ResizablePrimitive.Separator
     className={cn(
       "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className,
@@ -37,7 +37,7 @@ const ResizableHandle = ({
         <GripVertical className="h-2.5 w-2.5" />
       </div>
     )}
-  </ResizablePrimitive.PanelResizeHandle>
+  </ResizablePrimitive.Separator>
 );
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/playground/src/components/ui/resizable.tsx
+++ b/playground/src/components/ui/resizable.tsx
@@ -9,7 +9,7 @@ const ResizablePanelGroup = ({
 }: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
   <ResizablePrimitive.Group
     className={cn(
-      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      "flex h-full w-full",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const ResizableHandle = ({
 }) => (
   <ResizablePrimitive.Separator
     className={cn(
-      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0 [&[aria-orientation=horizontal]>div]:rotate-90",
       className,
     )}
     {...props}


### PR DESCRIPTION
Supersedes #343.

That PR bumps `react-resizable-panels` to v4, which passes CI but adds 5 typecheck errors to `playground/src/components/ui/resizable.tsx`. v4 renamed the exports:

| v2 | v4 |
| --- | --- |
| `PanelGroup` | `Group` |
| `PanelResizeHandle` | `Separator` |
| `Panel` | `Panel` |

The rename isn't backward compatible, so the component fix can't land ahead of the bump. This carries both.

### Verification

Playground typecheck, with a fresh `npm ci` per ref:

| ref | total | `resizable.tsx` |
| --- | --- | --- |
| `main` | 6 | 0 |
| #343 alone | 10 | 5 |
| this branch | 5 | 0 |

`vite build` and `eslint` pass. The 5 remaining are pre-existing in `calendar.tsx` and `Play.tsx`.

### Why CI missed it on #343

`vite build` tree-shakes the component out (bundle hash is identical across main and #343), and `vite build` doesn't typecheck. `eslint` doesn't either. No workflow runs `tsc` against `playground/tsconfig.app.json` — the root `typecheck` script covers `.`, `example`, and `example/convex` only.