### PR TITLE
Preserve stream cleanup order across statuses

### DIFF
--- a/src/component/streams.test.ts
+++ b/src/component/streams.test.ts
@@ -1,9 +1,11 @@
 /// <reference types="vite/client" />
 
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
 import { initConvexTest } from "./setup.test.js";
+
+afterEach(() => vi.useRealTimers());
 
 async function seedStream(t: ReturnType<typeof initConvexTest>) {
   const thread = await t.mutation(api.threads.createThread, {
@@ -105,5 +107,56 @@ describe("streams", () => {
     );
     expect(stream?.state.kind).toBe("finished");
     expect(stream?.fileRefs).toBeUndefined();
+  });
+
+  test("bulk deletion preserves global stream order across status lanes", async () => {
+    vi.useFakeTimers();
+
+    const t = initConvexTest();
+    const thread = await t.mutation(api.threads.createThread, {
+      userId: "stream-cleanup",
+    });
+    const threadId = thread._id as Id<"threads">;
+    const earlyStreamId = await t.run(async (ctx) => {
+      const streamId = await ctx.db.insert("streamingMessages", {
+        threadId,
+        order: 1,
+        stepOrder: 0,
+        format: "UIMessageChunk",
+        state: { kind: "streaming", lastHeartbeat: Date.now() },
+      });
+      await ctx.db.insert("streamingMessages", {
+        threadId,
+        order: 9,
+        stepOrder: 0,
+        format: "UIMessageChunk",
+        state: { kind: "aborted", reason: "retained regeneration" },
+      });
+      await ctx.db.insert("streamDeltas", {
+        streamId,
+        start: 0,
+        end: 1,
+        parts: [{ type: "text-start", id: "text" }],
+      });
+      return streamId;
+    });
+
+    await t.mutation(api.streams.deleteAllStreamsForThreadIdAsync, {
+      threadId,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(
+      await t.query(api.streams.list, {
+        threadId,
+        statuses: ["streaming", "finished", "aborted"],
+      }),
+    ).toEqual([]);
+    expect(
+      await t.query(api.streams.listDeltas, {
+        threadId,
+        cursors: [{ streamId: earlyStreamId, cursor: 0 }],
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/component/streams.ts
+++ b/src/component/streams.ts
@@ -470,8 +470,6 @@ export async function deleteStreamsPageForThreadId(
       );
   let deltaCursor = args.deltaCursor;
   const streamMessage = await mergedStream(allStreamMessages, [
-    "threadId",
-    "state.kind",
     "order",
     "stepOrder",
   ]).first();


### PR DESCRIPTION
Each status-specific stream query already equality-binds `threadId` and `state.kind`, but bulk cleanup included both fields in the merged ordering key. That sorted status ahead of stream order, while the continuation retained only `streamOrder`, allowing a higher-order row in one status to skip lower-order rows in another.

Merge the lanes by the remaining indexed order fields, `order` and `stepOrder`, and cover the behavior through public bulk cleanup.

Fixes #357