### PR TITLE
fix(streaming): persist opted-in source parts

### DIFF
--- a/docs/streaming.mdx
+++ b/docs/streaming.mdx
@@ -51,6 +51,8 @@ deltas to prevent excessive bandwidth usage. You can pass more options to
 ```
 
 - `chunking` can be "word", "line", a regex, or a custom function.
+- `sendSources` includes source parts emitted by the model. It defaults to
+  `false`.
 - `throttleMs` is how frequently the deltas are saved. This will send multiple
   chunks per delta, writes sequentially, and will not write faster than the
   throttleMs

--- a/src/vercel/client/streamText.test.ts
+++ b/src/vercel/client/streamText.test.ts
@@ -9,9 +9,11 @@ import {
   anyApi,
 } from "convex/server";
 import { v } from "convex/values";
+import type { LanguageModelV4Source } from "@ai-sdk/provider";
 import { components, initConvexTest } from "./setup.test.js";
 import { mockModel } from "./mockModel.js";
 import { runStreamCleanup } from "./streamText.js";
+import type { StreamingOptions } from "./streaming.js";
 import { errorToString } from "./utils.js";
 
 const schema = defineSchema({});
@@ -56,6 +58,31 @@ const failingAgent = new Agent(components.agent, {
   }),
 });
 
+const sourceParts: LanguageModelV4Source[] = [
+  {
+    type: "source",
+    sourceType: "url",
+    id: "source-url-1",
+    url: "https://example.com/reference",
+    title: "Reference",
+  },
+  {
+    type: "source",
+    sourceType: "document",
+    id: "source-document-1",
+    mediaType: "application/pdf",
+    title: "Document",
+    filename: "document.pdf",
+  },
+];
+
+const sourceAgent = new Agent(components.agent, {
+  name: "source-stream-test",
+  languageModel: mockModel({
+    content: [{ type: "text", text: FINAL_TEXT }, ...sourceParts],
+  }),
+});
+
 // Action that exercises streamText with saveStreamDeltas.returnImmediately=true.
 // It consumes the stream after streamText returns, simulating the HTTP response
 // path described in issue #265.
@@ -77,7 +104,6 @@ export const streamTextReturnImmediately = action({
     // Drain the stream the way an HTTP response would. This triggers
     // onStepFinish for every step, including the final one.
     await result.consumeStream();
-    return { ok: true };
   },
 });
 
@@ -282,6 +308,26 @@ export const streamTextEmptyNoStorageAwaited = action({
   },
 });
 
+export const streamTextWithSources = action({
+  args: { threadId: v.string(), sendSources: v.optional(v.boolean()) },
+  handler: async (ctx, { threadId, sendSources }) => {
+    const saveStreamDeltas: StreamingOptions = {
+      chunking: "word",
+      throttleMs: 0,
+    };
+    if (sendSources !== undefined) {
+      saveStreamDeltas.sendSources = sendSources;
+    }
+    await sourceAgent.streamText(
+      ctx,
+      { threadId },
+      { prompt: "Test" },
+      { saveStreamDeltas },
+    );
+    return { ok: true };
+  },
+});
+
 const testApi: ApiFromModules<{
   fns: {
     streamTextReturnImmediately: typeof streamTextReturnImmediately;
@@ -294,8 +340,89 @@ const testApi: ApiFromModules<{
     streamTextEmptyAwaited: typeof streamTextEmptyAwaited;
     streamTextEmptyReturnImmediately: typeof streamTextEmptyReturnImmediately;
     streamTextCleanupFailure: typeof streamTextCleanupFailure;
+    streamTextWithSources: typeof streamTextWithSources;
   };
 }>["fns"] = anyApi["streamText.test"] as any;
+
+describe("streamText source visibility", () => {
+  test.each([
+    { name: "omitted", sendSources: undefined },
+    { name: "enabled", sendSources: true },
+  ])(
+    "keeps awaited deltas healthy with sources $name",
+    async ({ sendSources }) => {
+      const t = initConvexTest(schema);
+      const threadId = await t.run(async (ctx) =>
+        createThread(ctx, components.agent, { userId: "u1" }),
+      );
+
+      await t.action(testApi.streamTextWithSources, {
+        threadId,
+        ...(sendSources === undefined ? {} : { sendSources }),
+      });
+
+      const streams = await t.run(async (ctx) =>
+        ctx.runQuery(components.agent.streams.list, {
+          threadId,
+          statuses: ["streaming", "finished", "aborted"],
+        }),
+      );
+      expect(streams).toEqual([
+        expect.objectContaining({ status: "finished" }),
+      ]);
+      const deltas = await t.run(async (ctx) =>
+        ctx.runQuery(components.agent.streams.listDeltas, {
+          threadId,
+          cursors: streams.map((stream) => ({
+            streamId: stream.streamId,
+            cursor: 0,
+          })),
+        }),
+      );
+      const parts = deltas.flatMap((delta) => delta.parts);
+      expect(
+        parts
+          .filter((part) => part.type === "text-delta")
+          .map((part) => part.delta)
+          .join(""),
+      ).toBe(FINAL_TEXT);
+      const streamedSources = parts.filter(
+        (part) => part.type === "source-url" || part.type === "source-document",
+      );
+      expect(streamedSources).toEqual(
+        sendSources
+          ? [
+              expect.objectContaining({
+                type: "source-url",
+                sourceId: "source-url-1",
+                url: "https://example.com/reference",
+                title: "Reference",
+              }),
+              expect.objectContaining({
+                type: "source-document",
+                sourceId: "source-document-1",
+                mediaType: "application/pdf",
+                title: "Document",
+                filename: "document.pdf",
+              }),
+            ]
+          : [],
+      );
+
+      const messages = await t.run(async (ctx) =>
+        sourceAgent.listMessages(ctx, {
+          threadId,
+          paginationOpts: { cursor: null, numItems: 50 },
+        }),
+      );
+      expect(
+        messages.page.filter(
+          (message) => message.message?.role === "assistant",
+        ),
+      ).toMatchObject([{ sources: sourceParts }]);
+    },
+  );
+});
 
 describe("streamText with saveStreamDeltas.returnImmediately (issue #265)", () => {
   test("persists the final assistant text to the messages table", async () => {

--- a/src/vercel/client/streamText.ts
+++ b/src/vercel/client/streamText.ts
@@ -9,6 +9,7 @@ import type { Context } from "@ai-sdk/provider-utils";
 import { streamText as streamTextAi } from "ai";
 import {
   compressUIMessageChunks,
+  DEFAULT_STREAMING_OPTIONS,
   DeltaStreamer,
   mergeTransforms,
   type StreamingOptions,
@@ -278,7 +279,13 @@ export async function streamText<
     typeof streamTextAi<Tools, RUNTIME_CONTEXT, OUTPUT>
   >[0]) as StreamTextResult<Tools, RUNTIME_CONTEXT, OUTPUT>;
   const stream = streamer?.consumeStream(
-    result.toUIMessageStream<AIUIMessage<Tools>>(),
+    result.toUIMessageStream<AIUIMessage<Tools>>({
+      sendSources:
+        typeof options.saveStreamDeltas === "object"
+          ? (options.saveStreamDeltas.sendSources ??
+            DEFAULT_STREAMING_OPTIONS.sendSources)
+          : DEFAULT_STREAMING_OPTIONS.sendSources,
+    }),
   );
   if (willAwaitStream) {
     try {

--- a/src/vercel/client/streaming.ts
+++ b/src/vercel/client/streaming.ts
@@ -134,6 +134,11 @@ export async function listStreams(
 
 export type StreamingOptions = {
   /**
+   * Whether source parts emitted by the model are included in the persisted
+   * delta stream. Defaults to false.
+   */
+  sendSources?: boolean;
+  /**
    * The minimum granularity of deltas to save.
    * Note: this is not a guarantee that every delta will be exactly one line.
    * E.g. if "line" is specified, it won't save any deltas until it encounters
@@ -156,6 +161,7 @@ export type StreamingOptions = {
   returnImmediately?: boolean;
 };
 export const DEFAULT_STREAMING_OPTIONS = {
+  sendSources: false,
   // This chunks by sentences / clauses. Punctuation followed by whitespace.
   chunking: /[\p{P}\s]/u,
   throttleMs: 250,


### PR DESCRIPTION
## Summary

Expose the AI SDK’s `sendSources` option through `saveStreamDeltas`, preserving the existing default of `false`. Source URL and document parts now reach the persisted delta stream when callers opt in.

Closes #353

## Verification

381 tests, typecheck, and lint pass.