### PR TITLE
fix: make tool approvals atomic and resumable

### DIFF
--- a/docs/tool-approval.mdx
+++ b/docs/tool-approval.mdx
@@ -60,7 +60,7 @@ The typical approval flow involves four server functions:
    thread.
 3. **Submit an approval or denial** for each pending tool call.
    `approveToolCall` and `denyToolCall` work from both mutations and actions.
-4. **Continue generation** once all pending approvals have been resolved.
+4. **Continue generation** from the returned message ID.
 
 ```ts
 import { approvalAgent } from "../agents/approval";
@@ -115,7 +115,7 @@ export const submitApproval = mutation({
   },
 });
 
-// 4. Continue generation after all approvals resolved.
+// 4. Continue generation from the saved approval decision.
 //    Pass the last approval message ID as promptMessageId so the agent
 //    resumes generation from where the approval was issued.
 export const continueAfterApprovals = internalAction({
@@ -142,11 +142,35 @@ For example, an action can call `approveToolCall` and then immediately call
 ## Handling multiple tool calls
 
 When the model calls several tools in a single step, some or all of them may
-require approval. **Every** pending approval must be resolved (approved or
-denied) before you continue generation.
+require approval. Submit decisions from the same assistant request together
+with `respondToToolCallApprovals`. The batch uses one bounded lookup and one
+write, and either every decision is saved or none are.
 
-If a new generation starts while approvals are still unresolved, the
-unresolved approvals are **automatically denied** with the reason
+```ts
+const { messageId } = await approvalAgent.respondToToolCallApprovals(ctx, {
+  threadId,
+  decisions: [
+    { approvalId: "delete-file", approved: true },
+    {
+      approvalId: "send-email",
+      approved: false,
+      reason: "Wrong recipient",
+    },
+  ],
+});
+```
+
+You may also submit and resume a subset. Sibling approvals that have not been
+decided remain pending and can be resumed later. `approveToolCall` and
+`denyToolCall` remain available for single decisions and use the same atomic
+path. For multiple decisions, use the batch method instead of looping over the
+single-decision helpers so the request history is read only once.
+
+If a partial continuation requests another approval, that newer request also
+remains pending while you resume an earlier sibling.
+
+If an unrelated generation starts while approvals are still unresolved, they
+are **automatically denied** with the reason
 `"auto-denied: new generation started"`. This prevents broken message
 histories where tool calls lack results.
 

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -27,7 +27,7 @@ export function planToolCallApprovals(
   threadId: string,
 ): { requestMessageId: string; message: Extract<Message, { role: "tool" }> } {
   const pending = new Set(decisions.map(({ approvalId }) => approvalId));
-  const requests = new Map<string, MessageDoc>();
+  let requestMessageId: string | undefined;
   const providerExecuted = new Set<string>();
 
   for (const doc of messages) {
@@ -48,7 +48,12 @@ export function planToolCallApprovals(
         part.type === "tool-approval-request" &&
         doc.message.role === "assistant"
       ) {
-        requests.set(part.approvalId, doc);
+        if (requestMessageId && requestMessageId !== doc._id) {
+          throw new Error(
+            "Approval decisions in one batch must belong to the same request message",
+          );
+        }
+        requestMessageId = doc._id;
         if (providerCalls.has(part.toolCallId)) {
           providerExecuted.add(part.approvalId);
         }
@@ -64,15 +69,8 @@ export function planToolCallApprovals(
     );
   }
 
-  const request = requests.get(decisions[0].approvalId)!;
-  if ([...requests.values()].some((doc) => doc._id !== request._id)) {
-    throw new Error(
-      "Approval decisions in one batch must belong to the same request message",
-    );
-  }
-
   return {
-    requestMessageId: request._id,
+    requestMessageId: requestMessageId!,
     message: {
       role: "tool",
       content: decisions.map(({ approvalId, approved, reason }) => ({

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -1,0 +1,87 @@
+import type { Message, MessageDoc } from "./validators.js";
+
+type ToolCallApprovalDecision = {
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+};
+
+export function validateApprovalDecisions(
+  decisions: ToolCallApprovalDecision[],
+) {
+  if (decisions.length === 0) {
+    throw new Error("An approval batch must contain at least one decision");
+  }
+  const approvalIds = new Set<string>();
+  for (const { approvalId } of decisions) {
+    if (approvalIds.has(approvalId)) {
+      throw new Error(`Duplicate approval ${approvalId} in batch`);
+    }
+    approvalIds.add(approvalId);
+  }
+}
+
+export function planToolCallApprovals(
+  messages: MessageDoc[],
+  decisions: ToolCallApprovalDecision[],
+  threadId: string,
+): { requestMessageId: string; message: Extract<Message, { role: "tool" }> } {
+  const pending = new Set(decisions.map(({ approvalId }) => approvalId));
+  const requests = new Map<string, MessageDoc>();
+  const providerExecuted = new Set<string>();
+
+  for (const doc of messages) {
+    if (!Array.isArray(doc.message?.content)) continue;
+    const providerCalls = new Set(
+      doc.message.content.flatMap((part) =>
+        part.type === "tool-call" && part.providerExecuted
+          ? [part.toolCallId]
+          : [],
+      ),
+    );
+    for (const part of doc.message.content) {
+      if (!("approvalId" in part) || !pending.has(part.approvalId)) continue;
+      if (part.type === "tool-approval-response") {
+        throw new Error(`Approval ${part.approvalId} was already handled`);
+      }
+      if (
+        part.type === "tool-approval-request" &&
+        doc.message.role === "assistant"
+      ) {
+        requests.set(part.approvalId, doc);
+        if (providerCalls.has(part.toolCallId)) {
+          providerExecuted.add(part.approvalId);
+        }
+        pending.delete(part.approvalId);
+      }
+    }
+    if (pending.size === 0) break;
+  }
+
+  if (pending.size > 0) {
+    throw new Error(
+      `Approval request ${pending.values().next().value} was not found in the last 100 messages of thread ${threadId}`,
+    );
+  }
+
+  const request = requests.get(decisions[0].approvalId)!;
+  if ([...requests.values()].some((doc) => doc._id !== request._id)) {
+    throw new Error(
+      "Approval decisions in one batch must belong to the same request message",
+    );
+  }
+
+  return {
+    requestMessageId: request._id,
+    message: {
+      role: "tool",
+      content: decisions.map(({ approvalId, approved, reason }) => ({
+        type: "tool-approval-response",
+        approvalId,
+        approved,
+        reason,
+        ...(providerExecuted.has(approvalId) ? { providerExecuted: true } : {}),
+      })),
+    },
+  };
+}

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -2944,6 +2944,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         },
         Name
       >;
+      respondToToolCallApprovals: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          agentName?: string;
+          decisions: Array<{
+            approvalId: string;
+            approved: boolean;
+            reason?: string;
+          }>;
+          threadId: string;
+        },
+        { messageId: string },
+        Name
+      >;
       searchMessages: FunctionReference<
         "action",
         "internal",

--- a/src/component/messages.ts
+++ b/src/component/messages.ts
@@ -47,6 +47,10 @@ import {
   abortStreamsAtOrder,
 } from "./streams.js";
 import { partial } from "convex-helpers/validators";
+import {
+  planToolCallApprovals,
+  validateApprovalDecisions,
+} from "../approvals.js";
 
 function publicMessage(message: Doc<"messages">): MessageDoc {
   return omit(message, ["parentMessageId", "stepId", "files"]);
@@ -579,6 +583,42 @@ export const updateMessage = mutation({
 
     await ctx.db.patch("messages", args.messageId, patch);
     return publicMessage((await ctx.db.get("messages", args.messageId))!);
+  },
+});
+
+export const respondToToolCallApprovals = mutation({
+  args: {
+    threadId: v.id("threads"),
+    agentName: v.optional(v.string()),
+    decisions: v.array(
+      v.object({
+        approvalId: v.string(),
+        approved: v.boolean(),
+        reason: v.optional(v.string()),
+      }),
+    ),
+  },
+  returns: v.object({ messageId: v.id("messages") }),
+  handler: async (ctx, args) => {
+    validateApprovalDecisions(args.decisions);
+    const page = await listMessagesByThreadIdHandler(ctx, {
+      threadId: args.threadId,
+      order: "desc",
+      paginationOpts: { cursor: null, numItems: 100 },
+    });
+    const plan = planToolCallApprovals(
+      page.page,
+      args.decisions,
+      args.threadId,
+    );
+    const saved = await addMessagesHandler(ctx, {
+      threadId: args.threadId,
+      agentName: args.agentName,
+      promptMessageId: plan.requestMessageId as Id<"messages">,
+      failPendingSteps: false,
+      messages: [{ message: plan.message }],
+    });
+    return { messageId: saved.messages[0]._id as Id<"messages"> };
   },
 });
 

--- a/src/vercel/client/approval.test.ts
+++ b/src/vercel/client/approval.test.ts
@@ -372,11 +372,15 @@ export const testMultiToolApproveFlow = action({
       approvalCount: approvalParts.length,
       firstText: result1.text,
       secondText: result2.text,
-      threadMessageRoles: allMessages.page.map((m) => m.message?.role),
-      // Check that both approvals were merged into one tool message
-      toolMessageCount: allMessages.page.filter(
-        (m) => m.message?.role === "tool",
-      ).length,
+      toolResultIds: allMessages.page
+        .flatMap((message) =>
+          message.message?.role === "tool"
+            ? message.message.content.flatMap((part) =>
+                part.type === "tool-result" ? [part.toolCallId] : [],
+              )
+            : [],
+        )
+        .sort(),
     };
   },
 });
@@ -496,14 +500,7 @@ describe("Tool Approval Workflow", () => {
     expect(result.secondText).toBe(
       "Done! Deleted old.txt and renamed a.txt to b.txt.",
     );
-    // Executed results are persisted separately from approval responses.
-    expect(result.threadMessageRoles).toEqual([
-      "assistant", // final text
-      "tool", // tool-results
-      "tool", // approval-responses
-      "assistant", // tool-calls + approval-requests
-      "user", // prompt
-    ]);
+    expect(result.toolResultIds).toEqual(["tc-multi-1", "tc-multi-2"]);
   });
 
   test("approve remains valid with an intervening thread message", async () => {

--- a/src/vercel/client/batchApprovals.test.ts
+++ b/src/vercel/client/batchApprovals.test.ts
@@ -1,0 +1,581 @@
+import type { ModelMessage } from "ai";
+import { defineSchema } from "convex/server";
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod/v4";
+import component from "../../test.js";
+import type { Message } from "../../validators.js";
+import { Agent, createTool, type ContextHandler } from "../index.js";
+import { MockLanguageModel } from "./mockModel.js";
+import { components, modules } from "./setup.test.js";
+
+const executed: string[] = [];
+const model = new MockLanguageModel({
+  content: [{ type: "text", text: "Done" }],
+});
+const agent = new Agent(components.agent, {
+  name: "batch-approval-test",
+  languageModel: model,
+  tools: {
+    echo: createTool({
+      inputSchema: z.object({ tag: z.string() }),
+      needsApproval: true,
+      execute: async (_ctx, { tag }) => {
+        executed.push(tag);
+        return tag;
+      },
+    }),
+  },
+});
+
+type ContextMode = "change-input" | "remove-result" | "fabricate-approval";
+
+function contextHandler(mode: ContextMode): ContextHandler {
+  return async (_ctx, { allMessages }): Promise<ModelMessage[]> => {
+    if (mode === "fabricate-approval") {
+      return [
+        ...allMessages,
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "b",
+              approved: true,
+            },
+          ],
+        },
+      ];
+    }
+    if (mode === "remove-result") {
+      const filtered: ModelMessage[] = [];
+      for (const message of allMessages) {
+        if (message.role !== "tool") {
+          filtered.push(message);
+          continue;
+        }
+        const content = message.content.filter(
+          (part) => part.type !== "tool-result" || part.toolCallId !== "call-a",
+        );
+        if (content.length > 0) filtered.push({ ...message, content });
+      }
+      return filtered;
+    }
+    return allMessages.map((message) => {
+      if (message.role !== "assistant" || typeof message.content === "string") {
+        return message;
+      }
+      return {
+        ...message,
+        content: message.content.map((part) =>
+          part.type === "tool-call" && part.toolCallId === "call-a"
+            ? { ...part, input: { tag: "changed" } }
+            : part,
+        ),
+      };
+    });
+  };
+}
+
+type Decision = {
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+};
+
+function request(ids: string[], providerExecuted = false): Message {
+  return {
+    role: "assistant",
+    content: ids.flatMap((approvalId) => [
+      {
+        type: "tool-call" as const,
+        toolCallId: `call-${approvalId}`,
+        toolName: "echo",
+        input: { tag: approvalId },
+        ...(providerExecuted ? { providerExecuted: true } : {}),
+      },
+      {
+        type: "tool-approval-request" as const,
+        toolCallId: `call-${approvalId}`,
+        approvalId,
+      },
+    ]),
+  };
+}
+
+type Limits = {
+  bytesRead?: number;
+  bytesWritten?: number;
+  documentsRead?: number;
+  documentsWritten?: number;
+};
+
+async function fixture({
+  ids = ["a", "b"],
+  olderMessages = 0,
+  providerExecuted = false,
+  transactionLimits = true,
+}: {
+  ids?: string[];
+  olderMessages?: number;
+  providerExecuted?: boolean;
+  transactionLimits?: true | Limits;
+} = {}) {
+  const t = convexTest({
+    schema: defineSchema({}),
+    modules,
+    transactionLimits,
+  });
+  component.register(t);
+  const { threadId } = await t.run((ctx) => agent.createThread(ctx));
+  if (olderMessages > 0) {
+    for (let start = 0; start < olderMessages; start += 10) {
+      await t.run((ctx) =>
+        agent.saveMessages(ctx, {
+          threadId,
+          messages: Array.from(
+            { length: Math.min(10, olderMessages - start) },
+            (_, offset) => ({
+              role: "user" as const,
+              content: `${start + offset}:${"x".repeat(4_000)}`,
+            }),
+          ),
+          skipEmbeddings: true,
+        }),
+      );
+    }
+  }
+  const { messageId: promptMessageId } = await t.run((ctx) =>
+    agent.saveMessage(ctx, { threadId, prompt: "Run the tools" }),
+  );
+  const { messageId: requestMessageId } = await t.run((ctx) =>
+    agent.saveMessage(ctx, {
+      threadId,
+      promptMessageId,
+      message: request(ids, providerExecuted),
+      skipEmbeddings: true,
+    }),
+  );
+  const messages = () =>
+    t.run((ctx) =>
+      agent.listMessages(ctx, {
+        threadId,
+        paginationOpts: { cursor: null, numItems: 200 },
+      }),
+    );
+  const results = async () =>
+    (await messages()).page.flatMap((stored) =>
+      stored.message?.role === "tool"
+        ? stored.message.content.filter((part) => part.type === "tool-result")
+        : [],
+    );
+  return {
+    t,
+    threadId,
+    promptMessageId,
+    requestMessageId,
+    messages,
+    results,
+  };
+}
+
+function lastModelPrompt(streaming = false) {
+  const calls = streaming ? model.doStreamCalls : model.doGenerateCalls;
+  const prompt = calls.at(-1)?.prompt;
+  expect(prompt).toBeDefined();
+  return prompt ?? [];
+}
+
+function expectNoDanglingLocalCalls(streaming = false) {
+  const calls = new Set<string>();
+  const results = new Set<string>();
+  for (const message of lastModelPrompt(streaming)) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (part.type === "tool-call" && !part.providerExecuted) {
+        calls.add(part.toolCallId);
+      }
+      if (part.type === "tool-result") results.add(part.toolCallId);
+    }
+  }
+  expect([...calls].filter((id) => !results.has(id))).toEqual([]);
+}
+
+async function submitDecisions(
+  t: Awaited<ReturnType<typeof fixture>>["t"],
+  threadId: string,
+  decisions: Decision[],
+): Promise<{ messageId: string }> {
+  return t.run((ctx) =>
+    agent.respondToToolCallApprovals(ctx, { threadId, decisions }),
+  );
+}
+
+async function submitAndCatch(
+  t: Awaited<ReturnType<typeof fixture>>["t"],
+  threadId: string,
+  decisions: Decision[],
+) {
+  return t.run(async (ctx) => {
+    try {
+      await agent.respondToToolCallApprovals(ctx, { threadId, decisions });
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  });
+}
+
+async function continueGeneration(
+  t: Awaited<ReturnType<typeof fixture>>["t"],
+  args: {
+    threadId: string;
+    promptMessageId: string;
+    streaming?: boolean;
+    contextMode?: ContextMode;
+  },
+) {
+  return t.action(async (ctx) => {
+    const options = args.contextMode
+      ? { contextHandler: contextHandler(args.contextMode) }
+      : undefined;
+    if (args.streaming) {
+      const result = await agent.streamText(
+        ctx,
+        { threadId: args.threadId },
+        { promptMessageId: args.promptMessageId },
+        options,
+      );
+      await result.consumeStream();
+      return result.text;
+    }
+    const result = await agent.generateText(
+      ctx,
+      { threadId: args.threadId },
+      { promptMessageId: args.promptMessageId },
+      options,
+    );
+    return result.text;
+  });
+}
+
+afterEach(() => {
+  executed.length = 0;
+  model.doGenerateCalls.length = 0;
+  model.doStreamCalls.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("respondToToolCallApprovals", () => {
+  test.each([false, true])(
+    "continues a mixed batch through generateText and streamText (streaming=%s)",
+    async (streaming) => {
+      const { t, threadId, results } = await fixture({
+        ids: ["a", "b", "c"],
+      });
+      const { messageId } = await submitDecisions(t, threadId, [
+        { approvalId: "a", approved: true },
+        { approvalId: "b", approved: false, reason: "Not permitted" },
+        { approvalId: "c", approved: true },
+      ]);
+
+      expect(executed).toEqual([]);
+      await continueGeneration(t, {
+        threadId,
+        promptMessageId: messageId,
+        streaming,
+      });
+
+      expect(executed).toEqual(["a", "c"]);
+      expectNoDanglingLocalCalls(streaming);
+      const storedResults = await results();
+      expect(storedResults).toHaveLength(3);
+      expect(storedResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ toolCallId: "call-a" }),
+          expect.objectContaining({
+            toolCallId: "call-b",
+            output: { type: "execution-denied", reason: "Not permitted" },
+          }),
+          expect.objectContaining({ toolCallId: "call-c" }),
+        ]),
+      );
+    },
+  );
+
+  test("combines separately submitted siblings before continuation", async () => {
+    const { t, threadId, results } = await fixture();
+    await submitDecisions(t, threadId, [{ approvalId: "a", approved: true }]);
+    const { messageId } = await submitDecisions(t, threadId, [
+      { approvalId: "b", approved: true },
+    ]);
+
+    await continueGeneration(t, { threadId, promptMessageId: messageId });
+
+    expect(executed).toEqual(["a", "b"]);
+    expectNoDanglingLocalCalls();
+    expect((await results()).map((part) => part.toolCallId).sort()).toEqual([
+      "call-a",
+      "call-b",
+    ]);
+  });
+
+  test.each([false, true])(
+    "resumes a later sibling without repeating completed work (streaming=%s)",
+    async (streaming) => {
+      const { t, threadId, results } = await fixture();
+      const first = await submitDecisions(t, threadId, [
+        { approvalId: "a", approved: true },
+      ]);
+      await continueGeneration(t, {
+        threadId,
+        promptMessageId: first.messageId,
+        streaming,
+      });
+
+      expect(executed).toEqual(["a"]);
+      expectNoDanglingLocalCalls(streaming);
+      expect((await results()).map((part) => part.toolCallId)).toEqual([
+        "call-a",
+      ]);
+
+      const second = await submitDecisions(t, threadId, [
+        { approvalId: "b", approved: true },
+      ]);
+      await continueGeneration(t, {
+        threadId,
+        promptMessageId: second.messageId,
+        streaming,
+      });
+
+      expect(executed).toEqual(["a", "b"]);
+      expectNoDanglingLocalCalls(streaming);
+      expect((await results()).map((part) => part.toolCallId).sort()).toEqual([
+        "call-a",
+        "call-b",
+      ]);
+    },
+  );
+
+  test("records a substantial batch within a bounded transaction", async () => {
+    const ids = Array.from({ length: 24 }, (_, index) => `approval-${index}`);
+    const { t, threadId, results } = await fixture({
+      ids,
+      olderMessages: 80,
+      transactionLimits: {
+        bytesRead: 1_200_000,
+        bytesWritten: 200_000,
+        documentsRead: 220,
+        documentsWritten: 16,
+      },
+    });
+
+    const { messageId } = await submitDecisions(
+      t,
+      threadId,
+      ids.map((approvalId) => ({
+        approvalId,
+        approved: true,
+        reason: "r".repeat(2_000),
+      })),
+    );
+    expect(typeof messageId).toBe("string");
+    expect(executed).toEqual([]);
+
+    await continueGeneration(t, { threadId, promptMessageId: messageId });
+    expect([...executed].sort()).toEqual([...ids].sort());
+    expect(await results()).toHaveLength(ids.length);
+  });
+
+  test.each([
+    "empty",
+    "missing",
+    "duplicate",
+    "already-handled",
+    "different-request-message",
+    "another-thread",
+  ] as const)("rejects an atomic invalid batch: %s", async (kind) => {
+    const { t, threadId, requestMessageId, messages } = await fixture();
+    let decisions: Decision[];
+    let expectedError: RegExp;
+    if (kind === "empty") {
+      decisions = [];
+      expectedError = /at least one|empty/i;
+    } else if (kind === "missing") {
+      decisions = [
+        { approvalId: "a", approved: true },
+        { approvalId: "missing", approved: true },
+      ];
+      expectedError = /not found/i;
+    } else if (kind === "duplicate") {
+      decisions = [
+        { approvalId: "a", approved: true },
+        { approvalId: "a", approved: false },
+      ];
+      expectedError = /duplicate/i;
+    } else if (kind === "already-handled") {
+      await submitDecisions(t, threadId, [{ approvalId: "a", approved: true }]);
+      decisions = [
+        { approvalId: "a", approved: false },
+        { approvalId: "b", approved: true },
+      ];
+      expectedError = /already handled/i;
+    } else if (kind === "different-request-message") {
+      await t.run((ctx) =>
+        agent.saveMessage(ctx, {
+          threadId,
+          promptMessageId: requestMessageId,
+          message: request(["c"]),
+          skipEmbeddings: true,
+        }),
+      );
+      decisions = [
+        { approvalId: "a", approved: true },
+        { approvalId: "c", approved: true },
+      ];
+      expectedError = /same.*message|request message/i;
+    } else {
+      const { threadId: otherThreadId } = await t.run((ctx) =>
+        agent.createThread(ctx),
+      );
+      const { messageId: otherPromptId } = await t.run((ctx) =>
+        agent.saveMessage(ctx, {
+          threadId: otherThreadId,
+          prompt: "Other thread",
+        }),
+      );
+      await t.run((ctx) =>
+        agent.saveMessage(ctx, {
+          threadId: otherThreadId,
+          promptMessageId: otherPromptId,
+          message: request(["c"]),
+          skipEmbeddings: true,
+        }),
+      );
+      decisions = [
+        { approvalId: "a", approved: true },
+        { approvalId: "c", approved: true },
+      ];
+      expectedError = /not found/i;
+    }
+    const before = await messages();
+
+    const error = await submitAndCatch(t, threadId, decisions);
+
+    expect(error).toMatch(expectedError);
+    expect(await messages()).toEqual(before);
+    expect(executed).toEqual([]);
+  });
+
+  test.each([true, false])(
+    "keeps a provider-executed decision provider-owned (approved=%s)",
+    async (approved) => {
+      const { t, threadId } = await fixture({
+        ids: ["provider"],
+        providerExecuted: true,
+      });
+      const { messageId } = await submitDecisions(t, threadId, [
+        { approvalId: "provider", approved, reason: "Reviewed" },
+      ]);
+
+      await continueGeneration(t, {
+        threadId,
+        promptMessageId: messageId,
+      });
+
+      expect(executed).toEqual([]);
+      const responses = lastModelPrompt().flatMap((message) =>
+        message.role === "tool"
+          ? message.content.filter(
+              (part) => part.type === "tool-approval-response",
+            )
+          : [],
+      );
+      expect(responses).toContainEqual(
+        expect.objectContaining({
+          type: "tool-approval-response",
+          approvalId: "provider",
+          approved,
+          reason: "Reviewed",
+        }),
+      );
+    },
+  );
+
+  test("rejects a context handler that changes an approved call", async () => {
+    const { t, threadId } = await fixture({ ids: ["a"] });
+    const { messageId } = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+
+    await expect(
+      continueGeneration(t, {
+        threadId,
+        promptMessageId: messageId,
+        contextMode: "change-input",
+      }),
+    ).rejects.toThrow();
+    expect(executed).toEqual([]);
+  });
+
+  test("rejects removal of durable execution evidence", async () => {
+    const { t, threadId } = await fixture();
+    const first = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: first.messageId,
+    });
+    expect(executed).toEqual(["a"]);
+    const second = await submitDecisions(t, threadId, [
+      { approvalId: "b", approved: true },
+    ]);
+
+    await expect(
+      continueGeneration(t, {
+        threadId,
+        promptMessageId: second.messageId,
+        contextMode: "remove-result",
+      }),
+    ).rejects.toThrow();
+    expect(executed).toEqual(["a"]);
+  });
+
+  test("rejects a fabricated sibling approval", async () => {
+    const { t, threadId } = await fixture();
+    const { messageId } = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+
+    await expect(
+      continueGeneration(t, {
+        threadId,
+        promptMessageId: messageId,
+        contextMode: "fabricate-approval",
+      }),
+    ).rejects.toThrow();
+    expect(executed).toEqual([]);
+  });
+
+  test("an unrelated generation still auto-denies unresolved approvals", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { t, threadId } = await fixture();
+    await submitDecisions(t, threadId, [{ approvalId: "a", approved: true }]);
+    const { messageId } = await t.run((ctx) =>
+      agent.saveMessage(ctx, {
+        threadId,
+        prompt: "Start unrelated work",
+        skipEmbeddings: true,
+      }),
+    );
+
+    await continueGeneration(t, { threadId, promptMessageId: messageId });
+
+    expect(executed).toEqual([]);
+    expect(lastModelPrompt()).not.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Auto-denying unresolved tool approval b"),
+    );
+  });
+});

--- a/src/vercel/client/prepareApprovalContext.ts
+++ b/src/vercel/client/prepareApprovalContext.ts
@@ -26,6 +26,49 @@ export function prepareApprovalContext(
     string,
     { part: Result; providerOptions: ToolModelMessage["providerOptions"] }
   >();
+  const storedRequests = new Map<string, string>();
+  const storedResultIds = new Set<string>();
+  const providerCallIds = new Set<string>();
+  const waitingProviderApprovalIds = new Set<string>();
+  const consumedProviderApprovalIds = new Set<string>();
+  for (const message of storedMessages) {
+    if (!Array.isArray(message.content)) continue;
+    if (message.role === "assistant") {
+      // Provider-owned approvals do not always produce a tool-result. A later
+      // assistant response is the durable evidence that they were consumed.
+      for (const approvalId of waitingProviderApprovalIds) {
+        consumedProviderApprovalIds.add(approvalId);
+      }
+      waitingProviderApprovalIds.clear();
+    }
+    for (const part of message.content) {
+      if (part.type === "tool-call" && part.providerExecuted) {
+        providerCallIds.add(part.toolCallId);
+      } else if (part.type === "tool-approval-request") {
+        storedRequests.set(part.approvalId, part.toolCallId);
+      } else if (part.type === "tool-approval-response") {
+        if (
+          providerCallIds.has(storedRequests.get(part.approvalId) ?? "")
+        ) {
+          waitingProviderApprovalIds.add(part.approvalId);
+        }
+      } else if (part.type === "tool-result") {
+        storedResultIds.add(part.toolCallId);
+      }
+    }
+  }
+  const deferredApprovalIds = new Set<string>();
+  const deferredCallIds = new Set<string>();
+  for (const [approvalId, toolCallId] of storedRequests) {
+    if (
+      !approvalIds.has(approvalId) &&
+      !storedResultIds.has(toolCallId) &&
+      !consumedProviderApprovalIds.has(approvalId)
+    ) {
+      deferredApprovalIds.add(approvalId);
+      deferredCallIds.add(toolCallId);
+    }
+  }
   const activeCallIds = new Set(
     messages.flatMap((message) =>
       Array.isArray(message.content)
@@ -106,8 +149,8 @@ export function prepareApprovalContext(
     );
   }
 
-  const storedResponseIds = new Set<string>();
-  const storedResultIds = new Set<string>();
+  const preservedResponseIds = new Set<string>();
+  const preservedResultIds = new Set<string>();
   for (const message of storedMessages) {
     if (!Array.isArray(message.content)) continue;
     for (const part of message.content) {
@@ -121,12 +164,12 @@ export function prepareApprovalContext(
         part.type === "tool-approval-response" &&
         approvalIds.has(part.approvalId)
       ) {
-        storedResponseIds.add(part.approvalId);
+        preservedResponseIds.add(part.approvalId);
         supplied = responses.get(part.approvalId);
       } else if (part.type === "tool-call" && callIds.has(part.toolCallId)) {
         supplied = calls.get(part.toolCallId);
       } else if (part.type === "tool-result" && callIds.has(part.toolCallId)) {
-        storedResultIds.add(part.toolCallId);
+        preservedResultIds.add(part.toolCallId);
         if (!results.has(part.toolCallId)) {
           throw new Error(
             `Continuation context removed result for ${part.toolCallId}`,
@@ -136,7 +179,10 @@ export function prepareApprovalContext(
       } else {
         continue;
       }
-      if (!supplied || signature(supplied) !== signature(part)) {
+      if (
+        !supplied ||
+        approvalPartSignature(supplied) !== approvalPartSignature(part)
+      ) {
         throw new Error(
           "Continuation context must preserve stored approval decisions and tool calls",
         );
@@ -144,10 +190,10 @@ export function prepareApprovalContext(
     }
   }
 
-  if ([...responses.keys()].some((id) => !storedResponseIds.has(id))) {
+  if ([...responses.keys()].some((id) => !preservedResponseIds.has(id))) {
     throw new Error("Continuation context cannot add approval decisions");
   }
-  if ([...results].some((id) => !storedResultIds.has(id))) {
+  if ([...results].some((id) => !preservedResultIds.has(id))) {
     throw new Error(
       "Continuation context cannot add results for approved tool calls",
     );
@@ -162,7 +208,12 @@ export function prepareApprovalContext(
         `Approval ${approvalId} is missing its request or tool call in continuation context`,
       );
     }
-    if (results.has(request.toolCallId)) continue;
+    if (
+      results.has(request.toolCallId) ||
+      consumedProviderApprovalIds.has(approvalId)
+    ) {
+      continue;
+    }
     if (responses.has(approvalId)) pending.add(request.toolCallId);
     else deferred.add(request.toolCallId);
   }
@@ -179,6 +230,19 @@ export function prepareApprovalContext(
       continue;
     }
     const content = message.content.filter((part) => {
+      if (
+        (part.type === "tool-call" ||
+          part.type === "tool-approval-request") &&
+        deferredCallIds.has(part.toolCallId)
+      ) {
+        return false;
+      }
+      if (
+        part.type === "tool-approval-response" &&
+        deferredApprovalIds.has(part.approvalId)
+      ) {
+        return false;
+      }
       if (
         part.type === "tool-result" &&
         resultMessages.has(part.toolCallId) &&
@@ -229,8 +293,9 @@ export function prepareApprovalContext(
           tool.providerOptions = message.providerOptions;
           toolOptionsSet = true;
           tool.content.push(part);
+          return false;
         }
-        return false;
+        return calls.get(request.toolCallId)?.providerExecuted === true;
       }
       return true;
     });
@@ -262,6 +327,32 @@ export function prepareApprovalContext(
 
   if (pending.size > 0) projected.push(assistant, tool);
   return projected;
+}
+
+function approvalPartSignature(part: Request | Call | Response): string {
+  if (part.type === "tool-approval-request") {
+    return signature({
+      type: part.type,
+      approvalId: part.approvalId,
+      toolCallId: part.toolCallId,
+    });
+  }
+  if (part.type === "tool-call") {
+    return signature({
+      type: part.type,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      input: part.input,
+      providerExecuted: part.providerExecuted ?? false,
+    });
+  }
+  return signature({
+    type: part.type,
+    approvalId: part.approvalId,
+    approved: part.approved,
+    reason: part.reason,
+    providerExecuted: part.providerExecuted ?? false,
+  });
 }
 
 function signature(value: unknown): string {

--- a/src/vercel/client/prepareApprovalContext.ts
+++ b/src/vercel/client/prepareApprovalContext.ts
@@ -1,0 +1,269 @@
+import type { AssistantModelMessage, ModelMessage, ToolModelMessage } from "ai";
+import { convexToJson, type Value } from "convex/values";
+
+type AssistantPart = Exclude<AssistantModelMessage["content"], string>[number];
+type Request = Extract<AssistantPart, { type: "tool-approval-request" }>;
+type Call = Extract<AssistantPart, { type: "tool-call" }>;
+type Response = Extract<
+  ToolModelMessage["content"][number],
+  { type: "tool-approval-response" }
+>;
+type Result = Extract<
+  ToolModelMessage["content"][number],
+  { type: "tool-result" }
+>;
+
+export function prepareApprovalContext(
+  messages: ModelMessage[],
+  approvalIds: ReadonlySet<string>,
+  storedMessages: ModelMessage[],
+): ModelMessage[] {
+  const requests = new Map<string, Request>();
+  const calls = new Map<string, Call>();
+  const responses = new Map<string, Response>();
+  const results = new Set<string>();
+  const resultMessages = new Map<
+    string,
+    { part: Result; providerOptions: ToolModelMessage["providerOptions"] }
+  >();
+  const activeCallIds = new Set(
+    messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.flatMap((part) =>
+            part.type === "tool-approval-request" &&
+            approvalIds.has(part.approvalId)
+              ? [part.toolCallId]
+              : [],
+          )
+        : [],
+    ),
+  );
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (
+        part.type === "tool-approval-request" &&
+        approvalIds.has(part.approvalId)
+      ) {
+        if (requests.has(part.approvalId)) {
+          throw new Error(
+            `Ambiguous approval request ${part.approvalId} in continuation context`,
+          );
+        }
+        requests.set(part.approvalId, part);
+      } else if (
+        part.type === "tool-approval-request" &&
+        activeCallIds.has(part.toolCallId)
+      ) {
+        throw new Error(
+          `Multiple approval requests refer to tool call ${part.toolCallId}`,
+        );
+      } else if (
+        part.type === "tool-call" &&
+        activeCallIds.has(part.toolCallId)
+      ) {
+        if (calls.has(part.toolCallId)) {
+          throw new Error(
+            `Ambiguous tool call ${part.toolCallId} in continuation context`,
+          );
+        }
+        calls.set(part.toolCallId, part);
+      } else if (
+        part.type === "tool-approval-response" &&
+        approvalIds.has(part.approvalId)
+      ) {
+        if (responses.has(part.approvalId)) {
+          throw new Error(
+            `Ambiguous approval response ${part.approvalId} in continuation context`,
+          );
+        }
+        responses.set(part.approvalId, part);
+      } else if (
+        part.type === "tool-result" &&
+        activeCallIds.has(part.toolCallId)
+      ) {
+        if (results.has(part.toolCallId)) {
+          throw new Error(
+            `Multiple results for approved tool call ${part.toolCallId}`,
+          );
+        }
+        results.add(part.toolCallId);
+        resultMessages.set(part.toolCallId, {
+          part,
+          providerOptions: message.providerOptions,
+        });
+      }
+    }
+  }
+
+  const callIds = new Set(
+    [...requests.values()].map((request) => request.toolCallId),
+  );
+  if (callIds.size !== requests.size) {
+    throw new Error(
+      "Multiple approval requests refer to the same tool call in continuation context",
+    );
+  }
+
+  const storedResponseIds = new Set<string>();
+  const storedResultIds = new Set<string>();
+  for (const message of storedMessages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      let supplied: Request | Call | Response | undefined;
+      if (
+        part.type === "tool-approval-request" &&
+        approvalIds.has(part.approvalId)
+      ) {
+        supplied = requests.get(part.approvalId);
+      } else if (
+        part.type === "tool-approval-response" &&
+        approvalIds.has(part.approvalId)
+      ) {
+        storedResponseIds.add(part.approvalId);
+        supplied = responses.get(part.approvalId);
+      } else if (part.type === "tool-call" && callIds.has(part.toolCallId)) {
+        supplied = calls.get(part.toolCallId);
+      } else if (part.type === "tool-result" && callIds.has(part.toolCallId)) {
+        storedResultIds.add(part.toolCallId);
+        if (!results.has(part.toolCallId)) {
+          throw new Error(
+            `Continuation context removed result for ${part.toolCallId}`,
+          );
+        }
+        continue;
+      } else {
+        continue;
+      }
+      if (!supplied || signature(supplied) !== signature(part)) {
+        throw new Error(
+          "Continuation context must preserve stored approval decisions and tool calls",
+        );
+      }
+    }
+  }
+
+  if ([...responses.keys()].some((id) => !storedResponseIds.has(id))) {
+    throw new Error("Continuation context cannot add approval decisions");
+  }
+  if ([...results].some((id) => !storedResultIds.has(id))) {
+    throw new Error(
+      "Continuation context cannot add results for approved tool calls",
+    );
+  }
+
+  const pending = new Set<string>();
+  const deferred = new Set<string>();
+  for (const approvalId of approvalIds) {
+    const request = requests.get(approvalId);
+    if (!request || !calls.has(request.toolCallId)) {
+      throw new Error(
+        `Approval ${approvalId} is missing its request or tool call in continuation context`,
+      );
+    }
+    if (results.has(request.toolCallId)) continue;
+    if (responses.has(approvalId)) pending.add(request.toolCallId);
+    else deferred.add(request.toolCallId);
+  }
+
+  const assistant: AssistantModelMessage = { role: "assistant", content: [] };
+  const tool: ToolModelMessage = { role: "tool", content: [] };
+  let assistantOptionsSet = false;
+  let toolOptionsSet = false;
+  const projected: ModelMessage[] = [];
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      projected.push(message);
+      continue;
+    }
+    const content = message.content.filter((part) => {
+      if (
+        part.type === "tool-result" &&
+        resultMessages.has(part.toolCallId) &&
+        !calls.get(part.toolCallId)?.providerExecuted
+      ) {
+        return false;
+      }
+      if (
+        part.type === "tool-approval-request" &&
+        approvalIds.has(part.approvalId) &&
+        results.has(part.toolCallId)
+      ) {
+        return false;
+      }
+      if (part.type === "tool-call" || part.type === "tool-approval-request") {
+        if (deferred.has(part.toolCallId)) return false;
+        if (pending.has(part.toolCallId)) {
+          if (
+            assistantOptionsSet &&
+            signature(assistant.providerOptions) !==
+              signature(message.providerOptions)
+          ) {
+            throw new Error(
+              "Cannot combine approval calls with different message provider options",
+            );
+          }
+          assistant.providerOptions = message.providerOptions;
+          assistantOptionsSet = true;
+          (assistant.content as AssistantPart[]).push(part);
+          return false;
+        }
+      }
+      if (
+        part.type === "tool-approval-response" &&
+        approvalIds.has(part.approvalId)
+      ) {
+        const request = requests.get(part.approvalId)!;
+        if (pending.has(request.toolCallId)) {
+          if (
+            toolOptionsSet &&
+            signature(tool.providerOptions) !==
+              signature(message.providerOptions)
+          ) {
+            throw new Error(
+              "Cannot combine approval responses with different message provider options",
+            );
+          }
+          tool.providerOptions = message.providerOptions;
+          toolOptionsSet = true;
+          tool.content.push(part);
+        }
+        return false;
+      }
+      return true;
+    });
+
+    if (content.length === 0) continue;
+    projected.push({ ...message, content } as ModelMessage);
+    if (message.role !== "assistant") continue;
+    let adjacentResults: ToolModelMessage | undefined;
+    for (const part of content) {
+      if (part.type !== "tool-call" || part.providerExecuted) continue;
+      const result = resultMessages.get(part.toolCallId);
+      if (!result) continue;
+      if (
+        adjacentResults &&
+        signature(adjacentResults.providerOptions) ===
+          signature(result.providerOptions)
+      ) {
+        adjacentResults.content.push(result.part);
+      } else {
+        adjacentResults = {
+          role: "tool",
+          content: [result.part],
+          providerOptions: result.providerOptions,
+        };
+        projected.push(adjacentResults);
+      }
+    }
+  }
+
+  if (pending.size > 0) projected.push(assistant, tool);
+  return projected;
+}
+
+function signature(value: unknown): string {
+  return JSON.stringify(convexToJson((value ?? null) as Value));
+}

--- a/src/vercel/client/search.ts
+++ b/src/vercel/client/search.ts
@@ -34,6 +34,7 @@ import {
   docsToModelMessages,
   toModelMessage,
 } from "../mapping.js";
+import { prepareApprovalContext } from "./prepareApprovalContext.js";
 
 const DEFAULT_VECTOR_SCORE_THRESHOLD = 0.0;
 // Bound the rare boundary-extension query; incomplete orders are trimmed below.
@@ -701,6 +702,70 @@ export async function fetchContextWithPrompt(
         threadId,
       })
     : allMessages;
+
+  if (
+    args.prompt === undefined &&
+    promptMessage?.message?.role === "tool" &&
+    promptMessage.message.content.some(
+      (part) => part.type === "tool-approval-response",
+    )
+  ) {
+    const responseIds = new Set(
+      promptMessage.message.content.flatMap((part) =>
+        part.type === "tool-approval-response" ? [part.approvalId] : [],
+      ),
+    );
+    const storedOrderDocs = recentMessages.filter(
+      (doc) => doc.order === promptMessage.order,
+    );
+    const requestDocs = new Map<string, MessageDoc>();
+    for (const doc of storedOrderDocs) {
+      if (
+        doc.message?.role !== "assistant" ||
+        !Array.isArray(doc.message.content)
+      ) {
+        continue;
+      }
+      if (
+        doc.message.content.some(
+          (part) =>
+            part.type === "tool-approval-request" &&
+            responseIds.has(part.approvalId),
+        )
+      ) {
+        requestDocs.set(doc._id, doc);
+      }
+    }
+    if (requestDocs.size !== 1) {
+      throw new Error(
+        "Approval continuation requires one complete request message",
+      );
+    }
+    const requestDoc = requestDocs.values().next().value!;
+    if (
+      requestDoc.message?.role !== "assistant" ||
+      !Array.isArray(requestDoc.message.content)
+    ) {
+      throw new Error(
+        "Approval continuation requires one complete request message",
+      );
+    }
+    const approvalIds = new Set(
+      requestDoc.message.content.flatMap((part) =>
+        part.type === "tool-approval-request" ? [part.approvalId] : [],
+      ),
+    );
+    if ([...responseIds].some((approvalId) => !approvalIds.has(approvalId))) {
+      throw new Error(
+        "Approval continuation requires one complete request message",
+      );
+    }
+    processedMessages = prepareApprovalContext(
+      processedMessages,
+      approvalIds,
+      docsToModelMessages(storedOrderDocs),
+    );
+  }
 
   // Post-process: auto-deny unresolved approvals so the AI SDK sees a
   // complete history. Applied after contextHandler so custom handlers

--- a/src/vercel/client/toolApprovals.test.ts
+++ b/src/vercel/client/toolApprovals.test.ts
@@ -28,7 +28,11 @@ const agent = new Agent(components.agent, {
   },
 });
 
-type ContextMode = "change-input" | "remove-result" | "fabricate-approval";
+type ContextMode =
+  | "change-input"
+  | "add-call-provider-options"
+  | "remove-result"
+  | "fabricate-approval";
 
 function contextHandler(mode: ContextMode): ContextHandler {
   return async (_ctx, { allMessages }): Promise<ModelMessage[]> => {
@@ -69,7 +73,16 @@ function contextHandler(mode: ContextMode): ContextHandler {
         ...message,
         content: message.content.map((part) =>
           part.type === "tool-call" && part.toolCallId === "call-a"
-            ? { ...part, input: { tag: "changed" } }
+            ? {
+                ...part,
+                input:
+                  mode === "add-call-provider-options"
+                    ? part.input
+                    : { tag: "changed" },
+                ...(mode === "add-call-provider-options"
+                  ? { providerOptions: { test: { trace: "allowed" } } }
+                  : {}),
+              }
             : part,
         ),
       };
@@ -106,6 +119,7 @@ function request(ids: string[], providerExecuted = false): Message {
 type Limits = {
   bytesRead?: number;
   bytesWritten?: number;
+  databaseQueries?: number;
   documentsRead?: number;
   documentsWritten?: number;
 };
@@ -129,12 +143,16 @@ async function fixture({
   component.register(t);
   const { threadId } = await t.run((ctx) => agent.createThread(ctx));
   if (olderMessages > 0) {
-    for (let start = 0; start < olderMessages; start += 10) {
+    const batchSize =
+      typeof transactionLimits === "object"
+        ? Math.min(10, transactionLimits.documentsWritten ?? 10)
+        : 10;
+    for (let start = 0; start < olderMessages; start += batchSize) {
       await t.run((ctx) =>
         agent.saveMessages(ctx, {
           threadId,
           messages: Array.from(
-            { length: Math.min(10, olderMessages - start) },
+            { length: Math.min(batchSize, olderMessages - start) },
             (_, offset) => ({
               role: "user" as const,
               content: `${start + offset}:${"x".repeat(4_000)}`,
@@ -266,7 +284,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("respondToToolCallApprovals", () => {
+describe("tool approval semantics", () => {
   test.each([false, true])(
     "continues a mixed batch through generateText and streamText (streaming=%s)",
     async (streaming) => {
@@ -286,7 +304,7 @@ describe("respondToToolCallApprovals", () => {
         streaming,
       });
 
-      expect(executed).toEqual(["a", "c"]);
+      expect([...executed].sort()).toEqual(["a", "c"]);
       expectNoDanglingLocalCalls(streaming);
       const storedResults = await results();
       expect(storedResults).toHaveLength(3);
@@ -312,7 +330,7 @@ describe("respondToToolCallApprovals", () => {
 
     await continueGeneration(t, { threadId, promptMessageId: messageId });
 
-    expect(executed).toEqual(["a", "b"]);
+    expect([...executed].sort()).toEqual(["a", "b"]);
     expectNoDanglingLocalCalls();
     expect((await results()).map((part) => part.toolCallId).sort()).toEqual([
       "call-a",
@@ -357,16 +375,103 @@ describe("respondToToolCallApprovals", () => {
     },
   );
 
+  test("defers and later resumes an approval from an earlier partial continuation", async () => {
+    const { t, threadId } = await fixture();
+    const first = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: first.messageId,
+    });
+    await t.run((ctx) =>
+      agent.saveMessage(ctx, {
+        threadId,
+        promptMessageId: first.messageId,
+        message: request(["c"]),
+        skipEmbeddings: true,
+      }),
+    );
+    const newer = await submitDecisions(t, threadId, [
+      { approvalId: "c", approved: true },
+    ]);
+    const sibling = await submitDecisions(t, threadId, [
+      { approvalId: "b", approved: true },
+    ]);
+
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: sibling.messageId,
+    });
+
+    expect(executed).toEqual(["a", "b"]);
+    const cParts = lastModelPrompt().flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.filter(
+            (part) =>
+              ("toolCallId" in part && part.toolCallId === "call-c") ||
+              ("approvalId" in part && part.approvalId === "c"),
+          )
+        : [],
+    );
+    expect(cParts).toEqual([]);
+
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: newer.messageId,
+    });
+    expect(executed).toEqual(["a", "b", "c"]);
+    expectNoDanglingLocalCalls();
+  });
+
+  test("does not resubmit a completed provider-owned sibling", async () => {
+    const { t, threadId } = await fixture({ providerExecuted: true });
+    const first = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: first.messageId,
+    });
+    const second = await submitDecisions(t, threadId, [
+      { approvalId: "b", approved: true },
+    ]);
+
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: second.messageId,
+    });
+
+    const approvalIdsByToolMessage = lastModelPrompt().flatMap((message) =>
+      message.role === "tool"
+        ? [
+            message.content.flatMap((part) =>
+              part.type === "tool-approval-response"
+                ? [part.approvalId]
+                : [],
+            ),
+          ]
+        : [],
+    );
+    const historicalApprovalIds = approvalIdsByToolMessage
+      .slice(0, -1)
+      .flat();
+    const finalApprovalIds = approvalIdsByToolMessage.at(-1);
+    expect(historicalApprovalIds).toContain("a");
+    expect(finalApprovalIds).toEqual(["b"]);
+  });
+
   test("records a substantial batch within a bounded transaction", async () => {
     const ids = Array.from({ length: 24 }, (_, index) => `approval-${index}`);
-    const { t, threadId, results } = await fixture({
+    const { t, threadId, messages } = await fixture({
       ids,
       olderMessages: 80,
       transactionLimits: {
-        bytesRead: 1_200_000,
+        bytesRead: 1_500_000,
         bytesWritten: 200_000,
+        databaseQueries: 40,
         documentsRead: 220,
-        documentsWritten: 16,
+        documentsWritten: 2,
       },
     });
 
@@ -381,10 +486,16 @@ describe("respondToToolCallApprovals", () => {
     );
     expect(typeof messageId).toBe("string");
     expect(executed).toEqual([]);
-
-    await continueGeneration(t, { threadId, promptMessageId: messageId });
-    expect([...executed].sort()).toEqual([...ids].sort());
-    expect(await results()).toHaveLength(ids.length);
+    const savedApprovalIds = (await messages()).page.flatMap((stored) =>
+      stored.message?.role === "tool"
+        ? stored.message.content.flatMap((part) =>
+            part.type === "tool-approval-response"
+              ? [part.approvalId]
+              : [],
+          )
+        : [],
+    );
+    expect(savedApprovalIds.sort()).toEqual([...ids].sort());
   });
 
   test.each([
@@ -516,6 +627,33 @@ describe("respondToToolCallApprovals", () => {
       }),
     ).rejects.toThrow();
     expect(executed).toEqual([]);
+  });
+
+  test("allows a context handler to add call provider options", async () => {
+    const { t, threadId } = await fixture({ ids: ["a"] });
+    const { messageId } = await submitDecisions(t, threadId, [
+      { approvalId: "a", approved: true },
+    ]);
+
+    await continueGeneration(t, {
+      threadId,
+      promptMessageId: messageId,
+      contextMode: "add-call-provider-options",
+    });
+
+    expect(executed).toEqual(["a"]);
+    const call = lastModelPrompt().flatMap((message) =>
+      message.role === "assistant" && Array.isArray(message.content)
+        ? message.content.filter(
+            (part) => part.type === "tool-call" && part.toolCallId === "call-a",
+          )
+        : [],
+    );
+    expect(call).toContainEqual(
+      expect.objectContaining({
+        providerOptions: { test: { trace: "allowed" } },
+      }),
+    );
   });
 
   test("rejects removal of durable execution evidence", async () => {

--- a/src/vercel/index.ts
+++ b/src/vercel/index.ts
@@ -1144,6 +1144,28 @@ export class Agent<
     return this.respondToToolCallApproval(ctx, { ...args, approved: false });
   }
 
+  /**
+   * Save approval decisions from one assistant request message atomically.
+   * Continue generation explicitly with the returned messageId.
+   */
+  async respondToToolCallApprovals(
+    ctx: MutationCtx,
+    args: {
+      threadId: string;
+      decisions: Array<{
+        approvalId: string;
+        approved: boolean;
+        reason?: string;
+      }>;
+    },
+  ): Promise<{ messageId: string }> {
+    return ctx.runMutation(this.component.messages.respondToToolCallApprovals, {
+      threadId: args.threadId,
+      agentName: this.options.name,
+      decisions: args.decisions,
+    });
+  }
+
   private async respondToToolCallApproval(
     ctx: MutationCtx,
     args: {

--- a/src/vercel/index.ts
+++ b/src/vercel/index.ts
@@ -1120,7 +1120,16 @@ export class Agent<
     ctx: MutationCtx,
     args: { threadId: string; approvalId: string; reason?: string },
   ): Promise<{ messageId: string }> {
-    return this.respondToToolCallApproval(ctx, { ...args, approved: true });
+    return this.respondToToolCallApprovals(ctx, {
+      threadId: args.threadId,
+      decisions: [
+        {
+          approvalId: args.approvalId,
+          approved: true,
+          reason: args.reason,
+        },
+      ],
+    });
   }
 
   /**
@@ -1141,7 +1150,16 @@ export class Agent<
     ctx: MutationCtx,
     args: { threadId: string; approvalId: string; reason?: string },
   ): Promise<{ messageId: string }> {
-    return this.respondToToolCallApproval(ctx, { ...args, approved: false });
+    return this.respondToToolCallApprovals(ctx, {
+      threadId: args.threadId,
+      decisions: [
+        {
+          approvalId: args.approvalId,
+          approved: false,
+          reason: args.reason,
+        },
+      ],
+    });
   }
 
   /**
@@ -1164,130 +1182,6 @@ export class Agent<
       agentName: this.options.name,
       decisions: args.decisions,
     });
-  }
-
-  private async respondToToolCallApproval(
-    ctx: MutationCtx,
-    args: {
-      threadId: string;
-      approvalId: string;
-      approved: boolean;
-      reason?: string;
-    },
-  ): Promise<{ messageId: string }> {
-    const { promptMessageId, existingResponseMessage } =
-      await this.findApprovalContext(ctx, {
-        threadId: args.threadId,
-        approvalId: args.approvalId,
-      });
-
-    const newPart = {
-      type: "tool-approval-response" as const,
-      approvalId: args.approvalId,
-      approved: args.approved,
-      reason: args.reason,
-    };
-
-    // Merge into an existing approval-response message for this step
-    // so the AI SDK sees a single tool message per step.
-    if (existingResponseMessage) {
-      const existingContent = existingResponseMessage.message?.content;
-      const mergedContent = Array.isArray(existingContent)
-        ? [...(existingContent as any[]), newPart]
-        : [newPart];
-      await this.updateMessage(ctx, {
-        messageId: existingResponseMessage._id,
-        patch: {
-          message: { role: "tool", content: mergedContent },
-          status: "success",
-        },
-      });
-      return { messageId: existingResponseMessage._id };
-    }
-
-    const { messageId } = await this.saveMessage(ctx, {
-      threadId: args.threadId,
-      promptMessageId,
-      skipEmbeddings: true,
-      message: {
-        role: "tool",
-        content: [newPart],
-      },
-    });
-    return { messageId };
-  }
-
-  private async findApprovalContext(
-    ctx: MutationCtx,
-    args: { threadId: string; approvalId: string },
-  ): Promise<{
-    promptMessageId: string;
-    existingResponseMessage: MessageDoc | undefined;
-  }> {
-    // NOTE: This pagination returns messages in descending order (newest first).
-    // The "already handled" check (tool-approval-response) relies on seeing
-    // responses before their corresponding requests. If the pagination order
-    // changes, this logic will need to be updated.
-    let existingResponseMessage: MessageDoc | undefined;
-    // Limit the search to the most recent messages. Approvals should always
-    // be near the end of the thread.
-    const page = await this.listMessages(ctx, {
-      threadId: args.threadId,
-      paginationOpts: { cursor: null, numItems: 100 },
-    });
-    {
-      for (const message of page.page) {
-        const content = message.message?.content;
-        if (!Array.isArray(content)) continue;
-        // Check if this assistant message starts a different approval step.
-        // If so, any response message we've seen so far belongs to a newer
-        // step — reset it so we don't merge across step boundaries.
-        // Only reset if the target approval is NOT in this message (i.e.,
-        // this is a genuinely different step, not the same step with
-        // multiple tool calls).
-        if (
-          message.message?.role === "assistant" &&
-          content.some(
-            (p: any) =>
-              p.type === "tool-approval-request" &&
-              p.approvalId !== args.approvalId,
-          ) &&
-          !content.some(
-            (p: any) =>
-              p.type === "tool-approval-request" &&
-              p.approvalId === args.approvalId,
-          )
-        ) {
-          existingResponseMessage = undefined;
-        }
-        for (const part of content) {
-          const typedPart = part as { type?: unknown; approvalId?: unknown };
-          if (
-            typedPart.type === "tool-approval-response" &&
-            typedPart.approvalId === args.approvalId
-          ) {
-            throw new Error(`Approval ${args.approvalId} was already handled`);
-          }
-          // Track the most recent tool-approval-response message for merging
-          if (
-            typedPart.type === "tool-approval-response" &&
-            !existingResponseMessage
-          ) {
-            existingResponseMessage = message;
-          }
-          if (
-            typedPart.type === "tool-approval-request" &&
-            typedPart.approvalId === args.approvalId
-          ) {
-            return { promptMessageId: message._id, existingResponseMessage };
-          }
-        }
-      }
-    }
-
-    throw new Error(
-      `Approval request ${args.approvalId} was not found in the last 100 messages of thread ${args.threadId}`,
-    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add respondToToolCallApprovals for approving or denying one request’s tool calls together.
- Validate the full decision set, then persist it with one bounded scan and one append-only write.
- Preserve partial, sequential, local, and provider-executed approval continuations.
- Route the single-decision helpers through the same implementation.

## Why

The existing one-at-a-time flow repeatedly scans recent history and rewrites a growing response message. At scale this becomes quadratic work and can exceed Convex transaction limits. Merging later decisions into an earlier message can also make a continuation silently miss them.

The new path records decisions atomically and assembles the AI SDK continuation context at read time. Multiple decisions should use the batch method rather than loop over the single-decision helpers.

Fixes #354
