### PR TITLE
Add user-scoped file ownership and safe storage cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Add optional file ownership (#264): `storeFile` accepts `userId`,
+  deduplication is scoped to that user, and `getFile` accepts
+  `{ requireUserId }` to reject other users' and ownerless files before
+  returning storage URLs. Automatic file saving carries the message/generation
+  user through streaming and finalization. Existing unchecked calls remain
+  supported; legacy rows are not backfilled.
+- Add `files.deleteFilesWithStorageIds` for cleanup that preserves blobs shared
+  by multiple file records. Call it and delete its returned blobs in one app
+  mutation; update custom vacuum jobs accordingly.
+- Offload oversized base64/data-URL and reasoning files during message
+  serialization so SDK responses retain their streamed file references.
+
 - Preserve classified provider errors when streamed responses fail, including
   aborts racing late message writes (#320). `DeltaStreamer.getOrCreateStreamId`
   now accepts `{ ifAborted: "returnUndefined" }` for abort-aware writes; its

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -68,10 +68,28 @@ No message-data migration is required. Agent reads messages saved by v0.6 and
 writes new streams in the AI SDK 7 `UIMessageChunk` format. The stream reader
 uses one reducer for the v0.6-compatible subset and the v0.7 superset.
 
-This release does not offload every oversized inline file encoding. Top-level
-`ArrayBuffer` image/file inputs and URL-backed files continue to work.
-Reasoning files, nested tool-result files, and tagged/base64/data-URL payloads
-will gain durable offloading separately.
+Oversized inline images, files, reasoning files, and canonical tool-result files
+are saved to storage from actions, including tagged/base64/data-URL payloads.
+Mutations must store these files in an action first, then pass their URLs and
+file IDs. Application-defined tool output shapes remain opaque.
+
+File records now have optional `userId` ownership. New automatically stored
+files inherit the explicit user or thread owner; explicit `storeFile` calls
+should pass `{ userId }`. Deduplication stays within that user scope, so new
+uploads may duplicate older unscoped content. Existing file records are not
+backfilled because they may be shared across users.
+
+Use `getFile(ctx, component, fileId, { requireUserId })` with an authenticated
+user ID to enforce owner-only access. This rejects ownerless legacy rows as well
+as another user's rows. Existing calls without the option retain their trusted
+server behavior; upgrading alone does not secure an app's existing wrappers.
+Keep any custom sharing authorization in the application.
+
+If your vacuum job deletes storage blobs, switch from `files.deleteFiles` to
+`files.deleteFilesWithStorageIds`. Delete only its returned `storageIdsToDelete`
+in the same app mutation, allowing errors to roll back both operations. The new
+operation protects storage still referenced by another file record. See the
+[file documentation](./docs/files.mdx) for the updated flow.
 
 ## 5. Verify
 

--- a/docs/files.mdx
+++ b/docs/files.mdx
@@ -60,11 +60,16 @@ the client waiting.
 import { storeFile } from "@convex-dev/agent";
 import { components } from "./_generated/api";
 
+// Use your app's authentication helper and the same user IDs as your threads.
+const userId = await getAuthUserId(ctx);
+if (!userId) throw new Error("Unauthorized");
+
 const { file } = await storeFile(
   ctx,
   components.agent,
   new Blob([bytes], { type: mimeType }),
   {
+    userId,
     filename,
     sha256,
   },
@@ -75,8 +80,12 @@ const { fileId, url, storageId } = file;
 ### 2: Sending the message
 
 ```ts
-// in your mutation
-const { filePart, imagePart } = await getFile(ctx, components.agent, fileId);
+// In your mutation, authenticate again before resolving a client-provided fileId.
+const userId = await getAuthUserId(ctx);
+if (!userId) throw new Error("Unauthorized");
+const { filePart, imagePart } = await getFile(ctx, components.agent, fileId, {
+  requireUserId: userId,
+});
 const { messageId } = await fileAgent.saveMessage(ctx, {
   threadId,
   message: {
@@ -89,6 +98,28 @@ const { messageId } = await fileAgent.saveMessage(ctx, {
   metadata: { fileIds: [fileId] }, // IMPORTANT: this tracks the file usage.
 });
 ```
+
+`storeFile` deduplicates within the supplied `userId`, hash, filename, and
+compatible media type. Different users uploading identical content get separate
+file records and storage objects. Both helpers return `file.userId` alongside
+the other file metadata.
+
+`getFile(..., { requireUserId })` rejects other users' files and ownerless
+legacy files before resolving their storage URLs. Derive this identifier from
+your app's authentication, never a browser-supplied user ID. The repository
+examples use a demo `getAuthUserId` stub; replace it with real authentication in
+your app. Also authorize access to the destination thread before attaching the
+file.
+
+Omitting the fourth argument preserves the existing trusted-server lookup for
+apps that apply their own sharing policy. Existing ownerless files remain in an
+unscoped pool and are not assigned an owner automatically. Unscoped files do not
+isolate anonymous sessions. Scoped uploads never reuse ownerless rows, so
+upgrading can increase storage use for previously shared content.
+
+This check controls metadata and URL retrieval. Authorize message and stream
+reads separately, since their content already contains URLs. It does not add
+per-download authorization or revoke URLs previously returned to a caller.
 
 ### 3: Generating the response & querying the responses
 
@@ -110,6 +141,13 @@ You can also pass in an image / file direction when generating text, if you're
 in an action. Any image or file passed in the `message` argument will
 automatically be saved in file storage if it's larger than 64k, and a fileId
 will be saved to the message.
+
+Automatically saved files inherit the explicitly supplied user ID, falling back
+to the thread's user. This applies to input messages, generated files, reasoning
+files, canonical tool-result files, and persisted streaming chunks. Message
+updates use the existing message's user, falling back to its thread. An
+anonymous thread without an explicit user remains unscoped. Attaching or cloning
+an existing file reference does not transfer its owner.
 
 Example:
 
@@ -158,6 +196,38 @@ await thread.generateText({
   },
 });
 ```
+
+### Cleaning up unused files
+
+File reference counts track retention by messages and in-flight streams,
+separately from `userId`. Registration starts at zero references; registration,
+reuse, and reference changes protect a file for 24 hours before it becomes
+eligible for cleanup.
+
+Use `getFilesToDelete` to page through candidates. From an app **mutation**,
+call `deleteFilesWithStorageIds` to recheck eligibility and delete their
+records, then delete only the returned storage IDs in that same mutation:
+
+```ts
+const { storageIdsToDelete } = await ctx.runMutation(
+  components.agent.files.deleteFilesWithStorageIds,
+  { fileIds: candidates.page.map((file) => file._id) },
+);
+for (const storageId of storageIdsToDelete) {
+  await ctx.storage.delete(storageId as Id<"_storage">);
+}
+```
+
+Import `Id` from your app's generated data model. Let errors propagate so the
+record and blob deletions roll back together. Do not split these operations
+across action calls. A blob is returned for deletion only when no other file
+record references its storage ID, even when `force` is used. Keep cleanup
+internal to your app; it is a maintenance API, not a user-authorized delete API.
+See [files/vacuum.ts](../example/convex/files/vacuum.ts) for a paginated job.
+
+Existing `deleteFiles` calls still return deleted file IDs. Update custom vacuum
+jobs that also delete blobs to use `deleteFilesWithStorageIds` so that one file
+record's cleanup cannot delete another record's shared storage.
 
 ## Generating images
 

--- a/docs/proposals/264-file-ownership.md
+++ b/docs/proposals/264-file-ownership.md
@@ -1,0 +1,215 @@
+# Proposal: user ownership for Agent files (#264)
+
+Draft against `origin/main` at `3cd5eb0faf7856783e59b1a13f0224f4472196b2`
+(package `0.7.1`, AI SDK v7). Related issue:
+[#264 — userId in the files table](https://github.com/get-convex/agent/issues/264).
+Design recorded before implementation. See the file documentation and changelog
+for the implemented API and migration guidance.
+
+**Recommendation.** Add optional `files.userId`, scope file deduplication to
+that user, and add an explicit ownership check to `getFile`. Carry the resolved
+user through every v7 path that stores files, including streamed file chunks and
+tool results. Keep authorization ownership separate from the existing reference
+count, which controls how long files are retained.
+
+The benefit is a single document read and owner comparison, without searching
+messages to establish ownership. Alice uploading a PDF twice can reuse her file;
+Bob uploading the same PDF gets his own file record and storage object. The cost
+is additional rows and bytes for identical content uploaded by different users.
+This is a deliberate change from global deduplication.
+
+**Current behavior and the security boundary.**
+
+| Surface                                                           | Behavior on this v7 base                                                        | Proposed change                                                      |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [File schema](../../src/component/schema.ts)                      | No user field; hash and cleanup indexes                                         | Optional owner and scoped dedup index                                |
+| [Component file functions](../../src/component/files.ts)          | Global hash/filename candidates, with normalized media-type matching            | Scope both lookup and registration by owner                          |
+| [File helpers](../../src/vercel/client/files.ts)                  | `getFile` fetches metadata and a storage URL without checking an owner          | Optional strict owner check before URL lookup; return owner metadata |
+| [Serialization](../../src/vercel/mapping.ts)                      | Large images, files, and canonical tool-result files can create file rows       | Propagate the resolved owner                                         |
+| [Stream materialization](../../src/vercel/fileMaterialization.ts) | Oversized file/reasoning-file chunks and tool outputs acquire stream references | Use the same owner as final message serialization                    |
+| [Stream lifecycle](../../src/component/streams.ts)                | Stream references protect files until finalization, abort, or recovery          | Preserve reference transfer and cleanup semantics                    |
+
+The earlier evaluation overstated the reachability of `files.get`. Component
+functions are called by the parent application's server functions, not directly
+by browser clients. Components also do not receive `ctx.auth`; the application
+authenticates the caller and passes its user identifier. This is the documented
+[component API and authentication boundary](https://docs.convex.dev/components/authoring).
+
+There is still a concrete unsafe example to fix:
+[`submitFileQuestion`](../../example/convex/files/addFile.ts) verifies that
+someone is signed in, then accepts any `fileId` without checking whose file it
+is. The proposal gives that wrapper a cheap ownership check. It does not make
+every existing application wrapper secure automatically.
+
+**Proposed API.** These are additions to the existing package exports:
+
+```ts
+// App server code: derive the same user identifier used for thread ownership.
+const userId = await getAuthUserId(ctx);
+if (!userId) throw new Error("Unauthorized");
+
+const { file } = await storeFile(ctx, components.agent, blob, {
+  filename,
+  sha256,
+  userId,
+});
+
+const { filePart, imagePart } = await getFile(ctx, components.agent, fileId, {
+  requireUserId: userId,
+});
+```
+
+`storeFile` gains `userId?: string` in its existing options. Both helpers return
+`file.userId?: string`. The optional fourth argument to `getFile` has type
+`{ requireUserId: string }`; omitting the argument preserves the existing
+trusted-server behavior. Do not accept the requester identity from browser
+arguments or silently skip the check when authentication fails.
+
+Add `requireUserId: v.optional(v.string())` to the component `files.get`
+arguments. When supplied, return `null` unless the row exists and its `userId`
+equals the requested user. The helper treats that as “File not found” and never
+calls `ctx.storage.getUrl` for the rejected file. Missing and wrong-owner rows
+use the same error. Existing calls without this option retain their behavior.
+
+| Stored owner               | Requested owner    | Checked read                     |
+| -------------------------- | ------------------ | -------------------------------- |
+| Alice                      | Alice              | Allowed                          |
+| Alice                      | Bob                | Denied                           |
+| Unset (legacy or unscoped) | Alice              | Denied                           |
+| Any                        | No check requested | Existing trusted-server behavior |
+
+In particular, the earlier suggestion that legacy rows should pass a requested
+ownership check is withdrawn. Unset ownership cannot establish Alice's access.
+An unscoped upload remains possible for compatibility, but that shared scope
+does not isolate anonymous sessions. Apps needing that isolation should pass a
+stable, server-verified session identifier in their ownership namespace.
+
+Existing custom sharing policies can continue to authorize access in app code
+before using the unchecked helper. Knowing a `fileId` is not authorization.
+Applications must also authorize thread/message reads and attachments: an
+already-stored URL in a message does not pass through `getFile` again. This
+proposal adds no per-download authorization or revocation of issued URLs.
+
+**Schema and deduplication.** Add `userId: v.optional(v.string())` to `files`
+and an index named `userId_hash_filename` on those three fields. Preserve
+`refcount`, `refcount_lastTouchedAt`, and initially `hash` for a staged rollout.
+The new index's user prefix also supports paginated owner listings if added
+later; no user-deletion convenience API is needed to deliver #264.
+
+Both `addFile`/`addFileHandler` and `useExistingFile` must accept the optional
+owner and use the same indexed `(userId, hash, filename)` candidate range.
+Persist the owner only when creating a row; a cache hit must never reassign
+ownership. An explicitly scoped request must not fall back to an unscoped row.
+Omitted owners match only other unscoped rows.
+
+Within that range, retain v7's `normalizeMediaType` and `sameMediaType`
+behavior, including the deprecated `mimeType` fallback and reuse of rows with no
+media type. The current `.collect().find(...)` exists because one hash/filename
+can have distinct media types. Replacing it with `.first()` would change
+behavior. Prefer lazy candidate iteration that stops on a compatible match; do
+not use an arbitrary `take(n)` that can miss a later compatible candidate.
+
+The client must pass the owner to both its pre-upload lookup and post-upload
+registration. Preserve the losing-upload cleanup in `storeFile`: concurrent
+uploads by one user may create two temporary blobs, but only the winner stays
+registered. Uploads by different users must not compete for that row.
+
+**Changes across the v7 code.**
+
+| Area                                                                                                            | Required work                                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Explicit message saves](../../src/vercel/client/messages.ts)                                                   | Resolve `args.userId ?? thread.userId` before serializing a batch, matching generation's existing fallback; pass it through `serializeMessage` and `serializeContent` |
+| [Generation](../../src/vercel/client/start.ts)                                                                  | Reuse the user already resolved by `startGeneration` for prompt and response serialization, including `serializeResponseMessages`                                     |
+| [Streaming](../../src/vercel/client/streamText.ts)                                                              | Pass that same resolved user into the `DeltaStreamer` materialization callback                                                                                        |
+| [File materialization](../../src/vercel/fileMaterialization.ts)                                                 | Thread the owner through UI chunks, reasoning files, canonical tool-result content, and `materializeInlineFile` into `storeFile`                                      |
+| [Message updates](../../src/vercel/index.ts)                                                                    | Load the existing message and resolve its user/thread owner before serializing replacement content; the current update API only receives a message ID                 |
+| [Canonical persistence](../../src/client/messages.ts) and [component messages](../../src/component/messages.ts) | Preserve supplied file IDs and their owners; do not relabel existing files when attaching or cloning messages                                                         |
+| Public types and generated API                                                                                  | Update file result types and options; regenerate component API types using repository codegen rather than editing generated declarations                              |
+| [File docs](../files.mdx) and [upload example](../../example/convex/files/addFile.ts)                           | Supply the authenticated user on upload and require it when resolving a client-provided file ID                                                                       |
+
+Capture the owner once for a generation so its streamed and finalized files
+deduplicate together. Explicit user IDs are supplied by trusted application
+code; thread fallback is metadata resolution, not an authorization check. Keep
+the existing nullish fallback semantics. An anonymous thread with no supplied
+user remains unscoped. Changing a thread's user later does not transfer existing
+file ownership.
+
+The reference-counting helpers remain concerned with retention. In particular,
+`copyFile` currently increments a reference on the same row. Keep its signature
+and behavior; adding `toUserId` would turn it into a different operation.
+Likewise, trusted cross-user message clones preserve the original file owner and
+require the application's sharing policy for subsequent access. An explicit
+cross-user copy/transfer API and an access-grant table are separate proposals.
+
+**Cleanup and storage aliases.** Preserve registration at `refcount: 0`,
+`lastTouchedAt` refresh on reuse, the 24-hour grace period, and set-based
+reference changes. Stream finalization and recovery must acquire message
+references before releasing stream references, as v7 does today.
+
+Per-user uploads through `storeFile` naturally create separate blobs, so owner
+scoping alone does not require a new blob table or persistent blob counter.
+However, direct `addFile` calls already permit multiple rows to name the same
+`storageId` (for example, different filenames). Cleanup must account for those
+aliases before any design introduces more of them.
+
+Include an indexed storage-alias check in the implementation: add a `storageId`
+index and an additive component mutation, tentatively
+`deleteFilesWithStorageIds`, returning `{ deletedFileIds, storageIdsToDelete }`.
+It should share the existing eligibility checks, delete eligible rows, and
+return each storage ID only if no file row still references it. Keep the
+existing `deleteFiles` return shape for compatibility. This needs an existence
+lookup per distinct storage ID, not a scan/count of every alias.
+
+Update the vacuum example to call this operation and then delete only the
+returned blobs in the same parent-app mutation. Propagate deletion errors so the
+whole operation rolls back. Do not split it into an action that commits row
+deletion before blob deletion. Convex supports
+[transactional changes across component calls](https://docs.convex.dev/components/understanding#isolation).
+Keep `force` a trusted maintenance operation; it must not bypass the
+remaining-alias check. Document the same change for apps with custom vacuum
+jobs.
+
+**Compatibility and rollout.** Ship optional schema fields and additive API
+arguments first, then update all creation paths and examples together. Existing
+rows remain unscoped; existing unchecked calls still work. New scoped uploads
+may duplicate old unscoped content. That storage cost is preferable to silently
+claiming a shared legacy row. Do not describe this as automatic security
+enforcement for existing installations.
+
+Do not run an automatic owner backfill. A file may be referenced by multiple
+users' messages, live streams, trusted clones, or app-side records the component
+cannot inspect. A future opt-in migration should first produce a paginated
+reference report, reconcile message and stream owners, and leave ambiguous or
+unreferenced rows untouched. Apply assignments only with application-level
+evidence and controlled concurrent writes; never assign the first user found.
+Splitting shared legacy rows also requires rewriting references and maintaining
+blob cleanup, so it is outside this initial change.
+
+**Acceptance criteria for implementation.**
+
+- Alice can read her file through the checked helper; Bob and an unauthenticated
+  app caller cannot. A requested check also rejects legacy rows, and rejected
+  reads never resolve storage URLs. Cover the actual app wrapper, including a
+  client attempting to supply another user's identity.
+- Equal owner/hash/filename and compatible media type reuse one row. Different
+  owners and scoped-versus-unscoped requests do not. Preserve legacy media-type
+  matching and filename distinctions in both dedup entry points.
+- Concurrent same-user uploads remove losing blobs; different-user uploads
+  retain their own blobs. Existing missing-storage and cleanup-error behavior
+  remains covered by the client tests.
+- Explicit saves, thread-only generation, assistant files, tool-result files,
+  message updates, and streamed reasoning/file chunks receive the expected
+  owner. Finalization reuses stream-created rows, including when only a thread
+  ID was supplied. Anonymous paths remain usable.
+- Finalization, abort, timeout recovery, message deletion, and same-user cloning
+  preserve refcounts and grace periods. Cross-user trusted cloning does not
+  reassign ownership or make an owner-only read succeed for the recipient.
+- Deleting one storage alias preserves the blob while any alias remains,
+  including a fresh zero-refcount alias. Deleting the last eligible alias
+  deletes the blob; failures roll back; `force` cannot orphan another alias.
+- Old API calls and ownerless fixtures still work. Extend the existing file,
+  mapping, stream, and integration suites, then run build/codegen, tests, lint,
+  and typechecking. The implementation should satisfy these checks.
+
+This scope supplies a useful owner field and enforceable owner-only retrieval
+without choosing a general sharing or account-deletion policy for applications.

--- a/example/convex/files/addFile.ts
+++ b/example/convex/files/addFile.ts
@@ -45,6 +45,7 @@ export const uploadFile = action({
       components.agent,
       new Blob([args.bytes], { type: args.mimeType }),
       {
+        userId,
         filename: args.filename,
         sha256: args.sha256,
       },
@@ -69,6 +70,7 @@ export const submitFileQuestion = mutation({
       ctx,
       components.agent,
       args.fileId,
+      { requireUserId: userId },
     );
     const { messageId } = await saveMessage(ctx, components.agent, {
       threadId,

--- a/example/convex/files/vacuum.ts
+++ b/example/convex/files/vacuum.ts
@@ -4,8 +4,6 @@ import { v } from "convex/values";
 import { components, internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
 
-const THRESHOLD_MS = 1000 * 60 * 60 * 24; // 24 hours
-
 // Registered in convex/crons.ts
 export const deleteUnusedFiles = internalMutation({
   args: { cursor: v.optional(v.string()) },
@@ -16,24 +14,21 @@ export const deleteUnusedFiles = internalMutation({
         numItems: 100,
       },
     });
-    // Only delete files that haven't been touched in the last 24 hours
-    const toDelete = files.page.filter(
-      (f) => f.lastTouchedAt < Date.now() - THRESHOLD_MS,
+    // Recheck eligibility and only delete blobs with no remaining file records.
+    const { storageIdsToDelete } = await ctx.runMutation(
+      components.agent.files.deleteFilesWithStorageIds,
+      { fileIds: files.page.map((file) => file._id) },
     );
-    if (toDelete.length > 0) {
-      console.debug(`Deleting ${toDelete.length} files...`);
-    }
+    // Both operations share this mutation's transaction. Let storage errors
+    // propagate so that deleting the component records also rolls back.
     await Promise.all(
-      toDelete.map((f) => ctx.storage.delete(f.storageId as Id<"_storage">)),
+      storageIdsToDelete.map((storageId) =>
+        ctx.storage.delete(storageId as Id<"_storage">),
+      ),
     );
-    // Also mark them as deleted in the component.
-    // This is in a transaction (mutation), so there's no races.
-    await ctx.runMutation(components.agent.files.deleteFiles, {
-      fileIds: toDelete.map((f) => f._id),
-    });
     if (!files.isDone) {
       console.debug(
-        `Deleted ${toDelete.length} files but not done yet, continuing...`,
+        `Deleted ${storageIdsToDelete.length} blobs but not done yet, continuing...`,
       );
       await ctx.scheduler.runAfter(0, internal.files.vacuum.deleteUnusedFiles, {
         cursor: files.continueCursor,

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -59,6 +59,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           mediaType?: string;
           mimeType?: string;
           storageId: string;
+          userId?: string;
         },
         { fileId: string; storageId: string },
         Name
@@ -77,10 +78,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         Array<string>,
         Name
       >;
+      deleteFilesWithStorageIds: FunctionReference<
+        "mutation",
+        "internal",
+        { fileIds: Array<string>; force?: boolean },
+        { deletedFileIds: Array<string>; storageIdsToDelete: Array<string> },
+        Name
+      >;
       get: FunctionReference<
         "query",
         "internal",
-        { fileId: string },
+        { fileId: string; requireUserId?: string },
         null | {
           _creationTime: number;
           _id: string;
@@ -91,6 +99,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           mimeType?: string;
           refcount: number;
           storageId: string;
+          userId?: string;
         },
         Name
       >;
@@ -120,6 +129,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             mimeType?: string;
             refcount: number;
             storageId: string;
+            userId?: string;
           }>;
         },
         Name
@@ -127,7 +137,12 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       useExistingFile: FunctionReference<
         "mutation",
         "internal",
-        { filename?: string; hash: string; mediaType?: string },
+        {
+          filename?: string;
+          hash: string;
+          mediaType?: string;
+          userId?: string;
+        },
         null | { fileId: string; storageId: string },
         Name
       >;

--- a/src/component/files.test.ts
+++ b/src/component/files.test.ts
@@ -203,3 +203,221 @@ describe("files", () => {
     ).resolves.toMatchObject({ page: [] });
   });
 });
+
+describe("file user ownership", () => {
+  afterEach(() => vi.useRealTimers());
+
+  test("deduplication and checked reads isolate users and the unscoped pool", async () => {
+    const t = convexTest(schema, modules);
+    const files = [];
+    for (const userId of [undefined, "alice", "bob"]) {
+      const args = {
+        userId,
+        hash: "same",
+        filename: "same.pdf",
+        mediaType: "application/pdf",
+      };
+      const file = await t.mutation(api.files.addFile, {
+        ...args,
+        storageId: `storage-${userId}`,
+      });
+      files.push(file);
+      await expect(
+        t.mutation(api.files.useExistingFile, args),
+      ).resolves.toEqual(file);
+      await expect(
+        t.mutation(api.files.addFile, { ...args, storageId: "losing-upload" }),
+      ).resolves.toEqual(file);
+      await expect(
+        t.query(api.files.get, { fileId: file.fileId }),
+      ).resolves.toMatchObject({
+        storageId: `storage-${userId}`,
+        refcount: 0,
+      });
+    }
+    expect(new Set(files.map((file) => file.fileId)).size).toBe(3);
+    await expect(
+      t.mutation(api.files.useExistingFile, {
+        userId: "charlie",
+        hash: "same",
+        filename: "same.pdf",
+      }),
+    ).resolves.toBeNull();
+    for (const [index, file] of files.entries()) {
+      const checked = await t.query(api.files.get, {
+        fileId: file.fileId,
+        requireUserId: "alice",
+      });
+      if (index === 1) expect(checked?.userId).toBe("alice");
+      else expect(checked).toBeNull();
+    }
+    await t.mutation(api.files.deleteFiles, {
+      fileIds: [files[1].fileId],
+      force: true,
+    });
+    await expect(
+      t.query(api.files.get, {
+        fileId: files[1].fileId,
+        requireUserId: "alice",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("scoped lookups preserve normalized media, legacy mimeType, and filename matching", async () => {
+    const t = convexTest(schema, modules);
+    const args = { userId: "alice", hash: "same", filename: "same" };
+    await t.mutation(api.files.addFile, {
+      ...args,
+      storageId: "pdf",
+      mediaType: "application/pdf",
+    });
+    const text = await t.mutation(api.files.addFile, {
+      ...args,
+      storageId: "text",
+      mimeType: " Text/Plain ",
+    });
+    // The first row has a different media type; both entry points must keep looking.
+    await expect(
+      t.mutation(api.files.useExistingFile, {
+        ...args,
+        mediaType: " TEXT/PLAIN ",
+      }),
+    ).resolves.toEqual(text);
+    await expect(
+      t.mutation(api.files.addFile, {
+        ...args,
+        storageId: "new",
+        mediaType: "text/plain",
+      }),
+    ).resolves.toEqual(text);
+    await expect(
+      t.mutation(api.files.useExistingFile, { ...args, filename: undefined }),
+    ).resolves.toBeNull();
+    await expect(
+      t.mutation(api.files.useExistingFile, { ...args, userId: undefined }),
+    ).resolves.toBeNull();
+
+    const legacy = await t.run((ctx) =>
+      ctx.db.insert("files", {
+        userId: "alice",
+        storageId: "legacy",
+        hash: "legacy",
+        mimeType: "TEXT/PLAIN",
+        refcount: 0,
+        lastTouchedAt: Date.now(),
+      }),
+    );
+    await expect(
+      t.mutation(api.files.useExistingFile, {
+        userId: "alice",
+        hash: "legacy",
+        mediaType: "text/plain",
+      }),
+    ).resolves.toMatchObject({ fileId: legacy });
+    const unknown = await t.mutation(api.files.addFile, {
+      userId: "alice",
+      storageId: "unknown",
+      hash: "unknown",
+    });
+    await expect(
+      t.mutation(api.files.addFile, {
+        userId: "alice",
+        storageId: "new-unknown",
+        hash: "unknown",
+        mediaType: "image/png",
+      }),
+    ).resolves.toEqual(unknown);
+  });
+
+  test("a fresh zero-reference alias protects a shared blob until its own grace expires", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const old = await t.mutation(api.files.addFile, {
+      userId: "alice",
+      storageId: "shared",
+      hash: "same",
+    });
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    const fresh = await t.mutation(api.files.addFile, {
+      userId: "bob",
+      storageId: "shared",
+      hash: "same",
+    });
+    await expect(
+      t.mutation(api.files.deleteFilesWithStorageIds, {
+        fileIds: [old.fileId],
+      }),
+    ).resolves.toEqual({
+      deletedFileIds: [old.fileId],
+      storageIdsToDelete: [],
+    });
+    expect(
+      await t.query(api.files.get, { fileId: fresh.fileId }),
+    ).not.toBeNull();
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    await expect(
+      t.mutation(api.files.deleteFilesWithStorageIds, {
+        fileIds: [fresh.fileId, fresh.fileId],
+      }),
+    ).resolves.toEqual({
+      deletedFileIds: [fresh.fileId],
+      storageIdsToDelete: ["shared"],
+    });
+  });
+
+  test("force never returns a blob still referenced by another file record", async () => {
+    const t = convexTest(schema, modules);
+    const first = await t.mutation(api.files.addFile, {
+      userId: "alice",
+      storageId: "shared",
+      hash: "same",
+    });
+    const second = await t.mutation(api.files.addFile, {
+      userId: "bob",
+      storageId: "shared",
+      hash: "same",
+    });
+    await t.mutation(api.files.copyFile, { fileId: second.fileId });
+    await expect(
+      t.mutation(api.files.deleteFilesWithStorageIds, {
+        fileIds: [first.fileId],
+        force: true,
+      }),
+    ).resolves.toEqual({
+      deletedFileIds: [first.fileId],
+      storageIdsToDelete: [],
+    });
+    await expect(
+      t.query(api.files.get, { fileId: second.fileId }),
+    ).resolves.toMatchObject({ userId: "bob", refcount: 1 });
+    await expect(
+      t.mutation(api.files.deleteFilesWithStorageIds, {
+        fileIds: [second.fileId],
+        force: true,
+      }),
+    ).resolves.toEqual({
+      deletedFileIds: [second.fileId],
+      storageIdsToDelete: ["shared"],
+    });
+  });
+
+  test("deleting all eligible aliases returns their storage ID once", async () => {
+    const t = convexTest(schema, modules);
+    const files = await Promise.all(
+      ["a", "b"].map((filename) =>
+        t.mutation(api.files.addFile, {
+          storageId: "shared",
+          hash: "same",
+          filename,
+        }),
+      ),
+    );
+    const fileIds = files.map((file) => file.fileId);
+    await expect(
+      t.mutation(api.files.deleteFilesWithStorageIds, { fileIds, force: true }),
+    ).resolves.toEqual({
+      deletedFileIds: fileIds,
+      storageIdsToDelete: ["shared"],
+    });
+  });
+});

--- a/src/component/files.ts
+++ b/src/component/files.ts
@@ -8,6 +8,7 @@ import type { Infer } from "convex/values";
 const FILE_CLEANUP_GRACE_MS = 24 * 60 * 60 * 1000;
 
 const addFileArgs = v.object({
+  userId: v.optional(v.string()),
   storageId: v.string(),
   hash: v.string(),
   filename: v.optional(v.string()),
@@ -32,18 +33,10 @@ export async function addFileHandler(
   // Support both mediaType (preferred) and mimeType (deprecated)
   const mediaType = normalizeMediaType(args.mediaType ?? args.mimeType);
 
-  const existingFiles = await ctx.db
-    .query("files")
-    .withIndex("hash", (q) => q.eq("hash", args.hash))
-    // eslint-disable-next-line @convex-dev/no-filter-in-query -- We do not expect many files with the same hash and different filenames
-    .filter((q) => q.eq(q.field("filename"), args.filename))
-    .collect();
-  const existingFile = existingFiles.find((file) =>
-    sameMediaType(file, mediaType),
-  );
+  const existingFile = await findExistingFile(ctx, { ...args, mediaType });
   if (existingFile) {
-    // Registration is not ownership. Persisted messages and in-flight streams
-    // acquire ownership explicitly.
+    // Registration does not retain the file. Persisted messages and in-flight
+    // streams acquire retention references explicitly.
     await ctx.db.patch("files", existingFile._id, {
       lastTouchedAt: Date.now(),
     });
@@ -53,6 +46,7 @@ export async function addFileHandler(
     };
   }
   const fileId = await ctx.db.insert("files", {
+    userId: args.userId,
     storageId: args.storageId,
     hash: args.hash,
     filename: args.filename,
@@ -71,35 +65,37 @@ export async function addFileHandler(
 export const get = query({
   args: {
     fileId: v.id("files"),
+    // The parent app authenticates the caller before supplying this identifier.
+    requireUserId: v.optional(v.string()),
   },
   returns: v.union(v.null(), v.doc("files")),
   handler: async (ctx, args) => {
-    return ctx.db.get("files", args.fileId);
+    const file = await ctx.db.get("files", args.fileId);
+    if (
+      args.requireUserId !== undefined &&
+      file?.userId !== args.requireUserId
+    ) {
+      return null;
+    }
+    return file;
   },
 });
 
 /**
  * If you plan to have the same file added over and over without a reference to
  * the fileId, you can use this query to get the fileId of the existing file.
- * Note: this will not increment the refcount. only saving messages does that.
- * It will only match if the filename is the same (or both are undefined).
+ * This does not increment refcount; messages and streams retain files explicitly.
+ * It will only match within the same user scope and filename (including unset).
  */
 export const useExistingFile = mutation({
   args: {
+    userId: v.optional(v.string()),
     hash: v.string(),
     filename: v.optional(v.string()),
     mediaType: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const files = await ctx.db
-      .query("files")
-      .withIndex("hash", (q) => q.eq("hash", args.hash))
-      // eslint-disable-next-line @convex-dev/no-filter-in-query -- We do not expect many files with the same hash and different filenames
-      .filter((q) => q.eq(q.field("filename"), args.filename))
-      .collect();
-    const file = files.find((candidate) =>
-      sameMediaType(candidate, normalizeMediaType(args.mediaType)),
-    );
+    const file = await findExistingFile(ctx, args);
     if (!file) {
       return null;
     }
@@ -117,6 +113,30 @@ export const useExistingFile = mutation({
   ),
 });
 
+async function findExistingFile(
+  ctx: MutationCtx,
+  args: {
+    userId?: string;
+    hash: string;
+    filename?: string;
+    mediaType?: string;
+  },
+) {
+  const expected = normalizeMediaType(args.mediaType);
+  const candidates = ctx.db
+    .query("files")
+    .withIndex("userId_hash_filename", (q) =>
+      q
+        .eq("userId", args.userId)
+        .eq("hash", args.hash)
+        .eq("filename", args.filename),
+    );
+  for await (const candidate of candidates) {
+    if (sameMediaType(candidate, expected)) return candidate;
+  }
+  return null;
+}
+
 function normalizeMediaType(value: string | undefined) {
   const normalized = value?.trim().toLowerCase();
   return normalized || undefined;
@@ -132,7 +152,7 @@ function sameMediaType(
   return expected === undefined || actual === undefined || actual === expected;
 }
 
-/** Transfer ownership between two durable records. */
+/** Transfer retention references between two durable records. */
 export async function changeRefcount(
   ctx: MutationCtx,
   previous: Id<"files">[],
@@ -184,7 +204,7 @@ export async function copyFileHandler(
  * Get files that are unused and can be deleted.
  * This is useful for cleaning up files that are no longer needed.
  * Files remain protected for 24 hours after registration or their last
- * ownership change, so a file cannot be removed between registration and the
+ * reference change, so a file cannot be removed between registration and the
  * transaction that saves its message or stream reference.
  */
 export const getFilesToDelete = query({
@@ -209,39 +229,78 @@ export const getFilesToDelete = query({
   }),
 });
 
+const deleteFilesArgs = {
+  fileIds: v.array(v.id("files")),
+  force: v.optional(v.boolean()),
+};
+
+/** Delete file records. Use deleteFilesWithStorageIds when also deleting blobs. */
 export const deleteFiles = mutation({
-  args: {
-    fileIds: v.array(v.id("files")),
-    force: v.optional(v.boolean()),
-  },
+  args: deleteFilesArgs,
   returns: v.array(v.id("files")),
   handler: async (ctx, args) => {
-    const deletedFileIds = await Promise.all(
-      args.fileIds.map(async (fileId) => {
-        const file = await ctx.db.get("files", fileId);
-        if (!file) {
-          console.error(`File ${fileId} not found when deleting, skipping...`);
-          return null;
-        }
-        if (file.refcount && file.refcount > 0) {
-          if (!args.force) {
-            console.error(
-              `File ${fileId} has refcount ${file.refcount} > 0, skipping...`,
-            );
-            return null;
-          }
-        }
-        if (
-          !args.force &&
-          file.lastTouchedAt > Date.now() - FILE_CLEANUP_GRACE_MS
-        ) {
-          console.error(`File ${fileId} is still within the cleanup grace period, skipping...`);
-          return null;
-        }
-        await ctx.db.delete("files", fileId);
-        return fileId;
-      }),
-    );
-    return deletedFileIds.filter((fileId) => fileId !== null);
+    const deleted = await deleteFileRecords(ctx, args);
+    return deleted.map((file) => file._id);
   },
 });
+
+/**
+ * Delete eligible records and return blobs with no remaining file references.
+ * Call from a parent-app mutation and delete the returned storage IDs in that
+ * same mutation, so record and blob deletion commit or roll back together.
+ * This is a trusted maintenance operation, not an end-user deletion API.
+ */
+export const deleteFilesWithStorageIds = mutation({
+  args: deleteFilesArgs,
+  returns: v.object({
+    deletedFileIds: v.array(v.id("files")),
+    storageIdsToDelete: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const deleted = await deleteFileRecords(ctx, args);
+    const storageIdsToDelete: string[] = [];
+    for (const storageId of new Set(deleted.map((file) => file.storageId))) {
+      const remaining = await ctx.db
+        .query("files")
+        .withIndex("storageId", (q) => q.eq("storageId", storageId))
+        .first();
+      if (!remaining) storageIdsToDelete.push(storageId);
+    }
+    return {
+      deletedFileIds: deleted.map((file) => file._id),
+      storageIdsToDelete,
+    };
+  },
+});
+
+async function deleteFileRecords(
+  ctx: MutationCtx,
+  args: { fileIds: Id<"files">[]; force?: boolean },
+) {
+  const deleted: Doc<"files">[] = [];
+  for (const fileId of new Set(args.fileIds)) {
+    const file = await ctx.db.get("files", fileId);
+    if (!file) {
+      console.error(`File ${fileId} not found when deleting, skipping...`);
+      continue;
+    }
+    if (!args.force && file.refcount > 0) {
+      console.error(
+        `File ${fileId} has refcount ${file.refcount} > 0, skipping...`,
+      );
+      continue;
+    }
+    if (
+      !args.force &&
+      file.lastTouchedAt > Date.now() - FILE_CLEANUP_GRACE_MS
+    ) {
+      console.error(
+        `File ${fileId} is still within the cleanup grace period, skipping...`,
+      );
+      continue;
+    }
+    await ctx.db.delete("files", fileId);
+    deleted.push(file);
+  }
+  return deleted;
+}

--- a/src/component/messages.test.ts
+++ b/src/component/messages.test.ts
@@ -1182,6 +1182,7 @@ describe("agent", () => {
     });
     const pending = messages[0]!;
     const { fileId: recoveredFileId } = await t.mutation(api.files.addFile, {
+      userId: "stream-file-recovery",
       storageId: "recovered-storage",
       hash: "recovered-hash",
       filename: "recovered.txt",
@@ -1222,6 +1223,7 @@ describe("agent", () => {
     await expect(
       t.query(api.files.get, { fileId: recoveredFileId }),
     ).resolves.toMatchObject({
+      userId: "stream-file-recovery",
       refcount: 1,
     });
     expect(
@@ -1230,6 +1232,7 @@ describe("agent", () => {
     ).toBeUndefined();
 
     const { fileId: timedOutFileId } = await t.mutation(api.files.addFile, {
+      userId: "stream-file-recovery",
       storageId: "timeout-storage",
       hash: "timeout-hash",
       filename: "timeout.txt",
@@ -1256,6 +1259,7 @@ describe("agent", () => {
     await expect(
       t.query(api.files.get, { fileId: timedOutFileId }),
     ).resolves.toMatchObject({
+      userId: "stream-file-recovery",
       refcount: 0,
     });
   });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -161,6 +161,7 @@ export const schema = defineSchema({
     .index("embeddingId", ["embeddingId"]),
 
   files: defineTable({
+    userId: v.optional(v.string()), // Unset for legacy or unscoped files
     storageId: v.string(),
     mediaType: v.optional(v.string()),
     /** @deprecated Use `mediaType` instead. */
@@ -171,6 +172,8 @@ export const schema = defineSchema({
     lastTouchedAt: v.number(),
   })
     .index("hash", ["hash"])
+    .index("userId_hash_filename", ["userId", "hash", "filename"])
+    .index("storageId", ["storageId"])
     .index("refcount", ["refcount"])
     .index("refcount_lastTouchedAt", ["refcount", "lastTouchedAt"]),
   ...vectorTables,

--- a/src/component/streams.test.ts
+++ b/src/component/streams.test.ts
@@ -17,6 +17,7 @@ async function seedStream(t: ReturnType<typeof initConvexTest>) {
     format: "UIMessageChunk",
   });
   const { fileId } = await t.mutation(api.files.addFile, {
+    userId: "stream-files",
     storageId: "stream-storage",
     hash: "stream-hash",
     filename: "stream.txt",
@@ -38,6 +39,7 @@ describe("streams", () => {
       fileRefs: [{ url, fileId }],
     });
     await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
+      userId: "stream-files",
       refcount: 1,
     });
 
@@ -100,6 +102,7 @@ describe("streams", () => {
     await expect(t.query(api.files.get, { fileId })).resolves.toMatchObject({
       refcount: 1,
     });
+    await expect(t.query(api.files.get, { fileId, requireUserId: "stream-files" })).resolves.toMatchObject({ refcount: 1 });
     const stream = await t.run((ctx) =>
       ctx.db.get("streamingMessages", streamId),
     );

--- a/src/vercel/client/definePlaygroundAPI.ts
+++ b/src/vercel/client/definePlaygroundAPI.ts
@@ -28,6 +28,7 @@ import {
   isTool,
 } from "../../shared.js";
 import { serializeResponseMessages, toModelMessage } from "../mapping.js";
+import { resolveFileUserId } from "./files.js";
 import type { Agent } from "../index.js";
 import { listMessages as listMessages_ } from "./messages.js";
 import { syncStreams, vStreamMessagesReturnValue } from "./streaming.js";
@@ -271,6 +272,10 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
       const namedAgent = agents.find(({ name }) => name === agentName);
       if (!namedAgent) throw new Error(`Unknown agent: ${agentName}`);
       const { agent } = namedAgent;
+      const fileUserId = await resolveFileUserId(ctx, component, {
+        userId,
+        threadId,
+      });
       const { text, steps } = await agent.streamText(
         ctx,
         { threadId, userId },
@@ -292,6 +297,7 @@ export function definePlaygroundAPI<DataModel extends GenericDataModel>(
             provider: getProviderName(agent.options.languageModel),
           },
           step.response.messages,
+          { userId: fileUserId },
         );
         outputMessages.push(
           messages.map((messageWithMetadata, i) => {

--- a/src/vercel/client/files.test.ts
+++ b/src/vercel/client/files.test.ts
@@ -1,7 +1,278 @@
 /// <reference types="vite/client" />
 
-import { describe, expect, test } from "vitest";
-import { storeFile } from "./files.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getFile, MAX_FILE_SIZE, storeFile } from "./files.js";
+import {
+  actionGeneric,
+  anyApi,
+  mutationGeneric,
+  queryGeneric,
+  type ApiFromModules,
+} from "convex/server";
+import { v } from "convex/values";
+import { components, initConvexTest } from "./setup.test.js";
+import { Agent, createThread, saveMessage } from "../index.js";
+import { saveMessages } from "./messages.js";
+import { mockModel } from "./mockModel.js";
+import { generateText } from "ai";
+import { materializeUIMessageChunkFiles } from "../fileMaterialization.js";
+
+const bytes = new Uint8Array(MAX_FILE_SIZE + 1).fill(65);
+
+// These app-side wrappers authenticate before passing a user ID to the component.
+export const uploadOwnedFile = actionGeneric({
+  args: {},
+  returns: v.any(),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthorized");
+    const { file } = await storeFile(
+      ctx,
+      components.agent,
+      new Blob([bytes], { type: "text/plain" }),
+      {
+        userId: identity.subject,
+      },
+    );
+    return { file };
+  },
+});
+
+export const readOwnedFile = queryGeneric({
+  args: { fileId: v.string() },
+  returns: v.any(),
+  handler: async (ctx, { fileId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthorized");
+    const { file } = await getFile(ctx, components.agent, fileId, {
+      requireUserId: identity.subject,
+    });
+    return { file };
+  },
+});
+
+export const uploadUnscopedFile = actionGeneric({
+  args: {},
+  returns: v.any(),
+  handler: async (ctx) => {
+    const { file } = await storeFile(
+      ctx,
+      components.agent,
+      new Blob(["legacy"]),
+    );
+    return { file };
+  },
+});
+
+export const saveInlineFiles = actionGeneric({
+  args: {
+    threadId: v.string(),
+    userId: v.optional(v.string()),
+    kind: v.union(
+      v.literal("image"),
+      v.literal("file"),
+      v.literal("reasoning"),
+      v.literal("tool"),
+    ),
+  },
+  returns: v.any(),
+  handler: (ctx, { kind, ...args }) =>
+    saveMessages(ctx, components.agent, {
+      ...args,
+      messages: [
+        kind === "image"
+          ? {
+              role: "user",
+              content: [
+                { type: "image", image: bytes, mediaType: "image/png" },
+              ],
+            }
+          : kind === "file"
+            ? {
+                role: "user",
+                content: [
+                  { type: "file", data: bytes, mediaType: "application/pdf" },
+                ],
+              }
+            : kind === "reasoning"
+              ? {
+                  role: "assistant",
+                  content: [
+                    {
+                      type: "reasoning-file",
+                      data: { type: "data", data: bytes },
+                      mediaType: "text/plain",
+                    },
+                  ],
+                }
+              : {
+                  role: "tool",
+                  content: [
+                    {
+                      type: "tool-result",
+                      toolCallId: "call",
+                      toolName: "test",
+                      output: {
+                        type: "content",
+                        value: [
+                          {
+                            type: "file",
+                            data: { type: "data", data: bytes },
+                            mediaType: "text/plain",
+                            filename: "tool.txt",
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+      ],
+    }),
+});
+
+export const updateInlineFile = actionGeneric({
+  args: { messageId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { messageId }) => {
+    const agent = new Agent(components.agent, {
+      name: "test",
+      languageModel: mockModel(),
+    });
+    await agent.updateMessage(ctx, {
+      messageId,
+      patch: {
+        status: "success",
+        message: {
+          role: "user",
+          content: [{ type: "file", data: bytes, mediaType: "text/plain" }],
+        },
+      },
+    });
+  },
+});
+
+export const deleteOwnedBlobs = mutationGeneric({
+  args: { fileIds: v.array(v.string()), fail: v.optional(v.boolean()) },
+  returns: v.null(),
+  handler: async (ctx, { fileIds, fail }) => {
+    const { storageIdsToDelete } = await ctx.runMutation(
+      components.agent.files.deleteFilesWithStorageIds,
+      { fileIds, force: true },
+    );
+    for (const storageId of storageIdsToDelete)
+      await ctx.storage.delete(storageId);
+    if (fail) throw new Error("storage cleanup failed");
+  },
+});
+
+export const generateFile = actionGeneric({
+  args: {
+    threadId: v.string(),
+    mode: v.union(
+      v.literal("generate"),
+      v.literal("stream"),
+      v.literal("manual"),
+    ),
+    kind: v.union(v.literal("file"), v.literal("reasoning-file")),
+  },
+  returns: v.any(),
+  handler: async (ctx, { threadId, mode, kind }) => {
+    const model = mockModel({
+      content: [
+        {
+          type: kind,
+          data: { type: "data", data: bytes },
+          mediaType: "text/plain",
+        },
+      ],
+    });
+    const agent = new Agent(components.agent, {
+      name: "file-generator",
+      languageModel: model,
+    });
+    if (mode === "stream") {
+      await agent.streamText(
+        ctx,
+        { threadId },
+        { prompt: "Generate a file" },
+        { saveStreamDeltas: { throttleMs: 0 } },
+      );
+    } else if (mode === "generate") {
+      await agent.generateText(
+        ctx,
+        { threadId },
+        { prompt: "Generate a file" },
+      );
+    } else {
+      const result = await generateText({ model, prompt: "Generate a file" });
+      const { messageId } = await saveMessage(ctx, components.agent, {
+        threadId,
+        prompt: "Generate a file",
+      });
+      await agent.saveStep(ctx, {
+        threadId,
+        promptMessageId: messageId,
+        step: result.steps[0],
+      });
+    }
+    return agent.listMessages(ctx, {
+      threadId,
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+  },
+});
+
+export const saveStreamedToolFile = actionGeneric({
+  args: { threadId: v.string() },
+  returns: v.any(),
+  handler: async (ctx, { threadId }) => {
+    const output = {
+      type: "content" as const,
+      value: [
+        {
+          type: "file" as const,
+          data: { type: "text" as const, text: "A".repeat(MAX_FILE_SIZE + 1) },
+          filename: "tool.txt",
+          mediaType: "text/plain",
+        },
+      ],
+    };
+    const { fileRefs } = await materializeUIMessageChunkFiles(
+      ctx,
+      components.agent,
+      [{ type: "tool-output-available", toolCallId: "tool-call", output }],
+      { userId: "alice" },
+    );
+    const { message } = await saveMessage(ctx, components.agent, {
+      threadId,
+      message: {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tool-call",
+            toolName: "test",
+            output,
+          },
+        ],
+      },
+    });
+    return { fileRefs, message };
+  },
+});
+
+const testApi: ApiFromModules<{
+  fns: {
+    uploadOwnedFile: typeof uploadOwnedFile;
+    uploadUnscopedFile: typeof uploadUnscopedFile;
+    readOwnedFile: typeof readOwnedFile;
+    saveInlineFiles: typeof saveInlineFiles;
+    updateInlineFile: typeof updateInlineFile;
+    deleteOwnedBlobs: typeof deleteOwnedBlobs;
+    generateFile: typeof generateFile;
+    saveStreamedToolFile: typeof saveStreamedToolFile;
+  };
+}>["fns"] = anyApi["files.test"] as any;
 
 describe("storeFile", () => {
   test("throws a clear error when a reused file is missing from storage", async () => {
@@ -52,5 +323,274 @@ describe("storeFile", () => {
       "File not found in storage: existing-storage",
     );
     expect(deleted).toEqual(["new-storage"]);
+  });
+});
+
+describe("file ownership through the client API", () => {
+  afterEach(() => vi.useRealTimers());
+
+  test("authenticated owners can read their files; other users and anonymous callers cannot", async () => {
+    const t = initConvexTest();
+    const alice = t.withIdentity({ subject: "alice" });
+    const bob = t.withIdentity({ subject: "bob" });
+    const { file } = await alice.action(testApi.uploadOwnedFile, {});
+    expect(file.userId).toBe("alice");
+    await expect(
+      alice.query(testApi.readOwnedFile, { fileId: file.fileId }),
+    ).resolves.toMatchObject({
+      file: { userId: "alice", fileId: file.fileId },
+    });
+    await expect(
+      bob.query(testApi.readOwnedFile, { fileId: file.fileId }),
+    ).rejects.toThrow("File not found");
+    await expect(
+      t.query(testApi.readOwnedFile, { fileId: file.fileId }),
+    ).rejects.toThrow("Unauthorized");
+    await expect(t.action(testApi.uploadOwnedFile, {})).rejects.toThrow(
+      "Unauthorized",
+    );
+    await expect(
+      bob.query(testApi.readOwnedFile, {
+        fileId: file.fileId,
+        // @ts-expect-error Identity cannot be supplied by a browser argument.
+        userId: "alice",
+      }),
+    ).rejects.toThrow();
+    const bobUpload = await bob.action(testApi.uploadOwnedFile, {});
+    expect(bobUpload.file.fileId).not.toBe(file.fileId);
+    expect(bobUpload.file.storageId).not.toBe(file.storageId);
+    const reused = await alice.action(testApi.uploadOwnedFile, {});
+    expect(reused.file).toEqual(file);
+  });
+
+  test("checked reads never resolve URLs for rejected rows or missing user identifiers", async () => {
+    const getUrl = vi.fn();
+    const ctx = {
+      runQuery: vi.fn(async () => null),
+      storage: { getUrl },
+    } as unknown as Parameters<typeof getFile>[0];
+    await expect(
+      getFile(ctx, components.agent, "someone-elses-file", {
+        requireUserId: "alice",
+      }),
+    ).rejects.toThrow("File not found");
+    await expect(
+      getFile(ctx, components.agent, "legacy-file", {
+        // @ts-expect-error A supplied check cannot silently accept an undefined user.
+        requireUserId: undefined,
+      }),
+    ).rejects.toThrow("requireUserId must be a string");
+    expect(getUrl).not.toHaveBeenCalled();
+  });
+
+  test("legacy files still support unchecked server reads, but fail owner checks", async () => {
+    const t = initConvexTest();
+    const { file } = await t.action(testApi.uploadUnscopedFile, {});
+    await t.run(async (ctx) => {
+      expect(
+        (await getFile(ctx, components.agent, file.fileId)).file.fileId,
+      ).toBe(file.fileId);
+    });
+    await expect(
+      t
+        .withIdentity({ subject: "alice" })
+        .query(testApi.readOwnedFile, { fileId: file.fileId }),
+    ).rejects.toThrow("File not found");
+  });
+
+  test("racing uploads deduplicate within an owner and clean up losing blobs", async () => {
+    const t = initConvexTest();
+    const alice = t.withIdentity({ subject: "alice" });
+    const uploads = await Promise.all(
+      Array.from({ length: 3 }, () =>
+        alice.action(testApi.uploadOwnedFile, {}),
+      ),
+    );
+    expect(new Set(uploads.map(({ file }) => file.fileId)).size).toBe(1);
+    // Only the registered blob survives even if several actions upload before registration.
+    const stored = await t.run((ctx) =>
+      ctx.db.system.query("_storage").collect(),
+    );
+    expect(stored.map((file) => file._id)).toEqual([uploads[0].file.storageId]);
+  });
+
+  test.each([undefined, "explicit-owner"])(
+    "inline files use thread fallback or explicit owner (%s)",
+    async (userId) => {
+      const t = initConvexTest();
+      const threadId = await t.run((ctx) =>
+        createThread(ctx, components.agent, { userId: "thread-owner" }),
+      );
+      const fileIds: string[] = [];
+      for (const kind of ["image", "file", "reasoning", "tool"] as const) {
+        const { messages } = await t.action(testApi.saveInlineFiles, {
+          threadId,
+          userId,
+          kind,
+        });
+        fileIds.push(
+          ...messages.flatMap(
+            (message: { fileIds?: string[] }) => message.fileIds ?? [],
+          ),
+        );
+      }
+      expect(fileIds).toHaveLength(4);
+      for (const fileId of fileIds) {
+        await expect(
+          t.query(components.agent.files.get, { fileId }),
+        ).resolves.toMatchObject({
+          userId: userId ?? "thread-owner",
+          refcount: 1,
+        });
+      }
+    },
+  );
+
+  test("message updates inherit the existing owner and reject a missing message before storing files", async () => {
+    const t = initConvexTest();
+    const threadId = await t.run((ctx) =>
+      createThread(ctx, components.agent, { userId: "alice" }),
+    );
+    const { messageId } = await t.run((ctx) =>
+      saveMessage(ctx, components.agent, { threadId, prompt: "before" }),
+    );
+    await t.action(testApi.updateInlineFile, { messageId });
+    const [message] = await t.query(
+      components.agent.messages.getMessagesByIds,
+      { messageIds: [messageId] },
+    );
+    expect(message?.fileIds).toHaveLength(1);
+    await expect(
+      t.query(components.agent.files.get, { fileId: message!.fileIds![0] }),
+    ).resolves.toMatchObject({ userId: "alice", refcount: 1 });
+    await t.mutation(components.agent.messages.deleteByIds, {
+      messageIds: [messageId],
+    });
+    await expect(
+      t.action(testApi.updateInlineFile, { messageId }),
+    ).rejects.toThrow("not found");
+    const stored = await t.run((ctx) =>
+      ctx.db.system.query("_storage").collect(),
+    );
+    expect(stored).toHaveLength(1);
+  });
+
+  test("record and storage deletion roll back together in an app mutation", async () => {
+    const t = initConvexTest();
+    const { file } = await t
+      .withIdentity({ subject: "alice" })
+      .action(testApi.uploadOwnedFile, {});
+    await expect(
+      t.mutation(testApi.deleteOwnedBlobs, {
+        fileIds: [file.fileId],
+        fail: true,
+      }),
+    ).rejects.toThrow("storage cleanup failed");
+    await expect(
+      t.query(components.agent.files.get, { fileId: file.fileId }),
+    ).resolves.not.toBeNull();
+    expect(
+      await t.run(
+        async (ctx) => (await ctx.storage.get(file.storageId)) !== null,
+      ),
+    ).toBe(true);
+    await t.mutation(testApi.deleteOwnedBlobs, { fileIds: [file.fileId] });
+    await expect(
+      t.query(components.agent.files.get, { fileId: file.fileId }),
+    ).resolves.toBeNull();
+    expect(
+      await t.run(
+        async (ctx) => (await ctx.storage.get(file.storageId)) !== null,
+      ),
+    ).toBe(false);
+  });
+
+  test.each(["generate", "stream", "manual"] as const)(
+    "%s propagates a thread owner to generated files and reasoning files",
+    async (mode) => {
+      for (const kind of ["file", "reasoning-file"] as const) {
+        const t = initConvexTest();
+        const threadId = await t.run((ctx) =>
+          createThread(ctx, components.agent, { userId: "alice" }),
+        );
+        const { page } = await t.action(testApi.generateFile, {
+          threadId,
+          mode,
+          kind,
+        });
+        const fileIds: string[] = page.flatMap(
+          (message: { fileIds?: string[] }) => message.fileIds ?? [],
+        );
+        expect(fileIds).toHaveLength(1);
+        await expect(
+          t.query(components.agent.files.get, { fileId: fileIds[0] }),
+        ).resolves.toMatchObject({ userId: "alice", refcount: 1 });
+        // Stream materialization and final serialization must share one blob.
+        expect(
+          await t.run((ctx) => ctx.db.system.query("_storage").collect()),
+        ).toHaveLength(1);
+      }
+    },
+  );
+
+  test("anonymous threads remain unscoped", async () => {
+    const t = initConvexTest();
+    const threadId = await t.run((ctx) => createThread(ctx, components.agent));
+    const { page } = await t.action(testApi.generateFile, {
+      threadId,
+      mode: "stream",
+      kind: "file",
+    });
+    const fileId = page.flatMap((message) => message.fileIds ?? [])[0];
+    expect(fileId).toBeDefined();
+    const file = await t.query(components.agent.files.get, { fileId });
+    expect(file).not.toBeNull();
+    expect(file?.userId).toBeUndefined();
+  });
+
+  test("streamed tool-result files reuse their owner's file during final serialization", async () => {
+    const t = initConvexTest();
+    const threadId = await t.run((ctx) =>
+      createThread(ctx, components.agent, { userId: "alice" }),
+    );
+    const { fileRefs, message } = await t.action(testApi.saveStreamedToolFile, {
+      threadId,
+    });
+    expect(fileRefs).toHaveLength(1);
+    expect(message.fileIds).toEqual([fileRefs[0].fileId]);
+    await expect(
+      t.query(components.agent.files.get, { fileId: fileRefs[0].fileId }),
+    ).resolves.toMatchObject({ userId: "alice", refcount: 1 });
+  });
+
+  test("trusted cross-user clones retain the original file owner and references", async () => {
+    const t = initConvexTest();
+    const sourceThreadId = await t.run((ctx) =>
+      createThread(ctx, components.agent, { userId: "alice" }),
+    );
+    const targetThreadId = await t.run((ctx) =>
+      createThread(ctx, components.agent, { userId: "bob" }),
+    );
+    const { messages } = await t.action(testApi.saveInlineFiles, {
+      threadId: sourceThreadId,
+      kind: "file",
+    });
+    const fileId = messages[0].fileIds![0];
+    await t.action(components.agent.messages.cloneThread, {
+      sourceThreadId,
+      targetThreadId,
+    });
+    await expect(
+      t.query(components.agent.files.get, { fileId }),
+    ).resolves.toMatchObject({ userId: "alice", refcount: 2 });
+    await expect(
+      t.query(components.agent.files.get, { fileId, requireUserId: "bob" }),
+    ).resolves.toBeNull();
+    await t.mutation(components.agent.messages.deleteByIds, {
+      messageIds: [messages[0]._id],
+    });
+    await expect(
+      t.query(components.agent.files.get, { fileId }),
+    ).resolves.toMatchObject({ userId: "alice", refcount: 1 });
   });
 });

--- a/src/vercel/client/files.ts
+++ b/src/vercel/client/files.ts
@@ -19,6 +19,7 @@ import type { StorageReader } from "convex/server";
 export const MAX_FILE_SIZE = 1024 * 64;
 
 type File = {
+  userId?: string;
   url: string;
   fileId: string;
   storageId: Id<"_storage">;
@@ -32,6 +33,8 @@ type File = {
  * @param component The agent component.
  * @param blob The blob to store.
  * @param args.filename The filename to store.
+ * @param args.userId Owner supplied by the app. Deduplication stays within this
+ *   user's files. Omit for the shared legacy/unscoped pool.
  * @param args.sha256 The sha256 hash of the file. If not provided, it will be
  *   computed. However, to ensure no corruption during transfer, you can
  *   calculate this on the client to enforce integrity.
@@ -41,7 +44,11 @@ export async function storeFile(
   ctx: ActionCtx | MutationCtx,
   component: AgentComponent,
   blob: Blob,
-  { filename, sha256 }: { filename?: string; sha256?: string } = {},
+  {
+    filename,
+    sha256,
+    userId,
+  }: { filename?: string; sha256?: string; userId?: string } = {},
 ): Promise<{
   file: File;
   filePart: FilePart;
@@ -65,6 +72,7 @@ export async function storeFile(
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   const reused = await ctx.runMutation(component.files.useExistingFile, {
+    userId,
     hash,
     filename,
     mediaType: blob.type || undefined,
@@ -77,6 +85,7 @@ export async function storeFile(
     return {
       ...getParts(url, blob.type, filename),
       file: {
+        userId,
         url,
         fileId: reused.fileId,
         storageId: reused.storageId as Id<"_storage">,
@@ -103,6 +112,7 @@ export async function storeFile(
     const { fileId, storageId } = await ctx.runMutation(
       component.files.addFile,
       {
+        userId,
         storageId: newStorageId,
         hash,
         filename,
@@ -123,6 +133,7 @@ export async function storeFile(
     return {
       ...getParts(url, blob.type, filename),
       file: {
+        userId,
         url,
         fileId,
         storageId: storageId as Id<"_storage">,
@@ -152,14 +163,25 @@ export async function storeFile(
  * @param ctx A ctx object from an action or query.
  * @param component The agent component, usually `components.agent`.
  * @param fileId The fileId of the file to get.
+ * @param options.requireUserId Require this owner before resolving a storage
+ *   URL. The app must authenticate the caller before supplying their user ID.
+ *   Ownerless legacy files fail this check. Omit options only after applying
+ *   your own access policy in trusted server code.
  * @returns The file metadata and content parts.
  */
 export async function getFile(
   ctx: ActionCtx | (QueryCtx & { storage: StorageReader }),
   component: AgentComponent,
   fileId: string,
+  options?: { requireUserId: string },
 ) {
-  const file = await ctx.runQuery(component.files.get, { fileId });
+  if (options !== undefined && typeof options.requireUserId !== "string") {
+    throw new Error("requireUserId must be a string");
+  }
+  const file = await ctx.runQuery(component.files.get, {
+    fileId,
+    ...(options ? { requireUserId: options.requireUserId } : {}),
+  });
   if (!file) {
     throw new Error(`File not found in component: ${fileId}`);
   }
@@ -172,6 +194,7 @@ export async function getFile(
   return {
     ...getParts(url, mediaType, file.filename),
     file: {
+      userId: file.userId,
       fileId,
       url,
       storageId: file.storageId as Id<"_storage">,
@@ -179,6 +202,20 @@ export async function getFile(
       filename: file.filename,
     },
   };
+}
+
+/** Resolve file ownership before serialization; this does not authorize access. */
+export async function resolveFileUserId(
+  ctx: QueryCtx | MutationCtx | ActionCtx,
+  component: AgentComponent,
+  { userId, threadId }: { userId?: string | null; threadId?: string },
+) {
+  return (
+    userId ??
+    (threadId
+      ? (await ctx.runQuery(component.threads.getThread, { threadId }))?.userId
+      : undefined)
+  );
 }
 
 function getParts(

--- a/src/vercel/client/messages.ts
+++ b/src/vercel/client/messages.ts
@@ -7,6 +7,7 @@ import {
   type MessageWithMetadata,
 } from "../../validators.js";
 import { serializeMessage } from "../mapping.js";
+import { resolveFileUserId } from "./files.js";
 import { toUIMessages, type UIMessage } from "../UIMessages.js";
 import {
   listMessages,
@@ -88,12 +89,15 @@ export async function saveMessages(
     agentName?: string;
   },
 ): Promise<{ messages: MessageDoc[] }> {
+  const userId = await resolveFileUserId(ctx, component, args);
   const serialized = await Promise.all(
-    args.messages.map((message) => serializeMessage(ctx, component, message)),
+    args.messages.map((message) =>
+      serializeMessage(ctx, component, message, { userId }),
+    ),
   );
   return saveCanonicalMessages(ctx, component, {
     threadId: args.threadId,
-    userId: args.userId ?? undefined,
+    userId,
     agentName: args.agentName,
     promptMessageId: args.promptMessageId,
     order: args.order,

--- a/src/vercel/client/start.ts
+++ b/src/vercel/client/start.ts
@@ -367,6 +367,7 @@ export async function startGeneration<
             toSave.step,
             activeModel,
             responseMessagesToSave,
+            { userId },
           );
         }
         const embeddings = await embedMessages(

--- a/src/vercel/client/streamText.ts
+++ b/src/vercel/client/streamText.ts
@@ -153,7 +153,7 @@ export async function streamText<
             onAsyncAbort: call.fail,
             compress: compressUIMessageChunks,
             materialize: (parts) =>
-              materializeUIMessageChunkFiles(ctx, component, parts),
+              materializeUIMessageChunkFiles(ctx, component, parts, { userId }),
             abortSignal: args.abortSignal,
           },
           {

--- a/src/vercel/fileMaterialization.ts
+++ b/src/vercel/fileMaterialization.ts
@@ -13,6 +13,7 @@ export async function materializeUIMessageChunkFiles(
   ctx: ActionCtx,
   component: AgentComponent,
   parts: readonly UIMessageChunk[],
+  options: { userId?: string } = {},
 ): Promise<{ parts: UIMessageChunk[]; fileRefs: MaterializedFileRef[] }> {
   const fileRefs: MaterializedFileRef[] = [];
   const materialized = await Promise.all(
@@ -22,6 +23,7 @@ export async function materializeUIMessageChunkFiles(
           ctx,
           component,
           part.output,
+          options,
         );
         fileRefs.push(...result.fileRefs);
         return { ...part, output: result.output };
@@ -34,6 +36,7 @@ export async function materializeUIMessageChunkFiles(
         component,
         part.url,
         part.mediaType,
+        options,
       );
       if (!file) {
         return { ...part };
@@ -53,6 +56,7 @@ export async function materializeCanonicalToolResultContentFiles(
   ctx: ActionCtx | MutationCtx,
   component: AgentComponent,
   output: unknown,
+  options: { userId?: string } = {},
 ): Promise<{ output: unknown; fileRefs: MaterializedFileRef[] }> {
   if (!isCanonicalToolResultContent(output)) {
     return { output, fileRefs: [] };
@@ -70,7 +74,7 @@ export async function materializeCanonicalToolResultContentFiles(
             ? part.data.data
             : new TextEncoder().encode(part.data.text),
         part.mediaType,
-        part.filename,
+        { ...options, filename: part.filename },
       );
       if (!file) return part;
       fileRefs.push({ url: file.url, fileId: file.fileId });
@@ -88,7 +92,7 @@ async function materializeInlineFile(
   component: AgentComponent,
   data: unknown,
   mediaType: string,
-  filename?: string,
+  { filename, userId }: { filename?: string; userId?: string } = {},
 ) {
   const bytes = decodeInlineFileData(data);
   if (!bytes) return undefined;
@@ -103,7 +107,7 @@ async function materializeInlineFile(
     new Blob([blobBytes], {
       type: mediaType || "application/octet-stream",
     }),
-    filename ? { filename } : {},
+    { filename, userId },
   );
   return file;
 }
@@ -140,7 +144,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function decodeInlineFileData(value: unknown): Uint8Array | undefined {
+export function decodeInlineFileData(value: unknown): Uint8Array | undefined {
   if (typeof value === "string") {
     if (!value.startsWith("data:")) {
       // Remote and already-stored files are references, not inline payloads.

--- a/src/vercel/index.ts
+++ b/src/vercel/index.ts
@@ -57,6 +57,7 @@ import {
   serializeObjectResult,
 } from "./mapping.js";
 import { getModelName, getProviderName } from "../shared.js";
+import { resolveFileUserId } from "./client/files.js";
 import {
   vMessageEmbeddings,
   vMessageWithMetadata,
@@ -553,7 +554,9 @@ export class Agent<
             {
               step,
               responseMessages: [
-                ...(initialResponseMessagesSaved ? [] : initialResponseMessages),
+                ...(initialResponseMessagesSaved
+                  ? []
+                  : initialResponseMessages),
                 ...step.response.messages,
               ],
             },
@@ -1301,6 +1304,7 @@ export class Agent<
       provider?: string;
     },
   ): Promise<{ messages: MessageDoc[] }> {
+    const userId = await resolveFileUserId(ctx, this.component, args);
     const { messages } = await serializeResponseMessages(
       ctx,
       this.component,
@@ -1312,14 +1316,15 @@ export class Agent<
       args.step.response.messages.length > 0
         ? args.step.response.messages
         : [{ role: "assistant", content: [] }],
+      { userId },
     );
     const embeddings = await this.generateEmbeddings(
       ctx,
-      { userId: args.userId, threadId: args.threadId },
+      { userId, threadId: args.threadId },
       messages.map((m) => m.message),
     );
     return ctx.runMutation(this.component.messages.addMessages, {
-      userId: args.userId,
+      userId,
       threadId: args.threadId,
       agentName: this.options.name,
       promptMessageId: args.promptMessageId,
@@ -1432,10 +1437,19 @@ export class Agent<
       };
     },
   ): Promise<void> {
+    const [existing] = await ctx.runQuery(
+      this.component.messages.getMessagesByIds,
+      {
+        messageIds: [args.messageId],
+      },
+    );
+    assert(existing, `Message ${args.messageId} not found`);
+    const userId = await resolveFileUserId(ctx, this.component, existing);
     const { message, fileIds } = await serializeMessage(
       ctx,
       this.component,
       args.patch.message,
+      { userId },
     );
     await ctx.runMutation(this.component.messages.updateMessage, {
       messageId: args.messageId,

--- a/src/vercel/mapping.test.ts
+++ b/src/vercel/mapping.test.ts
@@ -465,6 +465,73 @@ describe("mapping", () => {
     );
   });
 
+  test.each(["base64", "data URL", "multibyte data URL"])(
+    "stores oversized %s files with their owner",
+    async (encoding) => {
+      const text =
+        encoding === "multibyte data URL"
+          ? "漢".repeat(30_000)
+          : "A".repeat(65 * 1024);
+      const data =
+        encoding === "base64"
+          ? btoa(text)
+          : encoding === "data URL"
+            ? `data:text/plain;base64,${btoa(text)}`
+            : `data:text/plain,${text}`;
+      const store = vi.fn(async (_blob: Blob) => "storage-123");
+      const runMutation = vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          fileId: "file-123",
+          storageId: "storage-123",
+        });
+      const ctx = {
+        runAction: async () => undefined,
+        runMutation,
+        storage: { store, getUrl: async () => "https://example.com/file" },
+      } as unknown as ActionCtx;
+      const result = await serializeContent(
+        ctx,
+        api as unknown as AgentComponent,
+        [{ type: "file", data, mediaType: "text/plain" }],
+        { userId: "alice" },
+      );
+      expect(result.fileIds).toEqual(["file-123"]);
+      expect(result.content).toMatchObject([
+        { type: "file", data: "https://example.com/file" },
+      ]);
+      expect(await store.mock.calls[0][0].text()).toBe(text);
+      expect(runMutation).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({ userId: "alice" }),
+      );
+      expect(runMutation).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({ userId: "alice" }),
+      );
+    },
+  );
+
+  test("small decoded files stay inline even if their base64 exceeds 64 KiB", async () => {
+    const content = [
+      {
+        type: "file" as const,
+        data: btoa("A".repeat(50 * 1024)),
+        mediaType: "text/plain",
+      },
+    ];
+    const result = await serializeContent(
+      {} as ActionCtx,
+      {} as AgentComponent,
+      content,
+    );
+    expect(result.content).toMatchObject(content);
+    expect(result.fileIds).toBeUndefined();
+  });
+
   test("materializes oversized canonical tool-result files", async () => {
     const bytes = new Uint8Array(1024 * 65).fill(1);
     const ctx = {

--- a/src/vercel/mapping.ts
+++ b/src/vercel/mapping.ts
@@ -44,7 +44,10 @@ import {
 import type { ActionCtx, AgentComponent } from "./client/types.js";
 import type { MutationCtx } from "./client/types.js";
 import { MAX_FILE_SIZE, storeFile } from "./client/files.js";
-import { materializeCanonicalToolResultContentFiles } from "./fileMaterialization.js";
+import {
+  decodeInlineFileData,
+  materializeCanonicalToolResultContentFiles,
+} from "./fileMaterialization.js";
 import type { Infer } from "convex/values";
 import {
   convertUint8ArrayToBase64,
@@ -82,11 +85,13 @@ export async function serializeMessage(
   ctx: ActionCtx | MutationCtx,
   component: AgentComponent,
   message: ModelMessage | Message,
+  options: { userId?: string } = {},
 ): Promise<{ message: SerializedMessage; fileIds?: string[] }> {
   const { content, fileIds } = await serializeContent(
     ctx,
     component,
     message.content,
+    options,
   );
   return {
     message: {
@@ -290,8 +295,16 @@ export async function serializeResponseMessages<TOOLS extends ToolSet>(
   step: StepResult<TOOLS>,
   model: ModelOrMetadata | undefined,
   responseMessages: ModelMessage[],
+  options: { userId?: string } = {},
 ): Promise<{ messages: MessageWithMetadata[] }> {
-  return serializeStepMessages(ctx, component, step, model, responseMessages);
+  return serializeStepMessages(
+    ctx,
+    component,
+    step,
+    model,
+    responseMessages,
+    options,
+  );
 }
 
 async function serializeStepMessages<TOOLS extends ToolSet>(
@@ -300,6 +313,7 @@ async function serializeStepMessages<TOOLS extends ToolSet>(
   step: StepResult<TOOLS>,
   model: ModelOrMetadata | undefined,
   messagesToSerialize: ModelMessage[],
+  options: { userId?: string },
 ): Promise<{ messages: MessageWithMetadata[] }> {
   // If there are tool results, there's another message with the tool results
   // ref: https://github.com/vercel/ai/blob/main/packages/ai/src/generate-text/to-response-messages.ts#L120
@@ -323,7 +337,12 @@ async function serializeStepMessages<TOOLS extends ToolSet>(
 
   const messages: MessageWithMetadata[] = await Promise.all(
     messagesToSerialize.map(async (msg): Promise<MessageWithMetadata> => {
-      const { message, fileIds } = await serializeMessage(ctx, component, msg);
+      const { message, fileIds } = await serializeMessage(
+        ctx,
+        component,
+        msg,
+        options,
+      );
       return parse(vMessageWithMetadata, {
         message,
         ...(message.role === "tool" ? toolFields : assistantFields),
@@ -378,6 +397,7 @@ export async function serializeContent(
   ctx: ActionCtx | MutationCtx,
   component: AgentComponent,
   content: Content | Message["content"],
+  options: { userId?: string } = {},
 ): Promise<{ content: SerializedContent; fileIds?: string[] }> {
   if (typeof content === "string") {
     return { content };
@@ -404,9 +424,10 @@ export async function serializeContent(
           } satisfies Infer<typeof vTextPart>;
         }
         case "image": {
-          let image =
+          let image = inlineFileDataForStorage(
             toStoredProviderReference(part.image) ??
-            serializeDataOrUrl(part.image);
+              serializeDataOrUrl(part.image),
+          );
           if (
             image instanceof ArrayBuffer &&
             image.byteLength > MAX_FILE_SIZE
@@ -417,6 +438,7 @@ export async function serializeContent(
               new Blob([image], {
                 type: getMimeOrMediaType(part) || guessMimeType(image),
               }),
+              options,
             );
             image = file.url;
             fileIds.push(file.fileId);
@@ -429,14 +451,16 @@ export async function serializeContent(
           } satisfies Infer<typeof vImagePart>;
         }
         case "file": {
-          let data =
+          let data = inlineFileDataForStorage(
             toStoredProviderReference(part.data) ??
-            serializeDataOrUrl(part.data);
+              serializeDataOrUrl(part.data),
+          );
           if (data instanceof ArrayBuffer && data.byteLength > MAX_FILE_SIZE) {
             const { file } = await storeFile(
               ctx,
               component,
               new Blob([data], { type: getMimeOrMediaType(part) }),
+              options,
             );
             data = file.url;
             fileIds.push(file.fileId);
@@ -475,6 +499,7 @@ export async function serializeContent(
             ctx,
             component,
             output,
+            options,
           );
           fileIds.push(...materialized.fileRefs.map((ref) => ref.fileId));
           return serializeToolResult(
@@ -494,9 +519,26 @@ export async function serializeContent(
           } satisfies Infer<typeof vReasoningPart>;
         }
         case "reasoning-file": {
+          let fileData = serializeReasoningFile(part);
+          if (fileData.data !== undefined) {
+            fileData = { data: inlineFileDataForStorage(fileData.data) };
+          }
+          if (
+            fileData.data instanceof ArrayBuffer &&
+            fileData.data.byteLength > MAX_FILE_SIZE
+          ) {
+            const { file } = await storeFile(
+              ctx,
+              component,
+              new Blob([fileData.data], { type: part.mediaType }),
+              options,
+            );
+            fileData = { url: file.url };
+            fileIds.push(file.fileId);
+          }
           return {
             type: part.type,
-            ...serializeReasoningFile(part),
+            ...fileData,
             mediaType: part.mediaType,
             ...metadata,
           } satisfies Infer<typeof vReasoningFilePart>;
@@ -548,6 +590,17 @@ export async function serializeContent(
     content: serialized.filter((p) => p !== null) as SerializedContent,
     fileIds: fileIds.length > 0 ? fileIds : undefined,
   };
+}
+
+/** SDK responses can turn binary files into base64; retain small inline values. */
+function inlineFileDataForStorage<T>(value: T): T | ArrayBuffer {
+  if (typeof value !== "string") return value;
+  const bytes = decodeInlineFileData(value);
+  if (!bytes || bytes.byteLength <= MAX_FILE_SIZE) return value;
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
 }
 
 export function fromModelMessageContent(content: Content): Message["content"] {


### PR DESCRIPTION
Files currently deduplicate across users and have no owner field for an app to check before resolving a client-provided file ID. Add optional `files.userId`, deduplicate within that owner, and support `getFile(ctx, component, fileId, { requireUserId })`. Checked reads reject both other users' files and ownerless legacy rows before resolving storage URLs.

Carry ownership through explicit saves, generation, manual step saves, message updates, playground serialization, streamed file/reasoning chunks, and canonical tool-result files. Offload oversized base64/data-URL and reasoning payloads during final serialization as well, so SDK responses reuse and retain their stream-created files.

Add `files.deleteFilesWithStorageIds` and update the vacuum example to delete records and unreferenced blobs in one app mutation. Remaining file records protect shared storage, including when `force` is used. Preserve v7's refcounts, upload-race cleanup, and 24-hour grace period.

Compatibility: existing unchecked server calls remain available; applications still authenticate callers and authorize thread access. Legacy ownership is not backfilled, and new scoped uploads can increase storage use. Custom jobs that delete blobs should adopt the new cleanup operation. The file docs, migration guide, changelog, and design document explain these choices.

Validation:

- `npm run build:codegen` and `npm run build`
- `npm run test`: 395 tests pass across 33 files
- `npm run typecheck`
- `npm run lint`

Coverage includes owner/other-user/unauthenticated access, legacy rows, scoped dedup and concurrent uploads, streaming/finalization/recovery, tool and reasoning files, cloning, storage aliases, and transaction rollback.

Fixes #264.
